### PR TITLE
Split out interpolation WCS validation into new function

### DIFF
--- a/reproject/interpolation/core.py
+++ b/reproject/interpolation/core.py
@@ -34,6 +34,20 @@ def _validate_wcs(wcs_in, wcs_out, shape_out):
             raise ValueError("Output WCS has a spectral component but input WCS does not")
 
 
+def _validate_array_out(array_out, array, shape_out):
+    if array_out is None:
+        return
+
+    if array_out.shape != tuple(shape_out):
+        raise ValueError("Array sizes don't match.  Output array shape "
+                         "should be {}".format(str(tuple(shape_out))))
+    elif array_out.dtype != array.dtype:
+        raise ValueError("An output array of a different type than the "
+                         "input array was specified, which will create an "
+                         "undesired duplicate copy of the input array "
+                         "in memory.")
+
+
 def _reproject_full(array, wcs_in, wcs_out, shape_out, order=1, array_out=None,
                     return_footprint=True):
     """
@@ -53,6 +67,8 @@ def _reproject_full(array, wcs_in, wcs_out, shape_out, order=1, array_out=None,
     # shape_out must be exact a tuple type
     shape_out = tuple(shape_out)
 
+    _validate_array_out(array_out, array, shape_out)
+
     pixel_out = np.meshgrid(*[np.arange(size, dtype=float) for size in shape_out],
                             indexing='ij', sparse=False, copy=False)
     pixel_out = [p.ravel() for p in pixel_out]
@@ -60,16 +76,7 @@ def _reproject_full(array, wcs_in, wcs_out, shape_out, order=1, array_out=None,
     pixel_in = np.array(pixel_in)
 
     if array_out is not None:
-        if array_out.shape != tuple(shape_out):
-            raise ValueError("Array sizes don't match.  Output array shape "
-                             "should be {}".format(str(tuple(shape_out))))
-        elif array_out.dtype != array.dtype:
-            raise ValueError("An output array of a different type than the "
-                             "input array was specified, which will create an "
-                             "undesired duplicate copy of the input array "
-                             "in memory.")
-        else:
-            array_out.shape = (array_out.size,)
+        array_out.shape = (array_out.size,)
     else:
         array_out = np.empty(shape_out).ravel()
 

--- a/reproject/interpolation/core.py
+++ b/reproject/interpolation/core.py
@@ -9,29 +9,36 @@ from ..wcs_utils import efficient_pixel_to_pixel_with_roundtrip, has_celestial
 
 def _validate_wcs(wcs_in, wcs_out, shape_out):
     if wcs_in.low_level_wcs.pixel_n_dim != wcs_out.low_level_wcs.pixel_n_dim:
-        raise ValueError("Number of dimensions between input and output WCS should match")
+        raise ValueError(
+            "Number of dimensions between input and output WCS should match")
     elif len(shape_out) != wcs_out.low_level_wcs.pixel_n_dim:
-        raise ValueError("Length of shape_out should match number of dimensions in wcs_out")
+        raise ValueError(
+            "Length of shape_out should match number of dimensions in wcs_out")
 
     if has_celestial(wcs_in) and not has_celestial(wcs_out):
-        raise ValueError("Input WCS has celestial components but output WCS does not")
+        raise ValueError(
+            "Input WCS has celestial components but output WCS does not")
     elif has_celestial(wcs_out) and not has_celestial(wcs_in):
-        raise ValueError("Output WCS has celestial components but input WCS does not")
+        raise ValueError(
+            "Output WCS has celestial components but input WCS does not")
 
     if isinstance(wcs_in, WCS) and isinstance(wcs_out, WCS):
 
         # Check whether a spectral component is present, and if so, check that
         # the CTYPEs match.
         if wcs_in.wcs.spec >= 0 and wcs_out.wcs.spec >= 0:
-            if wcs_in.wcs.ctype[wcs_in.wcs.spec] != wcs_out.wcs.ctype[wcs_out.wcs.spec]:
+            if (wcs_in.wcs.ctype[wcs_in.wcs.spec] !=
+                    wcs_out.wcs.ctype[wcs_out.wcs.spec]):
                 raise ValueError("The input ({}) and output ({}) spectral "
                                  "coordinate types are not equivalent."
                                  .format(wcs_in.wcs.ctype[wcs_in.wcs.spec],
                                          wcs_out.wcs.ctype[wcs_out.wcs.spec]))
         elif wcs_in.wcs.spec >= 0:
-            raise ValueError("Input WCS has a spectral component but output WCS does not")
+            raise ValueError(
+                "Input WCS has a spectral component but output WCS does not")
         elif wcs_out.wcs.spec >= 0:
-            raise ValueError("Output WCS has a spectral component but input WCS does not")
+            raise ValueError(
+                "Output WCS has a spectral component but input WCS does not")
 
 
 def _validate_array_out(array_out, array, shape_out):


### PR DESCRIPTION
This is purely a code aesthetic change, but I think it makes it much more readable with the validation split off into it's own function.