### PR TITLE
MNT: Ignore import error in pytest collection

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -53,7 +53,7 @@ norecursedirs = build docs/_build
 astropy_header = true
 doctest_plus = enabled
 text_file_format = rst
-addopts = --doctest-rst --arraydiff --arraydiff-default-format=fits
+addopts = --doctest-rst --arraydiff --arraydiff-default-format=fits --doctest-ignore-import-errors
 
 [coverage:run]
 omit =


### PR DESCRIPTION
This is an automated update made by the `batchpr` tool :robot: to future-proof test collection behavior `pytest-doctestplus` - feel free to close if it doesn't look good or isn't relevant! You can report issues to @pllim.