### PR TITLE
MNT: Stop using distutils

### DIFF
--- a/reproject/spherical_intersect/setup_package.py
+++ b/reproject/spherical_intersect/setup_package.py
@@ -1,5 +1,5 @@
 import os
-from distutils.core import Extension
+from setuptools import Extension
 import numpy as np
 
 REPROJECT_ROOT = os.path.relpath(os.path.dirname(__file__))


### PR DESCRIPTION
`distutils` is deprecated.

This package does not seem to be affected by astropy/astropy#12633.