### PR TITLE
MNT: Set max-line-length for flake8

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -76,3 +76,6 @@ balanced_wrapping = True
 include_trailing_comma = False
 length_sort = False
 length_sort_stdlib = True
+
+[flake8]
+max-line-length = 100


### PR DESCRIPTION
This is an automated update made by the `batchpr` tool :robot: - feel free to close if it doesn't look good! You can report issues to @pllim.