### PR TITLE
Update astropy-helpers to v3.2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,9 +27,7 @@ matrix:
 
         # Try older numpy/astropy versions and with optional dependencies only
         - env: PYTHON_VERSION=3.6 NUMPY_VERSION=1.12 ASTROPY_VERSION=3.0
-        - env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.10 ASTROPY_VERSION=2.0
-        - env: PYTHON_VERSION=2.7 UMPY_VERSION=1.14 PIP_DEPENDENCIES='pytest-arraydiff'
-        - env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.15 PIP_DEPENDENCIES='pytest-arraydiff'
+        - env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.15
 
 before_install:
     # Make sure matplotlib uses PyQT not PySide

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
 
         # Check for sphinx doc build warnings - we do this first because it
         # may run for a long time
-        - env: SETUP_CMD='build_sphinx -w'
+        - env: SETUP_CMD='build_sphinx -w' PIP_DEPENDENCIES='sphinx-astropy'
 
         # Try Astropy development version
         - env: ASTROPY_VERSION=development

--- a/ah_bootstrap.py
+++ b/ah_bootstrap.py
@@ -48,11 +48,7 @@ import sys
 from distutils import log
 from distutils.debug import DEBUG
 
-
-try:
-    from ConfigParser import ConfigParser, RawConfigParser
-except ImportError:
-    from configparser import ConfigParser, RawConfigParser
+from configparser import ConfigParser, RawConfigParser
 
 import pkg_resources
 
@@ -60,25 +56,12 @@ from setuptools import Distribution
 from setuptools.package_index import PackageIndex
 
 # This is the minimum Python version required for astropy-helpers
-__minimum_python_version__ = (2, 7)
-
-if sys.version_info[0] < 3:
-    _str_types = (str, unicode)
-    _text_type = unicode
-    PY3 = False
-else:
-    _str_types = (str, bytes)
-    _text_type = str
-    PY3 = True
+__minimum_python_version__ = (3, 5)
 
 # TODO: Maybe enable checking for a specific version of astropy_helpers?
 DIST_NAME = 'astropy-helpers'
 PACKAGE_NAME = 'astropy_helpers'
-
-if PY3:
-    UPPER_VERSION_EXCLUSIVE = None
-else:
-    UPPER_VERSION_EXCLUSIVE = '3'
+UPPER_VERSION_EXCLUSIVE = None
 
 # Defaults for other options
 DOWNLOAD_IF_NEEDED = True
@@ -138,35 +121,39 @@ if SETUP_CFG.has_option('options', 'python_requires'):
     # allow pre-releases to count as 'new enough'
     if not req.specifier.contains(python_version, True):
         if parent_package is None:
-            print("ERROR: Python {} is required by this package".format(req.specifier))
+            message = "ERROR: Python {} is required by this package\n".format(req.specifier)
         else:
-            print("ERROR: Python {} is required by {}".format(req.specifier, parent_package))
+            message = "ERROR: Python {} is required by {}\n".format(req.specifier, parent_package)
+        sys.stderr.write(message)
         sys.exit(1)
 
 if sys.version_info < __minimum_python_version__:
 
     if parent_package is None:
-        print("ERROR: Python {} or later is required by astropy-helpers".format(
-            __minimum_python_version__))
+        message = "ERROR: Python {} or later is required by astropy-helpers\n".format(
+            __minimum_python_version__)
     else:
-        print("ERROR: Python {} or later is required by astropy-helpers for {}".format(
-            __minimum_python_version__, parent_package))
+        message = "ERROR: Python {} or later is required by astropy-helpers for {}\n".format(
+            __minimum_python_version__, parent_package)
 
+    sys.stderr.write(message)
     sys.exit(1)
+
+_str_types = (str, bytes)
 
 
 # What follows are several import statements meant to deal with install-time
 # issues with either missing or misbehaving pacakges (including making sure
 # setuptools itself is installed):
 
-# Check that setuptools 1.0 or later is present
+# Check that setuptools 30.3 or later is present
 from distutils.version import LooseVersion
 
 try:
     import setuptools
-    assert LooseVersion(setuptools.__version__) >= LooseVersion('1.0')
+    assert LooseVersion(setuptools.__version__) >= LooseVersion('30.3')
 except (ImportError, AssertionError):
-    print("ERROR: setuptools 1.0 or later is required by astropy-helpers")
+    sys.stderr.write("ERROR: setuptools 30.3 or later is required by astropy-helpers\n")
     sys.exit(1)
 
 # typing as a dependency for 1.6.1+ Sphinx causes issues when imported after
@@ -225,7 +212,7 @@ class _Bootstrapper(object):
         if not (isinstance(path, _str_types) or path is False):
             raise TypeError('path must be a string or False')
 
-        if PY3 and not isinstance(path, _text_type):
+        if not isinstance(path, str):
             fs_encoding = sys.getfilesystemencoding()
             path = path.decode(fs_encoding)  # path to unicode
 
@@ -852,9 +839,9 @@ def run_cmd(cmd):
         stdio_encoding = 'latin1'
 
     # Unlikely to fail at this point but even then let's be flexible
-    if not isinstance(stdout, _text_type):
+    if not isinstance(stdout, str):
         stdout = stdout.decode(stdio_encoding, 'replace')
-    if not isinstance(stderr, _text_type):
+    if not isinstance(stderr, str):
         stderr = stderr.decode(stdio_encoding, 'replace')
 
     return (p.returncode, stdout, stderr)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,11 +16,6 @@ environment:
       PIP_DEPENDENCIES: "pytest-arraydiff"
 
   matrix:
-
-      - PYTHON_VERSION: "2.7"
-        NUMPY_VERSION: "1.13"
-        ASTROPY_VERSION: "stable"
-
       - PYTHON_VERSION: "3.6"
         NUMPY_VERSION: "1.13"
         ASTROPY_VERSION: "stable"


### PR DESCRIPTION
This is an automated update of the astropy-helpers submodule to v3.2.1. This includes both the update of the astropy-helpers sub-module, and the ``ah_bootstrap.py`` file, if needed. 
Please note that since v3.2, ``sphinx-astropy`` needs to be explicitely listed as a dependency for building the documentation. 
A full list of changes can be found in the [changelog](https://github.com/astropy/astropy-helpers/blob/v3.2.1/CHANGES.rst). 
 
We also wanted to let you know that we have made new releases of the astropy package-template. You can find the latest [cookiecutter template here](https://github.com/astropy/package-template) or if you prefer you can find a [rendered version of the template here](https://github.com/astropy/package-template/tree/master). 

*This is intended to be helpful, but if you would prefer to manage these updates yourself, or if you notice any issues with this automated update, please let @bsipocz or @astrofrog know!* 

Similarly to the core package, the v3.0+ releases of astropy-helpers require Python 3.5+. We will open automated update PRs with astropy-helpers v3.2.x only for packages that specifically opt in for it when they start supporting Python 3.5+ only. Please let @bsipocz or @astrofrog know or add your package to the list in https://github.com/astropy/astropy-procedures/blob/master/update-packages/helpers_3.py