### PR TITLE
Save memory by re-using variable

### DIFF
--- a/reproject/wcs_utils.py
+++ b/reproject/wcs_utils.py
@@ -188,10 +188,10 @@ def efficient_pixel_to_pixel(wcs1, wcs2, *inputs):
 
         pixel_inputs = np.broadcast_arrays(*pixel_inputs)
 
-        world_outputs = wcs1.pixel_to_world(*pixel_inputs)
-        if not isinstance(world_outputs, (tuple, list)):
-            world_outputs = (world_outputs,)
-        pixel_outputs = wcs2.world_to_pixel(*world_outputs)
+        pixel_outputs = wcs1.pixel_to_world(*pixel_inputs)
+        if not isinstance(pixel_outputs, (tuple, list)):
+            pixel_outputs = (pixel_outputs,)
+        pixel_outputs = wcs2.world_to_pixel(*pixel_outputs)
 
         for ipix in range(wcs2.pixel_n_dim):
             if ipix in pixel_out_indices:


### PR DESCRIPTION
I'm currently running into memory issues running reproject on lots of data, so trying to see if memory usage can be reduced. Re-using a variable here saves a small but significant amount of memory. Using the example in the docs, I get

Before:
```python
   191  185.750 MiB   52.109 MiB           world_outputs = wcs1.pixel_to_world(*pixel_inputs)
   192  185.750 MiB    0.000 MiB           if not isinstance(world_outputs, (tuple, list)):
   193  185.750 MiB    0.000 MiB               world_outputs = (world_outputs,)
   194  197.637 MiB   48.848 MiB           pixel_outputs = wcs2.world_to_pixel(*world_outputs)
```

After:
```python
   191  185.730 MiB   52.117 MiB           pixel_outputs = wcs1.pixel_to_world(*pixel_inputs)
   192  185.730 MiB    0.000 MiB           if not isinstance(pixel_outputs, (tuple, list)):
   193  185.730 MiB    0.000 MiB               pixel_outputs = (pixel_outputs,)
   194  179.793 MiB   30.977 MiB           pixel_outputs = wcs2.world_to_pixel(*pixel_outputs)
```