### PR TITLE
Support large cube reprojection via 'out' arrays

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ env:
         - SETUP_CMD='test'
         - CONDA_CHANNELS='astropy'
         - CONDA_DEPENDENCIES='Cython scipy matplotlib shapely>=1.6 astropy-healpix'
-        - PIP_DEPENDENCIES='pytest-arraydiff'
+        - PIP_DEPENDENCIES='pytest-arraydiff codecov'
         - SETUP_XVFB=True
 
     matrix:
@@ -61,4 +61,4 @@ script:
    - python setup.py $SETUP_CMD
 
 after_success:
-    - if [[ $SETUP_CMD == 'test --coverage' ]]; then coveralls --rcfile='reproject/tests/coveragerc'; fi
+    - if [[ $SETUP_CMD == 'test --coverage' ]]; then codecov; fi

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,10 @@
 - Refactored HEALPix reprojection code to use the astropy-healpix package
   instead of healpy. [#139]
 
+- Added the ability to specify an output array in ``reproject_interp``, which
+  permits the use of memory-mapped arrays and therefore provides the capability
+  to handle data cubes much larger than memory [#115]
+
 - Fix test 32-bit test failures. [#146]
 
 - Fix an issue with reprojecting images where there are two solutions along

--- a/docs/celestial.rst
+++ b/docs/celestial.rst
@@ -126,13 +126,12 @@ interpolation. Supported strings include:
 
 Very Large Cubes
 ----------------
-If you have a very large cube to reproject, but one that is the same in each
-celestial axis - i.e., any normal IFU or radio spectral cube with many
+If you have a very large cube to reproject, i.e., any normal IFU or radio spectral cube with many
 individual spectral channels - you may not be able to hold two copies of the
 cube in memory.  In this case, you can specify an output memory mapped array to
 store the data.
 
-In theory, you can attempt the following::
+You can use the following approach for large data, but only with the interpolation reprojection methods::
 
 .. doctest-skip::
 
@@ -146,7 +145,7 @@ In theory, you can attempt the following::
     >>> newhdu = fits.PrimaryHDU(data=outarray, header=outhdr)
     >>> newhdu.writeto('new_cube_file.fits')
 
-Or better, skip the numpy memmap step and use `FITS large file creation
+Or if you're dealing with FITS files, you can skip the numpy memmap step and use `FITS large file creation
 <http://docs.astropy.org/en/stable/generated/examples/io/skip_create-large-fits.html>`_::
 
 .. doctest-skip::

--- a/docs/celestial.rst
+++ b/docs/celestial.rst
@@ -124,6 +124,14 @@ interpolation. Supported strings include:
 * ``'biquadratic'``: second order interpolation
 * ``'bicubic'``: third order interpolation
 
+Very Large Cubes
+----------------
+If you have a very large cube to reproject, but one that is the same in each
+celestial axis - i.e., any normal IFU or radio spectral cube with many
+individual spectral channels - you may not be able to hold two copies of the
+cube in memory.  In this case, you can specify an output memory mapped array to
+store the data.
+
 Drizzling
 =========
 

--- a/docs/celestial.rst
+++ b/docs/celestial.rst
@@ -132,32 +132,32 @@ individual spectral channels - you may not be able to hold two copies of the
 cube in memory.  In this case, you can specify an output memory mapped array to
 store the data.
 
-In theory, you can attempt the following:
+In theory, you can attempt the following::
 
-    >>> outhdr = fits.Header.fromtextfile('cube_header_gal.hdr')
-    >>> shape = (outhdr['NAXIS3'], outhdr['NAXIS2'], outhdr['NAXIS1'])
-    >>> outarray = np.memmap(filename='output.np', mode='w+', shape=shape, dtype='float32')
-    >>> hdu = fits.open('cube_file.fits')
-    >>> rslt = reproject.reproject_interp(hdu, outhdr, output_array=outarray,
+    >>> outhdr = fits.Header.fromtextfile('cube_header_gal.hdr') # doctest: +SKIP
+    >>> shape = (outhdr['NAXIS3'], outhdr['NAXIS2'], outhdr['NAXIS1']) # doctest: +SKIP
+    >>> outarray = np.memmap(filename='output.np', mode='w+', shape=shape, dtype='float32') # doctest: +SKIP
+    >>> hdu = fits.open('cube_file.fits') # doctest: +SKIP
+    >>> rslt = reproject.reproject_interp(hdu, outhdr, output_array=outarray, # doctest: +SKIP
     ...                                   return_footprint=False,
     ...                                   independent_celestial_slices=True)
-    >>> newhdu = fits.PrimaryHDU(data=outarray, header=outhdr)
-    >>> newhdu.writeto('new_cube_file.fits')
+    >>> newhdu = fits.PrimaryHDU(data=outarray, header=outhdr) # doctest: +SKIP
+    >>> newhdu.writeto('new_cube_file.fits') # doctest: +SKIP
 
 Or better, skip the numpy memmap step and use `FITS large file creation
-<http://docs.astropy.org/en/stable/generated/examples/io/skip_create-large-fits.html>`_:
+<http://docs.astropy.org/en/stable/generated/examples/io/skip_create-large-fits.html>`_::
 
-    >>> outhdr = fits.Header.fromtextfile('cube_header_gal.hdr')
-    >>> outhdr.tofile('new_cube.fits')
-    >>> shape = tuple(outhdr['NAXIS{0}'.format(ii)] for ii in range(1, outhdr['NAXIS']+1))
-    >>> with open('new_cube.fits', 'rb+') as fobj:
+    >>> outhdr = fits.Header.fromtextfile('cube_header_gal.hdr') # doctest: +SKIP
+    >>> outhdr.tofile('new_cube.fits') # doctest: +SKIP
+    >>> shape = tuple(outhdr['NAXIS{0}'.format(ii)] for ii in range(1, outhdr['NAXIS']+1)) # doctest: +SKIP
+    >>> with open('new_cube.fits', 'rb+') as fobj: # doctest: +SKIP
     >>>     fobj.seek(len(outhdr.tostring()) + (np.product(shape) * np.abs(outhdr['BITPIX']//8)) - 1)
     >>>     fobj.write(b'\0')
-    >>> outhdu = fits.open('new_cube.fits', mode='update')
-    >>> rslt = reproject.reproject_interp(hdu, outhdr, output_array=outhdu[0].data,
+    >>> outhdu = fits.open('new_cube.fits', mode='update') # doctest: +SKIP
+    >>> rslt = reproject.reproject_interp(hdu, outhdr, output_array=outhdu[0].data, # doctest: +SKIP
     ...                                   return_footprint=False,
     ...                                   independent_celestial_slices=True)
-    >>> outhdu.flush()
+    >>> outhdu.flush() # doctest: +SKIP
 
 Drizzling
 =========

--- a/docs/celestial.rst
+++ b/docs/celestial.rst
@@ -139,7 +139,8 @@ In theory, you can attempt the following:
     >>> outarray = np.memmap(filename='output.np', mode='w+', shape=shape, dtype='float32')
     >>> hdu = fits.open('cube_file.fits')
     >>> rslt = reproject.reproject_interp(hdu, outhdr, output_array=outarray,
-    ...                                   return_footprint=False)
+    ...                                   return_footprint=False,
+    ...                                   independent_celestial_slices=True)
 
 Drizzling
 =========

--- a/docs/celestial.rst
+++ b/docs/celestial.rst
@@ -134,30 +134,34 @@ store the data.
 
 In theory, you can attempt the following::
 
-    >>> outhdr = fits.Header.fromtextfile('cube_header_gal.hdr') # doctest: +SKIP
-    >>> shape = (outhdr['NAXIS3'], outhdr['NAXIS2'], outhdr['NAXIS1']) # doctest: +SKIP
-    >>> outarray = np.memmap(filename='output.np', mode='w+', shape=shape, dtype='float32') # doctest: +SKIP
-    >>> hdu = fits.open('cube_file.fits') # doctest: +SKIP
-    >>> rslt = reproject.reproject_interp(hdu, outhdr, output_array=outarray, # doctest: +SKIP
+.. doctest-skip::
+
+    >>> outhdr = fits.Header.fromtextfile('cube_header_gal.hdr')
+    >>> shape = (outhdr['NAXIS3'], outhdr['NAXIS2'], outhdr['NAXIS1'])
+    >>> outarray = np.memmap(filename='output.np', mode='w+', shape=shape, dtype='float32')
+    >>> hdu = fits.open('cube_file.fits')
+    >>> rslt = reproject.reproject_interp(hdu, outhdr, output_array=outarray,
     ...                                   return_footprint=False,
     ...                                   independent_celestial_slices=True)
-    >>> newhdu = fits.PrimaryHDU(data=outarray, header=outhdr) # doctest: +SKIP
-    >>> newhdu.writeto('new_cube_file.fits') # doctest: +SKIP
+    >>> newhdu = fits.PrimaryHDU(data=outarray, header=outhdr)
+    >>> newhdu.writeto('new_cube_file.fits')
 
 Or better, skip the numpy memmap step and use `FITS large file creation
 <http://docs.astropy.org/en/stable/generated/examples/io/skip_create-large-fits.html>`_::
 
-    >>> outhdr = fits.Header.fromtextfile('cube_header_gal.hdr') # doctest: +SKIP
-    >>> outhdr.tofile('new_cube.fits') # doctest: +SKIP
-    >>> shape = tuple(outhdr['NAXIS{0}'.format(ii)] for ii in range(1, outhdr['NAXIS']+1)) # doctest: +SKIP
-    >>> with open('new_cube.fits', 'rb+') as fobj: # doctest: +SKIP
+.. doctest-skip::
+
+    >>> outhdr = fits.Header.fromtextfile('cube_header_gal.hdr')
+    >>> outhdr.tofile('new_cube.fits')
+    >>> shape = tuple(outhdr['NAXIS{0}'.format(ii)] for ii in range(1, outhdr['NAXIS']+1))
+    >>> with open('new_cube.fits', 'rb+') as fobj:
     >>>     fobj.seek(len(outhdr.tostring()) + (np.product(shape) * np.abs(outhdr['BITPIX']//8)) - 1)
     >>>     fobj.write(b'\0')
-    >>> outhdu = fits.open('new_cube.fits', mode='update') # doctest: +SKIP
-    >>> rslt = reproject.reproject_interp(hdu, outhdr, output_array=outhdu[0].data, # doctest: +SKIP
+    >>> outhdu = fits.open('new_cube.fits', mode='update')
+    >>> rslt = reproject.reproject_interp(hdu, outhdr, output_array=outhdu[0].data,
     ...                                   return_footprint=False,
     ...                                   independent_celestial_slices=True)
-    >>> outhdu.flush() # doctest: +SKIP
+    >>> outhdu.flush()
 
 Drizzling
 =========

--- a/docs/celestial.rst
+++ b/docs/celestial.rst
@@ -141,6 +141,23 @@ In theory, you can attempt the following:
     >>> rslt = reproject.reproject_interp(hdu, outhdr, output_array=outarray,
     ...                                   return_footprint=False,
     ...                                   independent_celestial_slices=True)
+    >>> newhdu = fits.PrimaryHDU(data=outarray, header=outhdr)
+    >>> newhdu.writeto('new_cube_file.fits')
+
+Or better, skip the numpy memmap step and use `FITS large file creation
+<http://docs.astropy.org/en/stable/generated/examples/io/skip_create-large-fits.html>`_:
+
+    >>> outhdr = fits.Header.fromtextfile('cube_header_gal.hdr')
+    >>> outhdr.tofile('new_cube.fits')
+    >>> shape = tuple(outhdr['NAXIS{0}'.format(ii)] for ii in range(1, outhdr['NAXIS']+1))
+    >>> with open('new_cube.fits', 'rb+') as fobj:
+    >>>     fobj.seek(len(outhdr.tostring()) + (np.product(shape) * np.abs(outhdr['BITPIX']//8)) - 1)
+    >>>     fobj.write(b'\0')
+    >>> outhdu = fits.open('new_cube.fits', mode='update')
+    >>> rslt = reproject.reproject_interp(hdu, outhdr, output_array=outhdu[0].data,
+    ...                                   return_footprint=False,
+    ...                                   independent_celestial_slices=True)
+    >>> outhdu.flush()
 
 Drizzling
 =========

--- a/docs/celestial.rst
+++ b/docs/celestial.rst
@@ -132,6 +132,15 @@ individual spectral channels - you may not be able to hold two copies of the
 cube in memory.  In this case, you can specify an output memory mapped array to
 store the data.
 
+In theory, you can attempt the following:
+
+    >>> outhdr = fits.Header.fromtextfile('cube_header_gal.hdr')
+    >>> shape = (outhdr['NAXIS3'], outhdr['NAXIS2'], outhdr['NAXIS1'])
+    >>> outarray = np.memmap(filename='output.np', mode='w+', shape=shape, dtype='float32')
+    >>> hdu = fits.open('cube_file.fits')
+    >>> rslt = reproject.reproject_interp(hdu, outhdr, output_array=outarray,
+    ...                                   return_footprint=False)
+
 Drizzling
 =========
 

--- a/reproject/interpolation/core_celestial.py
+++ b/reproject/interpolation/core_celestial.py
@@ -9,7 +9,7 @@ from ..array_utils import iterate_over_celestial_slices, map_coordinates
 from astropy.utils.console import ProgressBar
 
 def _reproject_celestial(array, wcs_in, wcs_out, shape_out, order=1, array_out=None,
-                         return_footprint=True, progressbar=True):
+                         return_footprint=True, progress_bar=False):
     """
     Reproject data with celestial axes to a new projection using interpolation,
     assuming that the non-celestial axes match exactly and thus don't need to be
@@ -63,8 +63,12 @@ def _reproject_celestial(array, wcs_in, wcs_out, shape_out, order=1, array_out=N
 
     subset = None
 
-    if progressbar:
+    if progress_bar and array.ndim == 3:
         pb = ProgressBar(len(array))
+    else:
+        # if progress_bar set to true, but no progressbar is needed, shut it
+        # off to avoid failure below
+        progress_bar = False
 
     # Loop over slices and interpolate
     for slice_in, slice_out in iterate_over_celestial_slices(array,
@@ -121,7 +125,7 @@ def _reproject_celestial(array, wcs_in, wcs_out, shape_out, order=1, array_out=N
                                           mode='constant'
                                           ).reshape(slice_out.shape)
 
-        if progressbar:
+        if progress_bar:
             pb.update()
 
     if return_footprint:

--- a/reproject/interpolation/core_celestial.py
+++ b/reproject/interpolation/core_celestial.py
@@ -7,7 +7,8 @@ from ..wcs_utils import convert_world_coordinates
 from ..array_utils import iterate_over_celestial_slices, map_coordinates
 
 
-def _reproject_celestial(array, wcs_in, wcs_out, shape_out, order=1):
+def _reproject_celestial(array, wcs_in, wcs_out, shape_out, order=1, array_out=None,
+                         return_footprint=True):
     """
     Reproject data with celestial axes to a new projection using interpolation,
     assuming that the non-celestial axes match exactly and thus don't need to be
@@ -48,7 +49,11 @@ def _reproject_celestial(array, wcs_in, wcs_out, shape_out, order=1):
     # remainder of the array. We then operate on the view, but this will change
     # the original array with the correct shape.
 
-    array_new = np.zeros(shape_out)
+    if array_out is not None:
+        assert array_out.shape == shape_out
+        array_new = array_out
+    else:
+        array_new = np.zeros(shape_out)
 
     xp_in = yp_in = None
 
@@ -109,7 +114,10 @@ def _reproject_celestial(array, wcs_in, wcs_out, shape_out, order=1):
                                           mode='constant'
                                           ).reshape(slice_out.shape)
 
-    return array_new, (~np.isnan(array_new)).astype(float)
+    if return_footprint:
+        return array_new, (~np.isnan(array_new)).astype(float)
+    else:
+        return array_new
 
 
 def _get_input_pixels_celestial(wcs_in, wcs_out, shape_out):

--- a/reproject/interpolation/core_celestial.py
+++ b/reproject/interpolation/core_celestial.py
@@ -25,7 +25,8 @@ def _reproject_celestial(array, wcs_in, wcs_out, shape_out, order=1, array_out=N
     """
 
     # Make sure image is floating point
-    array = np.asarray(array, dtype=float)
+    if not np.issubdtype(array.dtype, np.float):
+        array = np.asarray(array, dtype=float)
 
     # Check dimensionality of WCS and shape_out
     if wcs_in.wcs.naxis != wcs_out.wcs.naxis:
@@ -51,7 +52,8 @@ def _reproject_celestial(array, wcs_in, wcs_out, shape_out, order=1, array_out=N
     # the original array with the correct shape.
 
     if array_out is not None:
-        assert array_out.shape == shape_out
+        if tuple(array_out.shape) != tuple(shape_out):
+            raise ValueError("Array sizes don't match")
         array_new = array_out
     else:
         array_new = np.zeros(shape_out)

--- a/reproject/interpolation/core_celestial.py
+++ b/reproject/interpolation/core_celestial.py
@@ -6,10 +6,8 @@ import numpy as np
 from ..wcs_utils import convert_world_coordinates
 from ..array_utils import iterate_over_celestial_slices, map_coordinates
 
-from astropy.utils.console import ProgressBar
-
 def _reproject_celestial(array, wcs_in, wcs_out, shape_out, order=1, array_out=None,
-                         return_footprint=True, progress_bar=False):
+                         return_footprint=True):
     """
     Reproject data with celestial axes to a new projection using interpolation,
     assuming that the non-celestial axes match exactly and thus don't need to be
@@ -62,13 +60,6 @@ def _reproject_celestial(array, wcs_in, wcs_out, shape_out, order=1, array_out=N
     xp_in = yp_in = None
 
     subset = None
-
-    if progress_bar and array.ndim == 3:
-        pb = ProgressBar(len(array))
-    else:
-        # if progress_bar set to true, but no progressbar is needed, shut it
-        # off to avoid failure below
-        progress_bar = False
 
     # Loop over slices and interpolate
     for slice_in, slice_out in iterate_over_celestial_slices(array,
@@ -124,9 +115,6 @@ def _reproject_celestial(array, wcs_in, wcs_out, shape_out, order=1, array_out=N
                                           order=order, cval=np.nan,
                                           mode='constant'
                                           ).reshape(slice_out.shape)
-
-        if progress_bar:
-            pb.update()
 
     if return_footprint:
         return array_new, (~np.isnan(array_new)).astype(float)

--- a/reproject/interpolation/core_celestial.py
+++ b/reproject/interpolation/core_celestial.py
@@ -6,9 +6,10 @@ import numpy as np
 from ..wcs_utils import convert_world_coordinates
 from ..array_utils import iterate_over_celestial_slices, map_coordinates
 
+from astropy.utils.console import ProgressBar
 
 def _reproject_celestial(array, wcs_in, wcs_out, shape_out, order=1, array_out=None,
-                         return_footprint=True):
+                         return_footprint=True, progressbar=True):
     """
     Reproject data with celestial axes to a new projection using interpolation,
     assuming that the non-celestial axes match exactly and thus don't need to be
@@ -58,6 +59,9 @@ def _reproject_celestial(array, wcs_in, wcs_out, shape_out, order=1, array_out=N
     xp_in = yp_in = None
 
     subset = None
+
+    if progressbar:
+        pb = ProgressBar(len(array))
 
     # Loop over slices and interpolate
     for slice_in, slice_out in iterate_over_celestial_slices(array,
@@ -113,6 +117,9 @@ def _reproject_celestial(array, wcs_in, wcs_out, shape_out, order=1, array_out=N
                                           order=order, cval=np.nan,
                                           mode='constant'
                                           ).reshape(slice_out.shape)
+
+        if progressbar:
+            pb.update()
 
     if return_footprint:
         return array_new, (~np.isnan(array_new)).astype(float)

--- a/reproject/interpolation/core_celestial.py
+++ b/reproject/interpolation/core_celestial.py
@@ -52,8 +52,9 @@ def _reproject_celestial(array, wcs_in, wcs_out, shape_out, order=1, array_out=N
     # the original array with the correct shape.
 
     if array_out is not None:
-        if tuple(array_out.shape) != tuple(shape_out):
-            raise ValueError("Array sizes don't match")
+        if array_out.shape != tuple(shape_out):
+            raise ValueError("Array sizes don't match.  Output array shape"
+                             "should be {0}".format(str(tuple(shape_out))))
         array_new = array_out
     else:
         array_new = np.zeros(shape_out)

--- a/reproject/interpolation/core_full.py
+++ b/reproject/interpolation/core_full.py
@@ -7,7 +7,8 @@ from ..wcs_utils import convert_world_coordinates
 from ..array_utils import map_coordinates
 
 
-def _reproject_full(array, wcs_in, wcs_out, shape_out, order=1):
+def _reproject_full(array, wcs_in, wcs_out, shape_out, order=1, array_out=None,
+                    return_footprint=True):
     """
     Reproject n-dimensional data to a new projection using interpolation.
 
@@ -126,10 +127,22 @@ def _reproject_full(array, wcs_in, wcs_out, shape_out, order=1):
 
     coordinates = pixel_in.transpose()[::-1]
 
-    array_new = map_coordinates(array,
+    if array_out is not None:
+        assert array_out.shape == shape_out
+        array_new = array_out
+        array_new[:] = map_coordinates(array,
                                 coordinates,
                                 order=order, cval=np.nan,
                                 mode='constant'
                                 ).reshape(shape_out)
+    else:
+        array_new = map_coordinates(array,
+                                    coordinates,
+                                    order=order, cval=np.nan,
+                                    mode='constant'
+                                    ).reshape(shape_out)
 
-    return array_new, (~np.isnan(array_new)).astype(float)
+    if return_footprint:
+        return array_new, (~np.isnan(array_new)).astype(float)
+    else:
+        return array_new

--- a/reproject/interpolation/core_full.py
+++ b/reproject/interpolation/core_full.py
@@ -138,9 +138,9 @@ def _reproject_full(array, wcs_in, wcs_out, shape_out, order=1, array_out=None,
             raise ValueError("An output array of a different type than the "
                              "input array was specified, which will create an "
                              "undesired duplicate copy of the input array "
-                             "in memory.") 
+                             "in memory.")
         else:
-            array_out = array_out.ravel()
+            array_out.shape = (array_out.size,)
     else:
         array_out = np.empty(shape_out).ravel()
 

--- a/reproject/interpolation/core_full.py
+++ b/reproject/interpolation/core_full.py
@@ -29,6 +29,9 @@ def _reproject_full(array, wcs_in, wcs_out, shape_out, order=1, array_out=None,
     elif len(shape_out) != wcs_out.wcs.naxis:
         raise ValueError("Length of shape_out should match number of dimensions in wcs_out")
 
+    # shape_out must be exact a tuple type
+    shape_out = tuple(shape_out)
+
     # Check whether celestial components are present
     if wcs_in.has_celestial and wcs_out.has_celestial:
         has_celestial = True
@@ -129,20 +132,24 @@ def _reproject_full(array, wcs_in, wcs_out, shape_out, order=1, array_out=None,
 
     if array_out is not None:
         if array_out.shape != tuple(shape_out):
-            raise ValueError("Array sizes don't match.  Output array shape"
+            raise ValueError("Array sizes don't match.  Output array shape "
                              "should be {0}".format(str(tuple(shape_out))))
+        elif array_out.dtype != array.dtype:
+            raise ValueError("An output array of a different type than the "
+                             "input array was specified, which will create an "
+                             "undesired duplicate copy of the input array "
+                             "in memory.") 
+        else:
+            array_out = array_out.ravel()
+    else:
+        array_out = np.empty(shape_out).ravel()
 
-    array_new = map_coordinates(array,
-                                coordinates,
-                                order=order, cval=np.nan,
-                                mode='constant',
-                                output=array_out,
-                                ).reshape(shape_out)
+    map_coordinates(array, coordinates, order=order, cval=np.nan,
+                    mode='constant', output=array_out,).reshape(shape_out)
 
-    if array_out is not None:
-        assert array_out is array_new
+    array_out.shape = shape_out
 
     if return_footprint:
-        return array_new, (~np.isnan(array_new)).astype(float)
+        return array_out, (~np.isnan(array_out)).astype(float)
     else:
-        return array_new
+        return array_out

--- a/reproject/interpolation/core_full.py
+++ b/reproject/interpolation/core_full.py
@@ -128,19 +128,19 @@ def _reproject_full(array, wcs_in, wcs_out, shape_out, order=1, array_out=None,
     coordinates = pixel_in.transpose()[::-1]
 
     if array_out is not None:
-        assert array_out.shape == shape_out
-        array_new = array_out
-        array_new[:] = map_coordinates(array,
+        if array_out.shape != tuple(shape_out):
+            raise ValueError("Array sizes don't match.  Output array shape"
+                             "should be {0}".format(str(tuple(shape_out))))
+
+    array_new = map_coordinates(array,
                                 coordinates,
                                 order=order, cval=np.nan,
                                 mode='constant'
                                 ).reshape(shape_out)
-    else:
-        array_new = map_coordinates(array,
-                                    coordinates,
-                                    order=order, cval=np.nan,
-                                    mode='constant'
-                                    ).reshape(shape_out)
+
+    if array_out is not None:
+        array_out[:] = array_new
+        array_new = array_out
 
     if return_footprint:
         return array_new, (~np.isnan(array_new)).astype(float)

--- a/reproject/interpolation/core_full.py
+++ b/reproject/interpolation/core_full.py
@@ -135,12 +135,12 @@ def _reproject_full(array, wcs_in, wcs_out, shape_out, order=1, array_out=None,
     array_new = map_coordinates(array,
                                 coordinates,
                                 order=order, cval=np.nan,
-                                mode='constant'
+                                mode='constant',
+                                output=array_out,
                                 ).reshape(shape_out)
 
     if array_out is not None:
-        array_out[:] = array_new
-        array_new = array_out
+        assert array_out is array_new
 
     if return_footprint:
         return array_new, (~np.isnan(array_new)).astype(float)

--- a/reproject/interpolation/high_level.py
+++ b/reproject/interpolation/high_level.py
@@ -18,7 +18,8 @@ ORDER['bicubic'] = 3
 
 
 def reproject_interp(input_data, output_projection, shape_out=None, hdu_in=0,
-                     order='bilinear', independent_celestial_slices=False):
+                     order='bilinear', independent_celestial_slices=False,
+                     output_array=None, return_footprint=True):
     """
     Reproject data to a new projection using interpolation (this is typically
     the fastest way to reproject an image).
@@ -71,6 +72,12 @@ def reproject_interp(input_data, output_projection, shape_out=None, hdu_in=0,
         In this special case, we can make things a little faster by
         reprojecting each celestial slice independently using the same
         transformation.
+    output_array : None or `~numpy.ndarray`
+        An array in which to store the reprojected data.  This can be any numpy
+        array including a memory map, which may be helpful when dealing with
+        extremely large files.
+    return_footprint : bool
+        Return the footprint in addition to the output array?
 
     Returns
     -------
@@ -89,6 +96,8 @@ def reproject_interp(input_data, output_projection, shape_out=None, hdu_in=0,
         order = ORDER[order]
 
     if (wcs_in.is_celestial and wcs_in.naxis == 2) or independent_celestial_slices:
-        return _reproject_celestial(array_in, wcs_in, wcs_out, shape_out=shape_out, order=order)
+        return _reproject_celestial(array_in, wcs_in, wcs_out, shape_out=shape_out, order=order,
+                                    array_out=output_array, return_footprint=return_footprint)
     else:
-        return _reproject_full(array_in, wcs_in, wcs_out, shape_out=shape_out, order=order)
+        return _reproject_full(array_in, wcs_in, wcs_out, shape_out=shape_out, order=order,
+                               return_footprint=return_footprint)

--- a/reproject/interpolation/tests/test_core.py
+++ b/reproject/interpolation/tests/test_core.py
@@ -427,8 +427,9 @@ def test_reproject_celestial_3d_withoutputarray():
     header_in = fits.Header.fromtextfile(get_pkg_data_filename('../../tests/data/cube.hdr'))
 
     array_in = np.ones((3, 200, 180))
-    out_full = np.empty((3, 160, 170))
-    out_celestial = np.empty((3, 160, 170))
+    outshape = (3, 160, 170)
+    out_full = np.empty(outshape)
+    out_celestial = np.empty(outshape)
 
     # TODO: here we can check that if we change the order of the dimensions in
     # the WCS, things still work properly
@@ -440,10 +441,10 @@ def test_reproject_celestial_3d_withoutputarray():
     wcs_out.wcs.crpix = [50., 50., wcs_in.wcs.crpix[2] + 0.4]
 
     # TODO when someone learns how to do it: make sure the memory isn't duplicated...
-    _ = _reproject_full(array_in, wcs_in, wcs_out, (3, 160, 170),
+    _ = _reproject_full(array_in, wcs_in, wcs_out, shape_out=outshape,
                         array_out=out_full, return_footprint=False)
 
-    _ = _reproject_celestial(array_in, wcs_in, wcs_out, (3, 160, 170),
+    _ = _reproject_celestial(array_in, wcs_in, wcs_out, shape_out=outshape,
                              array_out=out_celestial, return_footprint=False)
 
     np.testing.assert_allclose(out_full, out_celestial)

--- a/reproject/interpolation/tests/test_core.py
+++ b/reproject/interpolation/tests/test_core.py
@@ -443,8 +443,10 @@ def test_reproject_celestial_3d_withoutputarray():
     # TODO when someone learns how to do it: make sure the memory isn't duplicated...
     _ = _reproject_full(array_in, wcs_in, wcs_out, shape_out=outshape,
                         array_out=out_full, return_footprint=False)
+    assert out_full is _
 
     _ = _reproject_celestial(array_in, wcs_in, wcs_out, shape_out=outshape,
                              array_out=out_celestial, return_footprint=False)
+    assert out_celestial is _
 
     np.testing.assert_allclose(out_full, out_celestial)

--- a/reproject/interpolation/tests/test_core.py
+++ b/reproject/interpolation/tests/test_core.py
@@ -415,3 +415,35 @@ def test_reproject_celestial_3d():
 
     np.testing.assert_allclose(out_full, out_celestial)
     np.testing.assert_allclose(foot_full, foot_celestial)
+
+
+def test_reproject_celestial_3d_withoutputarray():
+    """
+    Test both full_reproject and slicewise reprojection. We use a case where the
+    non-celestial slices are the same and therefore where both algorithms can
+    work.
+    """
+
+    header_in = fits.Header.fromtextfile(get_pkg_data_filename('../../tests/data/cube.hdr'))
+
+    array_in = np.ones((3, 200, 180))
+    out_full = np.empty((3, 160, 170))
+    out_celestial = np.empty((3, 160, 170))
+
+    # TODO: here we can check that if we change the order of the dimensions in
+    # the WCS, things still work properly
+
+    wcs_in = WCS(header_in)
+    wcs_out = wcs_in.deepcopy()
+    wcs_out.wcs.ctype = ['GLON-SIN', 'GLAT-SIN', wcs_in.wcs.ctype[2]]
+    wcs_out.wcs.crval = [158.0501, -21.530282, wcs_in.wcs.crval[2]]
+    wcs_out.wcs.crpix = [50., 50., wcs_in.wcs.crpix[2] + 0.4]
+
+    # TODO when someone learns how to do it: make sure the memory isn't duplicated...
+    _ = _reproject_full(array_in, wcs_in, wcs_out, (3, 160, 170),
+                        array_out=out_full, return_footprint=False)
+
+    _ = _reproject_celestial(array_in, wcs_in, wcs_out, (3, 160, 170),
+                             array_out=out_celestial, return_footprint=False)
+
+    np.testing.assert_allclose(out_full, out_celestial)


### PR DESCRIPTION
When projecting very large cubes with independent celestial slices, it should be possible - in principle - to specify an output array that is a memory map on disk and write into that, thereby avoiding ever having the whole cube in memory.  

In practice, my first attempt with this failed.  I don't understand why yet, but I vaguely suspect that some interaction between the OS and python isn't capable enough to put the already-completed data aside...