### PR TITLE
Minor conftest.py cleanup

### DIFF
--- a/reproject/conftest.py
+++ b/reproject/conftest.py
@@ -1,8 +1,16 @@
 # This file is used to configure the behavior of pytest when using the Astropy
 # test infrastructure.
-
+import os
+from distutils.version import LooseVersion
 from astropy.version import version as astropy_version
-if astropy_version < '3.0':
+
+if LooseVersion(astropy_version) < LooseVersion('2.0.3'):
+    # Astropy is not compatible with the standalone plugins prior this while
+    # astroquery requires them, so we need this workaround. This will mess
+    # up the test header, but everything else will work.
+    from astropy.tests.pytest_plugins import (PYTEST_HEADER_MODULES,
+                                              TESTED_VERSIONS)
+elif astropy_version < '3.0':
     # With older versions of Astropy, we actually need to import the pytest
     # plugins themselves in order to make them discoverable by pytest.
     from astropy.tests.pytest_plugins import *
@@ -33,17 +41,11 @@ except (NameError, KeyError):  # NameError is needed to support Astropy < 1.0
 # Uncomment the following lines to display the version number of the
 # package rather than the version number of Astropy in the top line when
 # running the tests.
-import os
 
-# This is to figure out the affiliated package version, rather than
+# This is to figure out the reproject's version, rather than
 # using Astropy's
-try:
-    from .version import version
-except ImportError:
-    version = 'dev'
+from .version import version, astropy_helpers_version
 
-try:
-    packagename = os.path.basename(os.path.dirname(__file__))
-    TESTED_VERSIONS[packagename] = version
-except NameError:   # Needed to support Astropy <= 1.0.0
-    pass
+packagename = os.path.basename(os.path.dirname(__file__))
+TESTED_VERSIONS[packagename] = version
+TESTED_VERSIONS['astropy_helpers'] = astropy_helpers_version

--- a/reproject/conftest.py
+++ b/reproject/conftest.py
@@ -15,21 +15,7 @@ else:
 
 from astropy.tests.helper import enable_deprecations_as_exceptions
 
-# Uncomment the following line to treat all DeprecationWarnings as
-# exceptions. For Astropy v2.0 or later, there are 2 additional keywords,
-# as follow (although default should work for most cases).
-# To ignore some packages that produce deprecation warnings on import
-# (in addition to 'compiler', 'scipy', 'pygments', 'ipykernel', and
-# 'setuptools'), add:
-#     modules_to_ignore_on_import=['module_1', 'module_2']
-# To ignore some specific deprecation warning messages for Python version
-# MAJOR.MINOR or later, add:
-#     warnings_to_ignore_by_pyver={(MAJOR, MINOR): ['Message to ignore']}
-from distutils.version import LooseVersion
-if LooseVersion(astropy_version) < LooseVersion('2.0'):
-    enable_deprecations_as_exceptions()
-else:
-    enable_deprecations_as_exceptions(warnings_to_ignore_entire_module=['astropy.io.fits'])
+enable_deprecations_as_exceptions()
 
 # Uncomment and customize the following lines to add/remove entries from
 # the list of packages for which version numbers are displayed when running

--- a/reproject/conftest.py
+++ b/reproject/conftest.py
@@ -1,50 +1,19 @@
 # This file is used to configure the behavior of pytest when using the Astropy
 # test infrastructure.
 import os
-from distutils.version import LooseVersion
-from astropy.version import version as astropy_version
 
-if LooseVersion(astropy_version) < LooseVersion('2.0.3'):
-    # Astropy is not compatible with the standalone plugins prior this while
-    # astroquery requires them, so we need this workaround. This will mess
-    # up the test header, but everything else will work.
-    from astropy.tests.pytest_plugins import (PYTEST_HEADER_MODULES,
-                                              TESTED_VERSIONS)
-elif astropy_version < '3.0':
-    # With older versions of Astropy, we actually need to import the pytest
-    # plugins themselves in order to make them discoverable by pytest.
-    from astropy.tests.pytest_plugins import *
-else:
-    # As of Astropy 3.0, the pytest plugins provided by Astropy are
-    # automatically made available when Astropy is installed. This means it's
-    # not necessary to import them here, but we still need to import global
-    # variables that are used for configuration.
-    from astropy.tests.plugins.display import PYTEST_HEADER_MODULES, TESTED_VERSIONS
-
+from astropy.tests.plugins.display import PYTEST_HEADER_MODULES, TESTED_VERSIONS
 from astropy.tests.helper import enable_deprecations_as_exceptions
 
 enable_deprecations_as_exceptions()
 
-# Uncomment and customize the following lines to add/remove entries from
-# the list of packages for which version numbers are displayed when running
-# the tests. Making it pass for KeyError is essential in some cases when
-# the package uses other astropy affiliated packages.
-try:
-    PYTEST_HEADER_MODULES['Astropy'] = 'astropy'
-    PYTEST_HEADER_MODULES['astropy-healpix'] = 'astropy_healpix'
-    PYTEST_HEADER_MODULES['Cython'] = 'cython'
-    del PYTEST_HEADER_MODULES['h5py']
-    del PYTEST_HEADER_MODULES['Matplotlib']
-except (NameError, KeyError):  # NameError is needed to support Astropy < 1.0
-    pass
+PYTEST_HEADER_MODULES['Astropy'] = 'astropy'
+PYTEST_HEADER_MODULES['astropy-healpix'] = 'astropy_healpix'
+PYTEST_HEADER_MODULES['Cython'] = 'cython'
+del PYTEST_HEADER_MODULES['h5py']
+del PYTEST_HEADER_MODULES['Matplotlib']
 
-# Uncomment the following lines to display the version number of the
-# package rather than the version number of Astropy in the top line when
-# running the tests.
-
-# This is to figure out the reproject's version, rather than
-# using Astropy's
-from .version import version, astropy_helpers_version
+from .version import version, astropy_helpers_version  # noqa
 
 packagename = os.path.basename(os.path.dirname(__file__))
 TESTED_VERSIONS[packagename] = version


### PR DESCRIPTION
Currently astropy 2.0+ is required, and also the 0.2 version of pytest-arraydiff fixed their deprecated astropy.io.fits usage, thus some cleanup could be done.