### PR TITLE
Fix reproject_and_coadd for cyclic coordinate systems

### DIFF
--- a/reproject/mosaicking/coadd.py
+++ b/reproject/mosaicking/coadd.py
@@ -117,8 +117,8 @@ def reproject_and_coadd(input_data, output_projection, shape_out=None,
         # distortions of the edges in the reprojection process we could simply
         # add arbitrary numbers of midpoints to this list.
         ny, nx = array_in.shape
-        xc = np.array([-0.5, nx - 0.5, nx - 0.5, -0.5])
-        yc = np.array([-0.5, -0.5, ny - 0.5, ny - 0.5])
+        xc = np.array([0, nx + 1, nx + 1, 0])
+        yc = np.array([0, 0, ny + 1, ny + 1])
         xc_out, yc_out = wcs_out.world_to_pixel(wcs_in.pixel_to_world(xc, yc))
 
         # Determine the cutout parameters


### PR DESCRIPTION
`reproject_and_coadd` is clever and tries to minimize the footprint that is reprojected. However, the (0, 0) pixels it was using were actually the centers of the (-1, -1) pixels (-0.5, -0.5), which for cyclic coordinate systems (e.g. Heliographic Carrington) would wrap round to the top right corner, and therefore the footprint to be re-projected was completely empty!

This (I think) fixes that by using the edges of the corner pixels instead of the pixel centers.

I am struggling to produce a simple and self contained example...