### PR TITLE
Fix bug in exact mode related to WCS orientation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
       - run:
           name: Install dependencies
           command: |
-            /opt/python/cp36-cp36m/bin/pip install numpy scipy pytest-remotedata pytest-doctestplus astropy cython jinja2 pytest-arraydiff
+            /opt/python/cp36-cp36m/bin/pip install numpy scipy pytest==4.* pytest-remotedata pytest-doctestplus astropy cython jinja2 pytest-arraydiff
             /opt/python/cp36-cp36m/bin/pip install astropy-healpix
       - run:
           name: Build

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,12 @@
 
 - No changes yet.
 
+0.5.1 (unreleased)
+------------------
+
+- Fixed a bug that caused 'exact' reprojection to fail if one or more of
+  the WCSes was oriented such that E and W were flipped. [#188]
+
 0.5 (2019-06-13)
 ----------------
 

--- a/reproject/spherical_intersect/overlap.py
+++ b/reproject/spherical_intersect/overlap.py
@@ -27,9 +27,9 @@ def compute_overlap(ilon, ilat, olon, olat):
     area_ratio : np.ndarray of length N
         TODO
     """
-    ilon = np.asarray(ilon, dtype=np.float64)
-    ilat = np.asarray(ilat, dtype=np.float64)
-    olon = np.asarray(olon, dtype=np.float64)
-    olat = np.asarray(olat, dtype=np.float64)
+    ilon = np.ascontiguousarray(ilon, dtype=np.float64)
+    ilat = np.ascontiguousarray(ilat, dtype=np.float64)
+    olon = np.ascontiguousarray(olon, dtype=np.float64)
+    olat = np.ascontiguousarray(olat, dtype=np.float64)
 
     return _compute_overlap(ilon, ilat, olon, olat)

--- a/reproject/spherical_intersect/overlapArea.c
+++ b/reproject/spherical_intersect/overlapArea.c
@@ -58,6 +58,7 @@ void SaveSharedSeg(Vec *p, Vec *q);
 void PrintPolygon();
 
 void ComputeIntersection(Vec *P, Vec *Q);
+void EnsureCounterClockWise(Vec *V);
 
 int UpdateInteriorFlag(Vec *p, int interiorFlag, int pEndpointFromQdir,
                        int qEndpointFromPdir);
@@ -122,9 +123,48 @@ double computeOverlap(double *ilon, double *ilat, double *olon, double *olat,
     Q[i].z = sin(olat[i]);
   }
 
+  EnsureCounterClockWise(P);
+  EnsureCounterClockWise(Q);
+
   ComputeIntersection(P, Q);
 
   return (Girard());
+}
+
+void EnsureCounterClockWise(Vec *V) {
+
+  // Make sure that the polygon is counter-clockwise. For now we assume that we
+  // are dealing with convex quadrilaterals, and therefore we can just check
+  // the two first sides of the polygon.
+
+  Vec S1, S2, C;
+  double dir;
+  double tmp;
+
+  S1.x = V[1].x - V[0].x;
+  S1.y = V[1].y - V[0].y;
+  S1.z = V[1].z - V[0].z;
+
+  S2.x = V[2].x - V[1].x;
+  S2.y = V[2].y - V[1].y;
+  S2.z = V[2].z - V[1].z;
+
+  Cross(&S1, &S2, &C);
+
+  dir = Dot(&V[1], &C);
+
+  if (dir < 0) {
+    tmp = V[2].x;
+    V[2].x = V[0].x;
+    V[0].x = tmp;
+    tmp = V[2].y;
+    V[2].y = V[0].y;
+    V[0].y = tmp;
+    tmp = V[2].z;
+    V[2].z = V[0].z;
+    V[0].z = tmp;
+  }
+
 }
 
 /*

--- a/reproject/spherical_intersect/tests/test_overlap.py
+++ b/reproject/spherical_intersect/tests/test_overlap.py
@@ -1,8 +1,10 @@
+import pytest
+from itertools import product
 import numpy as np
 from ..overlap import compute_overlap
 
 
-def test_overlap():
+def test_full_overlap():
     EPS = np.radians(1e-2)
     lon, lat = np.array([[0, EPS, EPS, 0]]), np.array([[0, 0, EPS, EPS]])
     overlap, area_ratio = compute_overlap(lon, lat, lon, lat)
@@ -10,10 +12,32 @@ def test_overlap():
     np.testing.assert_allclose(area_ratio, 1, rtol=1e-6)
 
 
-def test_overlap2():
+def test_partial_overlap():
     EPS = np.radians(1e-2)
     ilon, ilat = np.array([[0, EPS, EPS, 0]]), np.array([[0, 0, EPS, EPS]])
     olon, olat = np.array([[0.5 * EPS, 1.5 * EPS, 1.5 * EPS, 0.5 * EPS]]), np.array([[0, 0, EPS, EPS]])
+
+    overlap, area_ratio = compute_overlap(ilon, ilat, olon, olat)
+    np.testing.assert_allclose(overlap, 0.5 * EPS ** 2, rtol=1e-6)
+    np.testing.assert_allclose(area_ratio, 1, rtol=1e-6)
+
+
+@pytest.mark.parametrize(('clockwise1', 'clockwise2'),
+                         product([False, True], [False, True]))
+def test_overlap_direction(clockwise1, clockwise2):
+
+    # Regression test for a bug that caused the calculation to fail if one or
+    # both of the polygons were clockwise
+
+    EPS = np.radians(1e-2)
+    ilon, ilat = np.array([[0, EPS, EPS, 0]]), np.array([[0, 0, EPS, EPS]])
+    olon, olat = np.array([[0.5 * EPS, 1.5 * EPS, 1.5 * EPS, 0.5 * EPS]]), np.array([[0, 0, EPS, EPS]])
+
+    if clockwise1:
+        ilon, ilat = ilon[:, ::-1], ilat[:, ::-1]
+
+    if clockwise2:
+        olon, olat = olon[:, ::-1], olat[:, ::-1]
 
     overlap, area_ratio = compute_overlap(ilon, ilat, olon, olat)
     np.testing.assert_allclose(overlap, 0.5 * EPS ** 2, rtol=1e-6)


### PR DESCRIPTION
This should fix the bug that has been reported a few times relating to WCSes with non-standard orientations (e.g. with E and W flipped). This was due to the ``overlapArea`` function not working correctly with clockwise spherical polygons.

Fixes #113 (checked)
Fixes #164 (checked)
Fixes #187 (checked)