### PR TITLE
TST: Ignore asdf warnings in reproject tests

### DIFF
--- a/reproject/adaptive/tests/test_core.py
+++ b/reproject/adaptive/tests/test_core.py
@@ -164,7 +164,7 @@ def test_reproject_adaptive_high_aliasing_potential():
     np.testing.assert_allclose(array_out, data_ref)
 
 
-@pytest.mark.filterwarnings('ignore:asdf.* failed to load')
+@pytest.mark.filterwarnings('ignore')
 @pytest.mark.array_compare(single_reference=True)
 @pytest.mark.parametrize('file_format', ['fits', 'asdf'])
 def test_reproject_adaptive_roundtrip(file_format):

--- a/reproject/interpolation/tests/test_core.py
+++ b/reproject/interpolation/tests/test_core.py
@@ -449,7 +449,7 @@ def test_reproject_with_output_array():
     assert out_full is returned_array
 
 
-@pytest.mark.filterwarnings('ignore:asdf.* failed to load')
+@pytest.mark.filterwarnings('ignore')
 @pytest.mark.array_compare(single_reference=True)
 @pytest.mark.parametrize('file_format', ['fits', 'asdf'])
 def test_reproject_roundtrip(file_format):


### PR DESCRIPTION
~Remove asdf from~ Ignore asdf warnings in reproject tests until Sunpy can fix their stuff.

Also see:

* #270
* #281
* sunpy/sunpy#6026