### PR TITLE
Add boundary handling options for adaptive resampling

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,18 @@
 
 - Drop support for Python 3.7.
 - Infrastructure and packaging updates.
+- Made many improvements, bug fixes, and significant speed-ups for the adaptive
+  resampling algorithm, ``reproject_adaptive``. These bug fixes may cause
+  changes to the reprojected images, which are typically negligible.
+  Improvements include the addition of a flux-conserving mode, support for a
+  Gaussian filter kernel, a menu of boundary-handling modes, and a
+  ``center_jacobian`` flag to trade speed for accuracy with rapidly-varying
+  transformations.
+- Added a ``roundtrip_coords`` argument to ``reproject_adaptive`` and
+  ``reproject_interp``. By default, all coordinate transformations are run in
+  both directions to handle some situations where they are ambiguous. This can
+  be disabled by setting ``roundtrip_coords=False`` which may offer a
+  significant speed increase.
 
 0.8 (2021-08-11)
 ----------------

--- a/docs/celestial.rst
+++ b/docs/celestial.rst
@@ -243,6 +243,37 @@ points. This is more efficient, and the loss of accuracy is extremely small for
 transformations that vary smoothly between pixels. The default (``False``) is
 to use the faster option.
 
+When, for any one output pixel, the sampling region in the input image
+straddles the boundary of the input image or lies entirely outside the input
+image, a range of boundary modes can be applied, and this is set with the
+``boundary_mode`` option. Allowed values are:
+
+* ``strict`` --- Output pixels will be ``NaN`` if any of their input samples
+  fall outside the input image.
+* ``constant`` --- Samples outside the bounds of the input image are
+  replaced by a constant value, set with the ``boundary_fill_value`` argument.
+  Output values become ``NaN`` if there are no valid input samples.
+* ``grid-constant`` --- Samples outside the bounds of the input image are
+  replaced by a constant value, set with the ``boundary_fill_value`` argument.
+  Output values will be ``boundary_fill_value`` if there are no valid input
+  samples.
+* ``ignore`` --- Samples outside the input image are simply ignored,
+  contributing neither to the output value nor the sum-of-weights
+  normalization. If there are no valid input samples, the output value will be
+  ``NaN``.
+* ``ignore_threshold`` --- Acts as ``ignore``, unless the total weight that
+  would have been assigned to the ignored samples exceeds a set fraction of the
+  total weight across the entire sampling region, set by the
+  ``boundary_ignore_threshold`` argument. In that case, acts as ``strict``.
+* ``nearest`` --- Samples outside the input image are replaced by the nearst
+  in-bounds input pixel.
+
+The input image can also be marked as being cyclic or periodic in the x and/or
+y axes with the ``x_cyclic`` and ``y_cyclic`` flags. If these are set, samples
+will wrap around to the opposite side of the image, ignoring the
+``boundary_mode`` for that axis.
+
+
 Algorithm Description
 ---------------------
 

--- a/reproject/adaptive/core.py
+++ b/reproject/adaptive/core.py
@@ -35,7 +35,10 @@ def _reproject_adaptive_2d(array, wcs_in, wcs_out, shape_out,
                            return_footprint=True, center_jacobian=False,
                            roundtrip_coords=True, conserve_flux=False,
                            kernel='Hann', kernel_width=1.3,
-                           sample_region_width=4):
+                           sample_region_width=4,
+                           boundary_mode='ignore', boundary_fill_value=0,
+                           boundary_ignore_threshold=0.5,
+                           x_cyclic=False, y_cyclic=False):
     """
     Reproject celestial slices from an n-d array from one WCS to another
     using the DeForest (2004) algorithm [1]_, and assuming all other dimensions
@@ -67,6 +70,14 @@ def _reproject_adaptive_2d(array, wcs_in, wcs_out, shape_out,
     sample_region_width : double
         The width in pixels of the sample region, used only for the Gaussian
         kernel which otherwise has infinite extent.
+    boundary_mode : str
+        Boundary handling mode
+    boundary_fill_value : double
+        Fill value for 'constant' boundary mode
+    boundary_ignore_threshold : double
+        Threshold for 'ignore_threshold' boundary mode, ranging from 0 to 1.
+    x_cyclic, y_cyclic : bool
+        Marks in input-image axis as cyclic.
 
     Returns
     -------
@@ -107,7 +118,11 @@ def _reproject_adaptive_2d(array, wcs_in, wcs_out, shape_out,
     map_coordinates(array_in, array_out, transformer, out_of_range_nan=True,
                     center_jacobian=center_jacobian, conserve_flux=conserve_flux,
                     kernel=kernel, kernel_width=kernel_width,
-                    sample_region_width=sample_region_width)
+                    sample_region_width=sample_region_width,
+                    boundary_mode=boundary_mode,
+                    boundary_fill_value=boundary_fill_value,
+                    boundary_ignore_threshold=boundary_ignore_threshold,
+                    x_cyclic=x_cyclic, y_cyclic=y_cyclic)
 
     if return_footprint:
         return array_out, (~np.isnan(array_out)).astype(float)

--- a/reproject/adaptive/high_level.py
+++ b/reproject/adaptive/high_level.py
@@ -12,7 +12,10 @@ def reproject_adaptive(input_data, output_projection, shape_out=None, hdu_in=0,
                        order=None,
                        return_footprint=True, center_jacobian=False,
                        roundtrip_coords=True, conserve_flux=False,
-                       kernel='Hann', kernel_width=1.3, sample_region_width=4):
+                       kernel='Hann', kernel_width=1.3, sample_region_width=4,
+                       boundary_mode='ignore', boundary_fill_value=0,
+                       boundary_ignore_threshold=0.5, x_cyclic=False,
+                       y_cyclic=False):
     """
     Reproject a 2D array from one WCS to another using the DeForest (2004)
     adaptive, anti-aliased resampling algorithm, with optional flux
@@ -94,6 +97,40 @@ def reproject_adaptive(input_data, output_projection, shape_out=None, hdu_in=0,
         with the default kernel width, should limit the most extreme errors to
         less than one percent. Higher values will offer even more photometric
         accuracy.
+    boundary_mode : str
+        How to handle when the sampling region includes regions outside the
+        bounds of the input image. Allowed values are:
+
+            * ``strict`` --- Output pixels will be NaN if any input sample
+              falls outside the input image.
+            * ``constant`` --- Samples outside the input image are replaced by
+              a constant value, set with the ``boundary_fill_value`` argument.
+              Output values become NaN if there are no valid input samples.
+            * ``grid-constant`` --- Samples outside the input image are
+              replaced by a constant value, set with the
+              ``boundary_fill_value`` argument. Output values will be
+              ``boundary_fill_value`` if there are no valid input samples.
+            * ``ignore`` --- Samples outside the input image are simply
+              ignored, contributing neither to the output value nor the
+              sum-of-weights normalization.
+            * ``ignore_threshold`` --- Acts as ``ignore``, unless the total
+              weight of the ignored samples exceeds a set fraction of the total
+              weight across the entire sampling region, set by the
+              ``boundary_ignore_threshold`` argument. In that case, acts as
+              ``strict``.
+            * ``nearest`` --- Samples outside the input image are replaced by
+              the nearst in-bounds input pixel.
+
+    boundary_fill_value : double
+        The constant value used by the ``constant`` boundary mode.
+    boundary_ignore_threshold : double
+        The threshold used by the ``ignore_threshold`` boundary mode. Should be
+        a value between 0 and 1, representing a fraction of the total weight
+        across the sampling region.
+    x_cyclic, y_cyclic : bool
+        Indicates that the x or y axis of the input image should be treated as
+        cyclic or periodic. Overrides the boundary mode for that axis, so that
+        out-of-bounds samples wrap to the other side of the image.
 
     Returns
     -------
@@ -116,4 +153,8 @@ def reproject_adaptive(input_data, output_projection, shape_out=None, hdu_in=0,
                                   roundtrip_coords=roundtrip_coords,
                                   conserve_flux=conserve_flux,
                                   kernel=kernel, kernel_width=kernel_width,
-                                  sample_region_width=sample_region_width)
+                                  sample_region_width=sample_region_width,
+                                  boundary_mode=boundary_mode,
+                                  boundary_fill_value=boundary_fill_value,
+                                  boundary_ignore_threshold=boundary_ignore_threshold,
+                                  x_cyclic=x_cyclic, y_cyclic=y_cyclic)


### PR DESCRIPTION
I lied, here's a fourth PR, applying on top of #276. The two commits belong to this PR are "Add boundary handling..." and "Set default boundary mode...".

This adds a few different boundary-handling modes, to adjust how the adaptive resampling algorithm handles the case when the sampling window straddles or lies outside of the boundary of the input image---that is, when some of the input pixels that should be sampled for a given output pixel do not exist. The existing behavior was to simply ignore those out-of-bounds samples and base the output pixel value on the remaining in-bounds samples (or set the output to NaN if there are no in-bounds samples), and that can give rise to some strong edge effects, depending on the input image. The old behavior can be had with the "ignore" mode in this PR. ~~I've set the default to be the "strict" mode, which sets output pixels to NaN if any of the input pixels to be sampled do not exist. That's a change in default behavior, but it seems like the most conservative choice and so the best default.~~ (EDIT: this defaults change has been moved to #293.) There are also "nearest", "constant", "grid-constant", and "ignore_threshold" modes, for which I'll refer to the added documentation.

The existing `deforest.pyx` had some support for treating the x or y axes of the input image as cyclic, which I'd been sort of ignoring but trying not to break in the previous PRs. I've tested that functionality and exposed it in the public API as well. There are separate flags for the two axes, and the boundary mode then applies to any non-cyclic axes.

One could imagine someday adding a similar choice of boundary modes to the interpolating and exact algorithms, though I haven't attempted to do so. The interpolating algorithm wraps `scipy.ndimage.map_coordinates` which does offer a menu of boundary modes, and so in case those are ever exposed for the interpolating algorithm, I've matched the names of my boundary modes to its menu when it implements a similar mode. (Though it seems to have cyclic axes as an all-or-nothing choice, whereas I've maintained the per-axis choice via separate flags.)