### PR TITLE
Add support for NDData

### DIFF
--- a/reproject/healpix/high_level.py
+++ b/reproject/healpix/high_level.py
@@ -62,7 +62,7 @@ def reproject_from_healpix(input_data, output_projection, shape_out=None,
 
     array_in, coord_system_in, nested = parse_input_healpix_data(input_data, hdu_in=hdu_in,
                                                                  field=field, nested=nested)
-    wcs_out, shape_out = parse_output_projection(output_projection, shape_out=shape_out)
+    wcs_out, shape_out, _ = parse_output_projection(output_projection, shape_out=shape_out)
 
     if nested is None:
         raise ValueError("Could not determine whether the data follows the "
@@ -80,13 +80,16 @@ def reproject_to_healpix(input_data, coord_system_out, hdu_in=0,
 
     Parameters
     ----------
-    input_data : str or `~astropy.io.fits.HDUList` or `~astropy.io.fits.PrimaryHDU` or `~astropy.io.fits.ImageHDU` or tuple
+    input_data : `str` or `~astropy.io.fits.HDUList` or `~astropy.io.fits.PrimaryHDU` or `~astropy.io.fits.ImageHDU` or `~astropy.nddata.NDDataBase` or `tuple`
         The input data to reproject. This can be:
 
             * The name of a FITS file
             * An `~astropy.io.fits.HDUList` object
             * An image HDU object such as a `~astropy.io.fits.PrimaryHDU` or
               `~astropy.io.fits.ImageHDU` instance
+            * A tuple where the first element is a `~numpy.ndarray` and the
+              second element is either a `~astropy.wcs.WCS` or a
+              `~astropy.io.fits.Header` object
             * A tuple where the first element is a `~numpy.ndarray` and the
               second element is either a `~astropy.wcs.WCS` or a
               `~astropy.io.fits.Header` object

--- a/reproject/interpolation/high_level.py
+++ b/reproject/interpolation/high_level.py
@@ -26,7 +26,7 @@ def reproject_interp(input_data, output_projection, shape_out=None, hdu_in=0,
 
     Parameters
     ----------
-    input_data : str or `~astropy.io.fits.HDUList` or `~astropy.io.fits.PrimaryHDU` or `~astropy.io.fits.ImageHDU` or tuple
+    input_data : `str` or `~astropy.io.fits.HDUList` or `~astropy.io.fits.PrimaryHDU` or `~astropy.io.fits.ImageHDU` or `~astropy.nddata.NDDataBase` or `tuple`
         The input data to reproject. This can be:
 
             * The name of a FITS file
@@ -34,13 +34,22 @@ def reproject_interp(input_data, output_projection, shape_out=None, hdu_in=0,
             * An image HDU object such as a `~astropy.io.fits.PrimaryHDU`,
               `~astropy.io.fits.ImageHDU`, or `~astropy.io.fits.CompImageHDU`
               instance
+            * An `~astropy.nddata.NDDataBase` object, where the ``.data``
+              attribute will be used as the input array and the ``.wcs``
+              attribute will be used as the input projection.
             * A tuple where the first element is a `~numpy.ndarray` and the
               second element is either a `~astropy.wcs.WCS` or a
               `~astropy.io.fits.Header` object
 
-    output_projection : `~astropy.wcs.WCS` or `~astropy.io.fits.Header`
-        The output projection, which can be either a `~astropy.wcs.WCS`
-        or a `~astropy.io.fits.Header` instance.
+    output_projection : `~astropy.wcs.WCS` or `~astropy.io.fits.Header` or `~astropy.nddata.NDDataBase`
+        The output projection, which can be either a:
+            * `~astropy.wcs.WCS` instance.
+            * A `~astropy.io.fits.Header` instance.
+            * An `~astropy.nddata.NDDataBase` object, where the ``.data``
+              attribute will be used as the output array (and modified in place
+              as if ``output_array`` had been specified) and the ``.wcs``
+              attribute will be used as the output projection.
+
     shape_out : tuple, optional
         If ``output_projection`` is a `~astropy.wcs.WCS` instance, the
         shape of the output data should be specified separately.
@@ -90,7 +99,7 @@ def reproject_interp(input_data, output_projection, shape_out=None, hdu_in=0,
     """
 
     array_in, wcs_in = parse_input_data(input_data, hdu_in=hdu_in)
-    wcs_out, shape_out = parse_output_projection(output_projection, shape_out=shape_out)
+    wcs_out, shape_out, output_array = parse_output_projection(output_projection, shape_out, output_array)
 
     if isinstance(order, six.string_types):
         order = ORDER[order]
@@ -100,4 +109,4 @@ def reproject_interp(input_data, output_projection, shape_out=None, hdu_in=0,
                                     array_out=output_array, return_footprint=return_footprint)
     else:
         return _reproject_full(array_in, wcs_in, wcs_out, shape_out=shape_out, order=order,
-                               return_footprint=return_footprint)
+                               array_out=output_array, return_footprint=return_footprint)

--- a/reproject/spherical_intersect/high_level.py
+++ b/reproject/spherical_intersect/high_level.py
@@ -16,7 +16,7 @@ def reproject_exact(input_data, output_projection, shape_out=None, hdu_in=0,
 
     Parameters
     ----------
-    input_data : str or `~astropy.io.fits.HDUList` or `~astropy.io.fits.PrimaryHDU` or `~astropy.io.fits.ImageHDU` or tuple
+    input_data : `str` or `~astropy.io.fits.HDUList` or `~astropy.io.fits.PrimaryHDU` or `~astropy.io.fits.ImageHDU` or `~astropy.nddata.NDDataBase` or `tuple`
         The input data to reproject. This can be:
 
             * The name of a FITS file
@@ -24,6 +24,9 @@ def reproject_exact(input_data, output_projection, shape_out=None, hdu_in=0,
             * An image HDU object such as a `~astropy.io.fits.PrimaryHDU`,
               `~astropy.io.fits.ImageHDU`, or `~astropy.io.fits.CompImageHDU`
               instance
+            * A tuple where the first element is a `~numpy.ndarray` and the
+              second element is either a `~astropy.wcs.WCS` or a
+              `~astropy.io.fits.Header` object
             * A tuple where the first element is a `~numpy.ndarray` and the
               second element is either a `~astropy.wcs.WCS` or a
               `~astropy.io.fits.Header` object
@@ -55,7 +58,7 @@ def reproject_exact(input_data, output_projection, shape_out=None, hdu_in=0,
     """
 
     array_in, wcs_in = parse_input_data(input_data, hdu_in=hdu_in)
-    wcs_out, shape_out = parse_output_projection(output_projection, shape_out=shape_out)
+    wcs_out, shape_out, _ = parse_output_projection(output_projection, shape_out=shape_out)
 
     if wcs_in.has_celestial and wcs_in.naxis == 2:
         return _reproject_celestial(array_in, wcs_in, wcs_out, shape_out=shape_out, parallel=parallel)

--- a/reproject/utils.py
+++ b/reproject/utils.py
@@ -27,7 +27,7 @@ def parse_input_data(input_data, hdu_in=None):
     elif isinstance(input_data, NDDataBase):
         return (input_data.data, input_data.wcs)
     elif isinstance(input_data, tuple) and isinstance(input_data[0], np.ndarray):
-        if isinstance(input_data[1], Header):
+        if isinstance(input_data[1], (Header, dict)):
             return input_data[0], WCS(input_data[1])
         else:
             return input_data
@@ -40,7 +40,7 @@ def parse_output_projection(output_projection, shape_out=None, output_array=None
         if output_array is not None:
             shape_out = output_array.shape
 
-    if isinstance(output_projection, Header):
+    if isinstance(output_projection, (Header, dict)):
         wcs_out = WCS(output_projection)
         try:
             shape_out = [output_projection['NAXIS{0}'.format(i + 1)] for i in range(output_projection['NAXIS'])][::-1]


### PR DESCRIPTION
This ended up adding support for NDData input in `reproject_exact` and `reproject_to_healpix` and both input and output in `reproject_interp`. The outputs for the others could be added if they grew `output_array` support.

This needs tests, but otherwise should be good.

Closes #177