### PR TITLE
Allow WCS merging to work without loading all data at once

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,12 @@
+0.8 (unreleased)
+----------------
+
+- Improve ``find_optimal_celestial_wcs`` to accept input data descriptions as
+  just array shapes, not necessarily fully populated arrays. This makes it
+  possible to solve for the optimal WCS for a set of images that couldn't fit
+  into memory all at once, since the actual data aren't needed for optimal WCS
+  determination. [#242]
+
 0.7.1 (2020-05-29)
 ------------------
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,7 +22,7 @@ jobs:
 
 - template: run-tox-env.yml@OpenAstronomy
   parameters:
-
+    default_python: '3.8'
     coverage: codecov
 
     libraries:

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -34,6 +34,10 @@ and to run the tests, you will also need:
 
 * `pytest-arraydiff <https://github.com/astrofrog/pytest-fits>`__
 
+* `pytest-astropy <https://github.com/astropy/pytest-astropy>`__
+
+* `pytest-doctestplus <https://github.com/astropy/pytest-doctestplus>`__
+
 
 Installation
 ============

--- a/docs/mosaicking.rst
+++ b/docs/mosaicking.rst
@@ -261,8 +261,8 @@ We can take a look at the output:
     pos = SkyCoord.from_name('M17')
     table = imagesearch('https://irsa.ipac.caltech.edu/cgi-bin/2MASS/IM/nph-im_sia?type=at&ds=asky&',
                        pos, size=0.25).to_table()
-    table = table[(table['band'] == b'K') & (table['format'] == b'image/fits')]
-    m17_hdus = [fits.open(row['download'].decode('ascii'))[0] for row in table]
+    table = table[(table['band'] == 'K') & (table['format'] == 'image/fits')]
+    m17_hdus = [fits.open(row['download'])[0] for row in table]
 
     from astropy.coordinates import SkyCoord
     from reproject.mosaicking import find_optimal_celestial_wcs

--- a/reproject/mosaicking/tests/test_wcs_helpers.py
+++ b/reproject/mosaicking/tests/test_wcs_helpers.py
@@ -165,7 +165,7 @@ class TestOptimalWCS():
 
         with pytest.raises(ValueError) as exc:
             wcs, shape = find_optimal_celestial_wcs([(array, self.wcs)])
-        assert exc.value.args[0] == 'Input data is not 2-dimensional'
+        assert exc.value.args[0] == 'Input data is not 2-dimensional (got shape (30, 20, 10))'
 
     def test_invalid_wcs_shape(self):
 

--- a/reproject/mosaicking/tests/test_wcs_helpers.py
+++ b/reproject/mosaicking/tests/test_wcs_helpers.py
@@ -46,6 +46,13 @@ class TestOptimalWCS():
         assert_allclose(wcs.wcs.crpix, (10, 15))
         assert shape == (30, 40)
 
+    def test_args_tuple_wcs(self):
+        wcs, shape = find_optimal_celestial_wcs([(self.array.shape, self.wcs)], frame=FK5())
+
+    def test_args_tuple_header(self):
+        wcs, shape = find_optimal_celestial_wcs([(self.array.shape, self.wcs.to_header())],
+                                                frame=FK5())
+
     def test_frame_projection(self):
 
         wcs, shape = find_optimal_celestial_wcs([(self.array, self.wcs)], frame=Galactic(),

--- a/reproject/mosaicking/wcs_helpers.py
+++ b/reproject/mosaicking/wcs_helpers.py
@@ -11,7 +11,7 @@ from ..utils import parse_input_shape
 __all__ = ['find_optimal_celestial_wcs']
 
 
-def find_optimal_celestial_wcs(input_shapes, frame=None, auto_rotate=False,
+def find_optimal_celestial_wcs(input_data, frame=None, auto_rotate=False,
                                projection='TAN', resolution=None,
                                reference=None):
     """
@@ -22,7 +22,7 @@ def find_optimal_celestial_wcs(input_shapes, frame=None, auto_rotate=False,
 
     Parameters
     ----------
-    input_shapes : iterable
+    input_data : iterable
         One or more input data specifications to include in the calculation of
         the final WCS. This should be an iterable containing one entry for each
         specification, where a single data specification is one of:
@@ -69,7 +69,7 @@ def find_optimal_celestial_wcs(input_shapes, frame=None, auto_rotate=False,
     if isinstance(frame, str):
         frame = frame_transform_graph.lookup_name(frame)()
 
-    input_shapes = [parse_input_shape(shape) for shape in input_shapes]
+    input_shapes = [parse_input_shape(shape) for shape in input_data]
 
     # We start off by looping over images, checking that they are indeed
     # celestial images, and building up a list of all corners and all reference

--- a/reproject/utils.py
+++ b/reproject/utils.py
@@ -67,7 +67,7 @@ def parse_input_shape(input_shape, hdu_in=None):
         else:
             return input_shape
     elif isinstance(input_shape, astropy.nddata.NDDataBase):
-        return input_shape.shape, input_shape.wcs
+        return input_shape.data.shape, input_shape.wcs
     else:
         raise TypeError("input_shape should either be an HDU object or a tuple "
                         "of (array-or-shape, WCS) or (array-or-shape, Header)")

--- a/reproject/utils.py
+++ b/reproject/utils.py
@@ -6,7 +6,7 @@ from astropy.io.fits import CompImageHDU, HDUList, Header, ImageHDU, PrimaryHDU
 from astropy.wcs import WCS
 from astropy.wcs.wcsapi import BaseHighLevelWCS
 
-__all__ = ['parse_input_data', 'parse_input_weights', 'parse_output_projection']
+__all__ = ['parse_input_data', 'parse_input_shape', 'parse_input_weights', 'parse_output_projection']
 
 
 def parse_input_data(input_data, hdu_in=None):
@@ -36,6 +36,40 @@ def parse_input_data(input_data, hdu_in=None):
     else:
         raise TypeError("input_data should either be an HDU object or a tuple "
                         "of (array, WCS) or (array, Header)")
+
+
+def parse_input_shape(input_shape, hdu_in=None):
+    """
+    Parse input shape information to return an array shape tuple and WCS object.
+    """
+
+    if isinstance(input_shape, str):
+        return parse_input_shape(fits.open(input_shape), hdu_in=hdu_in)
+    elif isinstance(input_shape, HDUList):
+        if hdu_in is None:
+            if len(input_shape) > 1:
+                raise ValueError("More than one HDU is present, please specify "
+                                 "HDU to use with ``hdu_in=`` option")
+            else:
+                hdu_in = 0
+        return parse_input_shape(input_shape[hdu_in])
+    elif isinstance(input_shape, (PrimaryHDU, ImageHDU, CompImageHDU)):
+        return input_shape.shape, WCS(input_shape.header)
+    elif isinstance(input_shape, tuple) and isinstance(input_shape[0], np.ndarray):
+        if isinstance(input_shape[1], Header):
+            return input_shape[0].shape, WCS(input_shape[1])
+        else:
+            return input_shape[0].shape, input_shape[1]
+    elif isinstance(input_shape, tuple) and isinstance(input_shape[0], tuple):
+        if isinstance(input_shape[1], Header):
+            return input_shape[0], WCS(input_shape[1])
+        else:
+            return input_shape
+    elif isinstance(input_shape, astropy.nddata.NDDataBase):
+        return input_shape.shape, input_shape.wcs
+    else:
+        raise TypeError("input_shape should either be an HDU object or a tuple "
+                        "of (array-or-shape, WCS) or (array-or-shape, Header)")
 
 
 def parse_input_weights(input_weights, hdu_weights=None):

--- a/reproject/utils.py
+++ b/reproject/utils.py
@@ -6,7 +6,8 @@ from astropy.io.fits import CompImageHDU, HDUList, Header, ImageHDU, PrimaryHDU
 from astropy.wcs import WCS
 from astropy.wcs.wcsapi import BaseHighLevelWCS
 
-__all__ = ['parse_input_data', 'parse_input_shape', 'parse_input_weights', 'parse_output_projection']
+__all__ = ['parse_input_data', 'parse_input_shape', 'parse_input_weights',
+           'parse_output_projection']
 
 
 def parse_input_data(input_data, hdu_in=None):

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ test =
     pytest-astropy
     pytest-arraydiff
     pytest-cov
+    pytest-doctestplus
 testall =
     shapely;sys_platform!='win32' and python_version!='3.8'
     sunpy;platform_machine!='i686'


### PR DESCRIPTION
For `find_optimal_celestial_wcs`, we only really need the input image shape, not the actual data. Modify the support infrastructure to allow computation in this regime. This allows us to solve for the optimal WCS even in cases where we wouldn't be able to hold all of the input images in memory at the same time.