### PR TITLE
Docs?

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@ reproject/reproject.cfg
 reproject/version.py
 reproject.egg-info
 reproject/_overlap.c
+docs/_build
+docs/api
+.coverage
+htmlcov

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,3 +3,11 @@ Documentation
 
 This is an affiliated package for the AstroPy package. The documentation for
 this package is here:
+
+.. toctree::
+  :maxdepth: 2
+
+  resample/index.rst
+
+.. note:: Do not edit this page - instead, place all documentation for the
+          affiliated package inside ``photutils/``

--- a/docs/resample/api.rst
+++ b/docs/resample/api.rst
@@ -1,0 +1,5 @@
+Reference/API
+=============
+
+.. automodapi:: reproject
+   :no-inheritance-diagram:

--- a/docs/resample/index.rst
+++ b/docs/resample/index.rst
@@ -1,0 +1,41 @@
+Image reprojection (resampling) (`reproject`)
+=============================================
+
+Introduction
+------------
+
+The `reproject` package implements image reprojection (resampling) methods
+for astronomical images.
+
+
+.. note::
+
+    We plan to propose that `reproject` will be merged into the
+    ``astropy`` core as ``astropy.reproject`` once the main functionality
+    is in place and has been tested for a while.
+
+.. note::
+
+    `reproject` requires `numpy <http://www.numpy.org/>`__ and
+    `astropy <http://www.astropy.org/>`__ to be installed.
+    Some functionality is only available if `scipy <http://www.scipy.org/>`__ or
+    `scikit-image <http://scikit-image.org/>`__ are installed, users are
+    encouraged to install those optional dependencies.
+
+Getting Started
+---------------
+
+We just started, no functionality has been implemented yet, except this:
+
+  >>> import reproject
+
+
+Using `reproject`
+-----------------
+
+.. toctree::
+    :maxdepth: 2
+
+    api
+
+.. _SourceExtractor: http://www.astromatic.net/software/sextractor


### PR DESCRIPTION
@astrofrog I wanted to have a quick look at what is already available in `python-reprojection`, but as far as I can see there's no docs online?
Actually the docs build doesn't seem to work at the moment:

```
$ python setup.py build_sphinx
Freezing version number to reproject/version.py
running build_sphinx
error: error in 'source_dir' option: 'docs' does not exist or is not a directory
```

I'll have a look through the open issues and what code from `gammapy` could fit in this repo on the weekend.
