### PR TITLE
Add support for blocked and parallel reprojection in ``reproject_interp``

### DIFF
--- a/reproject/interpolation/high_level.py
+++ b/reproject/interpolation/high_level.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import os
+
 from astropy.utils import deprecated_renamed_argument
 
 from ..utils import parse_input_data, parse_output_projection, reproject_blocked
@@ -70,6 +71,11 @@ def reproject_interp(input_data, output_projection, shape_out=None, hdu_in=0,
         reprojected to one block at a time, this is useful for memory limited scenarios
         such as dealing with very large arrays or high resolution output spaces.
     parallel : bool or int
+        Flag for parallel implementation. If ``True``, a parallel implementation
+        is chosen, the number of processes selected automatically to be equal to
+        the number of logical CPUs detected on the machine. If ``False``, a
+        serial implementation is chosen. If the flag is a positive integer ``n``
+        greater than one, a parallel implementation using ``n`` processes is chosen.
     roundtrip_coords : bool
         Whether to verify that coordinate transformations are defined in both
         directions.

--- a/reproject/interpolation/tests/test_core.py
+++ b/reproject/interpolation/tests/test_core.py
@@ -583,7 +583,7 @@ def test_identity_with_offset(roundtrip_coords):
     assert_allclose(expected, array_out, atol=1e-10)
 
 
-@pytest.mark.parametrize('parallel', [True, 0, 2, False])
+@pytest.mark.parametrize('parallel', [True, 2, False])
 @pytest.mark.parametrize('block_size', [[10, 10], [500, 500], [500, 100], None])
 def test_blocked_against_single(parallel, block_size):
 

--- a/reproject/utils.py
+++ b/reproject/utils.py
@@ -1,9 +1,13 @@
+from concurrent import futures
+import numpy as np
 import astropy.nddata
 import numpy as np
 from astropy.io import fits
 from astropy.io.fits import CompImageHDU, HDUList, Header, ImageHDU, PrimaryHDU
 from astropy.wcs import WCS
 from astropy.wcs.wcsapi import BaseHighLevelWCS
+from astropy.wcs.wcsapi import SlicedLowLevelWCS
+from astropy.wcs.wcsapi.high_level_wcs_wrapper import HighLevelWCSWrapper
 
 __all__ = ['parse_input_data', 'parse_input_shape', 'parse_input_weights',
            'parse_output_projection']
@@ -133,3 +137,103 @@ def parse_output_projection(output_projection, shape_out=None, output_array=None
         raise ValueError("The shape of the output image should not be an "
                          "empty tuple")
     return wcs_out, shape_out
+
+
+def _block(reproject_func, array_in, wcs_in, wcs_out_sub, shape_out, i_range, j_range,
+           return_footprint):
+    # i and j range must be passed through for multiprocessing to know where to reinsert patches
+    result = reproject_func(array_in, wcs_in, wcs_out_sub,
+                            shape_out=shape_out, return_footprint=return_footprint)
+
+    res_arr = None
+    res_fp = None
+
+    if return_footprint:
+        res_arr, res_fp = result
+    else:
+        res_arr = result
+
+    return {'i': i_range, 'j': j_range, 'res_arr': res_arr, 'res_fp': res_fp}
+
+
+def reproject_blocked(reproject_func, array_in, wcs_in, shape_out, wcs_out, block_size,
+                      output_array=None,
+                      return_footprint=True, output_footprint=None, parallel=True):
+    if output_array is None:
+        output_array = np.zeros(shape_out, dtype=float)
+    if output_footprint is None and return_footprint:
+        output_footprint = np.zeros(shape_out, dtype=float)
+
+    # setup variables needed for multiprocessing if required
+    proc_pool = None
+    blocks_futures = []
+
+    if parallel or type(parallel) is int:
+        if type(parallel) is int and parallel > 0:
+            proc_pool = futures.ProcessPoolExecutor(max_workers=parallel)
+        else:
+            proc_pool = futures.ProcessPoolExecutor()
+
+    sequential_blocks_done = 0
+    for imin in range(0, output_array.shape[0], block_size[0]):
+        imax = min(imin + block_size[0], output_array.shape[0])
+        for jmin in range(0, output_array.shape[1], block_size[1]):
+            jmax = min(jmin + block_size[1], output_array.shape[1])
+            shape_out_sub = (imax - imin, jmax - jmin)
+            # if the output has more than two dims, just append them on the end of the
+            # shape to it still matches the base WCS
+            for dim in range(2, len(output_array.shape)):
+                shape_out_sub = shape_out_sub + (output_array.shape[dim],)
+
+            slices = [slice(imin, imax), slice(jmin, jmax)]
+            wcs_out_sub = HighLevelWCSWrapper(SlicedLowLevelWCS(wcs_out, slices=slices))
+
+            if proc_pool is None:
+                # if sequential input data and reinsert block into main array immediately
+                completed_block = _block(reproject_func=reproject_func, array_in=array_in,
+                                         wcs_in=wcs_in,
+                                         wcs_out_sub=wcs_out_sub, shape_out=shape_out_sub,
+                                         return_footprint=return_footprint,
+                                         j_range=(jmin, jmax), i_range=(imin, imax))
+
+                output_array[imin:imax, jmin:jmax] = completed_block['res_arr'][:]
+                if return_footprint:
+                    output_footprint[imin:imax, jmin:jmax] = completed_block['res_fp'][:]
+
+                sequential_blocks_done += 1
+            else:
+                # if parallel just submit all work items and move on to waiting for them to be done
+                future = proc_pool.submit(_block, reproject_func=reproject_func, array_in=array_in,
+                                          wcs_in=wcs_in, wcs_out_sub=wcs_out_sub,
+                                          shape_out=shape_out_sub,
+                                          return_footprint=return_footprint, j_range=(jmin, jmax),
+                                          i_range=(imin, imax))
+                blocks_futures.append(future)
+
+    # If a parallel implementation is being used that means the
+    # blocks have not been reassembled yet and must be done now
+    if proc_pool is not None:
+        completed_future_count = 0
+        for completed_future in futures.as_completed(blocks_futures):
+            completed_block = completed_future.result()
+            i_range = completed_block['i']
+            j_range = completed_block['j']
+            output_array[i_range[0]:i_range[1], j_range[0]:j_range[1]] \
+                = completed_block['res_arr'][:]
+
+            if return_footprint:
+                footprint_block = completed_block['res_fp'][:]
+                output_footprint[i_range[0]:i_range[1], j_range[0]:j_range[1]] = footprint_block
+
+            completed_future_count += 1
+            idx = blocks_futures.index(completed_future)
+            # ensure memory used by returned data is freed
+            completed_future._result = None
+            del blocks_futures[idx], completed_future
+        proc_pool.shutdown()
+        del blocks_futures
+
+    if return_footprint:
+        return output_array, output_footprint
+    else:
+        return output_array


### PR DESCRIPTION
Performing reprojection of any non-healpix type by breaking up the out space into blocks and iterating over each block to perform reprojection into that specific block of area. This means a large output space can be used whilst only having to load one block into memory at a time. 

Additionally these output blocks can be processed in parallel to achieve a speed up of any function. 

As mentioned there is still some debug code in there which needs to be cleaned up (commented print statement, imports used for profiling), but the functionality is there.