### PR TITLE
Fix test failure when h5py and matplotlib are not installed

### DIFF
--- a/reproject/conftest.py
+++ b/reproject/conftest.py
@@ -10,13 +10,14 @@ os.environ['MPLBACKEND'] = 'Agg'
 
 # from astropy.tests.helper import enable_deprecations_as_exceptions
 # enable_deprecations_as_exceptions()
-
-PYTEST_HEADER_MODULES['Astropy'] = 'astropy'
-PYTEST_HEADER_MODULES['astropy-healpix'] = 'astropy_healpix'
-PYTEST_HEADER_MODULES['Cython'] = 'cython'
-del PYTEST_HEADER_MODULES['h5py']
-del PYTEST_HEADER_MODULES['Matplotlib']
-
+try:
+    PYTEST_HEADER_MODULES['Astropy'] = 'astropy'  # noqa
+    PYTEST_HEADER_MODULES['astropy-healpix'] = 'astropy_healpix'
+    PYTEST_HEADER_MODULES['Cython'] = 'cython'
+    del PYTEST_HEADER_MODULES['h5py']
+    del PYTEST_HEADER_MODULES['Matplotlib']
+except KeyError:
+    pass
 
 packagename = os.path.basename(os.path.dirname(__file__))
 TESTED_VERSIONS[packagename] = version


### PR DESCRIPTION
`h5py` and `matplotlib` are optional dependencies of `astropy`. When these are not installed, `reproject` tests fail with the following error:

```
reproject/conftest.py:15: in <module>
    del PYTEST_HEADER_MODULES['h5py']
E   KeyError: 'h5py'
```

This PR fixes the tests.