### PR TITLE
Changed default filter kernel and boundary mode in ``reproject_adaptive``, and removed ``order`` argument.

### DIFF
--- a/docs/celestial.rst
+++ b/docs/celestial.rst
@@ -205,14 +205,14 @@ kernel---see below.)
 
 The kernel used for interpolation and averaging can be controlled with a set of
 options. The ``kernel`` argument can be set to 'hann' or 'gaussian' to set the
-function being used. The Hann window is the default, and the Gaussian window
-improves anti-aliasing and photometric accuracy (or flux conservation, when the
-flux-conserving mode is enabled) at the cost of blurring the output image by a
-few pixels. The ``kernel_width`` argument sets the width of the Gaussian
-kernel, in pixels, and is ignored for the Hann window. This width is measured
-between the Gaussian's :math:`\pm 1 \sigma` points. The default value is 1.3
-for the Gaussian, chosen to minimize blurring without compromising accuracy.
-Lower values may introduce photometric errors or leave input pixels
+function being used. The Gaussian window is the default, as it provides better
+anti-aliasing and photometric accuracy (or flux conservation, when the
+flux-conserving mode is enabled), though at the cost of blurring the output
+image by a few pixels. The ``kernel_width`` argument sets the width of the
+Gaussian kernel, in pixels, and is ignored for the Hann window. This width is
+measured between the Gaussian's :math:`\pm 1 \sigma` points. The default value
+is 1.3 for the Gaussian, chosen to minimize blurring without compromising
+accuracy. Lower values may introduce photometric errors or leave input pixels
 under-sampled, while larger values may improve anti-aliasing behavior but will
 increase blurring of the output image. Since the Gaussian function has infinite
 extent, it must be truncated. This is done by sampling within a region of

--- a/reproject/adaptive/core.py
+++ b/reproject/adaptive/core.py
@@ -32,7 +32,7 @@ def _reproject_adaptive_2d(array, wcs_in, wcs_out, shape_out,
                            roundtrip_coords=True, conserve_flux=False,
                            kernel='Gaussian', kernel_width=1.3,
                            sample_region_width=4,
-                           boundary_mode='ignore', boundary_fill_value=0,
+                           boundary_mode='strict', boundary_fill_value=0,
                            boundary_ignore_threshold=0.5,
                            x_cyclic=False, y_cyclic=False):
     """

--- a/reproject/adaptive/core.py
+++ b/reproject/adaptive/core.py
@@ -30,7 +30,7 @@ class CoordinateTransformer:
 def _reproject_adaptive_2d(array, wcs_in, wcs_out, shape_out,
                            return_footprint=True, center_jacobian=False,
                            roundtrip_coords=True, conserve_flux=False,
-                           kernel='Hann', kernel_width=1.3,
+                           kernel='Gaussian', kernel_width=1.3,
                            sample_region_width=4,
                            boundary_mode='ignore', boundary_fill_value=0,
                            boundary_ignore_threshold=0.5,
@@ -112,7 +112,8 @@ def _reproject_adaptive_2d(array, wcs_in, wcs_out, shape_out,
 
     transformer = CoordinateTransformer(wcs_in, wcs_out, roundtrip_coords)
     map_coordinates(array_in, array_out, transformer, out_of_range_nan=True,
-                    center_jacobian=center_jacobian, conserve_flux=conserve_flux,
+                    center_jacobian=center_jacobian,
+                    conserve_flux=conserve_flux,
                     kernel=kernel, kernel_width=kernel_width,
                     sample_region_width=sample_region_width,
                     boundary_mode=boundary_mode,

--- a/reproject/adaptive/deforest.pyx
+++ b/reproject/adaptive/deforest.pyx
@@ -189,7 +189,7 @@ def map_coordinates(double[:,:] source, double[:,:] target, Ci, int max_samples_
                     int conserve_flux=False, int progress=False, int singularities_nan=False,
                     int x_cyclic=False, int y_cyclic=False, int out_of_range_nan=False,
                     bint center_jacobian=False, str kernel='gaussian', double kernel_width=1.3,
-                    double sample_region_width=4, str boundary_mode="ignore",
+                    double sample_region_width=4, str boundary_mode="strict",
                     double boundary_fill_value=0, double boundary_ignore_threshold=0.5):
     cdef int kernel_flag
     try:

--- a/reproject/adaptive/deforest.pyx
+++ b/reproject/adaptive/deforest.pyx
@@ -188,7 +188,7 @@ BOUNDARY_MODES['nearest'] = 6
 def map_coordinates(double[:,:] source, double[:,:] target, Ci, int max_samples_width=-1,
                     int conserve_flux=False, int progress=False, int singularities_nan=False,
                     int x_cyclic=False, int y_cyclic=False, int out_of_range_nan=False,
-                    bint center_jacobian=False, str kernel='Hann', double kernel_width=1.3,
+                    bint center_jacobian=False, str kernel='gaussian', double kernel_width=1.3,
                     double sample_region_width=4, str boundary_mode="ignore",
                     double boundary_fill_value=0, double boundary_ignore_threshold=0.5):
     cdef int kernel_flag

--- a/reproject/adaptive/high_level.py
+++ b/reproject/adaptive/high_level.py
@@ -14,7 +14,7 @@ def reproject_adaptive(input_data, output_projection, shape_out=None, hdu_in=0,
                        order=None,
                        return_footprint=True, center_jacobian=False,
                        roundtrip_coords=True, conserve_flux=False,
-                       kernel=None, kernel_width=1.3,
+                       kernel='gaussian', kernel_width=1.3,
                        sample_region_width=4,
                        boundary_mode=None, boundary_fill_value=0,
                        boundary_ignore_threshold=0.5, x_cyclic=False,
@@ -147,14 +147,6 @@ def reproject_adaptive(input_data, output_projection, shape_out=None, hdu_in=0,
         no coverage or valid values in the input image, while values of 1
         indicate valid values.
     """
-
-    if kernel is None:
-        kernel = 'hann'
-        warnings.warn(
-                "The default kernel will change from 'Hann' to "
-                " 'Gaussian' in a future release. To suppress this warning, "
-                "explicitly select a kernel with the 'kernel' argument.",
-                FutureWarning, stacklevel=3)
 
     if boundary_mode is None:
         boundary_mode = 'ignore'

--- a/reproject/adaptive/high_level.py
+++ b/reproject/adaptive/high_level.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-import warnings
 
 import astropy.utils
 
@@ -16,7 +15,7 @@ def reproject_adaptive(input_data, output_projection, shape_out=None, hdu_in=0,
                        roundtrip_coords=True, conserve_flux=False,
                        kernel='gaussian', kernel_width=1.3,
                        sample_region_width=4,
-                       boundary_mode=None, boundary_fill_value=0,
+                       boundary_mode='strict', boundary_fill_value=0,
                        boundary_ignore_threshold=0.5, x_cyclic=False,
                        y_cyclic=False):
     """
@@ -147,14 +146,6 @@ def reproject_adaptive(input_data, output_projection, shape_out=None, hdu_in=0,
         no coverage or valid values in the input image, while values of 1
         indicate valid values.
     """
-
-    if boundary_mode is None:
-        boundary_mode = 'ignore'
-        warnings.warn(
-                "The default boundary mode will change from 'ignore' to "
-                " 'strict' in a future release. To suppress this warning, "
-                "explicitly select a mode with the 'boundary_mode' argument.",
-                FutureWarning, stacklevel=3)
 
     # TODO: add support for output_array
 

--- a/reproject/adaptive/high_level.py
+++ b/reproject/adaptive/high_level.py
@@ -1,16 +1,12 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-import astropy.utils
-
 from ..utils import parse_input_data, parse_output_projection
 from .core import _reproject_adaptive_2d
 
 __all__ = ['reproject_adaptive']
 
 
-@astropy.utils.deprecated_renamed_argument('order', None, since=0.9)
 def reproject_adaptive(input_data, output_projection, shape_out=None, hdu_in=0,
-                       order=None,
                        return_footprint=True, center_jacobian=False,
                        roundtrip_coords=True, conserve_flux=False,
                        kernel='gaussian', kernel_width=1.3,
@@ -50,9 +46,6 @@ def reproject_adaptive(input_data, output_projection, shape_out=None, hdu_in=0,
     hdu_in : int or str, optional
         If ``input_data`` is a FITS file or an `~astropy.io.fits.HDUList`
         instance, specifies the HDU to use.
-    order : str
-        Deprecated, and no longer has any effect. Will be removed in a future
-        release.
     return_footprint : bool
         Whether to return the footprint in addition to the output array.
     center_jacobian : bool

--- a/reproject/adaptive/tests/test_core.py
+++ b/reproject/adaptive/tests/test_core.py
@@ -53,7 +53,7 @@ def test_reproject_adaptive_2d(wcsapi, center_jacobian, roundtrip_coords):
             (data_in, wcs_in), wcs_out, shape_out=(60, 60),
             center_jacobian=center_jacobian,
             roundtrip_coords=roundtrip_coords,
-            kernel='hann')
+            kernel='hann', boundary_mode='ignore')
 
     # Check that surface brightness is conserved in the unrotated case
     assert_allclose(np.nansum(data_in), np.nansum(array_out) * (256 / 60) ** 2, rtol=0.1)
@@ -96,7 +96,7 @@ def test_reproject_adaptive_2d_rotated(center_jacobian, roundtrip_coords):
             (data_in, wcs_in), wcs_out, shape_out=(60, 60),
             center_jacobian=center_jacobian,
             roundtrip_coords=roundtrip_coords,
-            kernel='hann')
+            kernel='hann', boundary_mode='ignore')
 
     # ASTROPY_LT_40: astropy v4.0 introduced new default header keywords,
     # once we support only astropy 4.0 and later we can update the reference
@@ -294,7 +294,9 @@ def test_reproject_adaptive_flux_conservation():
         # The Gaussian kernel does a better job at flux conservation, so
         # choosing it here allows a tighter tolerance. Increasing the sample
         # region width also allows a tighter tolerance---less room for bugs to
-        # hide!
+        # hide! Setting the boundary mode to 'ignore' avoids excessive clipping
+        # of the edges of our small output image, letting us use a smaller
+        # image and do more tests in the same time.
         array_out = reproject_adaptive((data_in, wcs_in),
                                        wcs_out, shape_out=(30, 30),
                                        return_footprint=False,
@@ -302,7 +304,8 @@ def test_reproject_adaptive_flux_conservation():
                                        center_jacobian=False,
                                        kernel='gaussian',
                                        sample_region_width=5,
-                                       conserve_flux=True)
+                                       conserve_flux=True,
+                                       boundary_mode='ignore')
 
         # The degree of flux-conservation we end up seeing isn't necessarily
         # something that we can constrain a priori, so here we test for

--- a/reproject/adaptive/tests/test_core.py
+++ b/reproject/adaptive/tests/test_core.py
@@ -52,7 +52,8 @@ def test_reproject_adaptive_2d(wcsapi, center_jacobian, roundtrip_coords):
     array_out, footprint_out = reproject_adaptive(
             (data_in, wcs_in), wcs_out, shape_out=(60, 60),
             center_jacobian=center_jacobian,
-            roundtrip_coords=roundtrip_coords)
+            roundtrip_coords=roundtrip_coords,
+            kernel='hann')
 
     # Check that surface brightness is conserved in the unrotated case
     assert_allclose(np.nansum(data_in), np.nansum(array_out) * (256 / 60) ** 2, rtol=0.1)
@@ -94,7 +95,8 @@ def test_reproject_adaptive_2d_rotated(center_jacobian, roundtrip_coords):
     array_out, footprint_out = reproject_adaptive(
             (data_in, wcs_in), wcs_out, shape_out=(60, 60),
             center_jacobian=center_jacobian,
-            roundtrip_coords=roundtrip_coords)
+            roundtrip_coords=roundtrip_coords,
+            kernel='hann')
 
     # ASTROPY_LT_40: astropy v4.0 introduced new default header keywords,
     # once we support only astropy 4.0 and later we can update the reference
@@ -603,7 +605,7 @@ def test_reproject_adaptive_roundtrip(file_format):
     data, wcs, target_wcs = prepare_test_data(file_format)
 
     output, footprint = reproject_adaptive((data, wcs), target_wcs, (128, 128),
-                                           center_jacobian=True)
+                                           center_jacobian=True, kernel='hann')
 
     header_out = target_wcs.to_header()
 
@@ -630,7 +632,7 @@ def test_reproject_adaptive_uncentered_jacobian():
     data, wcs, target_wcs = prepare_test_data('fits')
 
     output, footprint = reproject_adaptive((data, wcs), target_wcs, (128, 128),
-                                           center_jacobian=False)
+                                           center_jacobian=False, kernel='hann')
 
     header_out = target_wcs.to_header()
 

--- a/reproject/tests/test_high_level.py
+++ b/reproject/tests/test_high_level.py
@@ -132,8 +132,10 @@ def test_surface_brightness(projection_type, dtype):
     if projection_type == 'flux-conserving':
         data_out, footprint = reproject_exact((data_in, header_in), header_out)
     elif projection_type.startswith('adaptive'):
-        data_out, footprint = reproject_adaptive((data_in, header_in), header_out,
-                                                 kernel=projection_type.split('-', 1)[1])
+        data_out, footprint = reproject_adaptive(
+                (data_in, header_in), header_out,
+                kernel=projection_type.split('-', 1)[1],
+                boundary_mode='ignore')
     else:
         data_out, footprint = reproject_interp((data_in, header_in), header_out,
                                                order=projection_type)
@@ -174,8 +176,10 @@ def test_identity_projection(projection_type):
     if projection_type == 'flux-conserving':
         data_out, footprint = reproject_exact((data_in, header_in), header_in)
     elif projection_type.startswith('adaptive'):
-        data_out, footprint = reproject_adaptive((data_in, header_in), header_in,
-                                                 kernel=projection_type.split('-', 1)[1])
+        data_out, footprint = reproject_adaptive(
+                (data_in, header_in), header_in,
+                kernel=projection_type.split('-', 1)[1],
+                boundary_mode='ignore')
     else:
         data_out, footprint = reproject_interp((data_in, header_in), header_in,
                                                order=projection_type)


### PR DESCRIPTION
Split from #276 

This PR changes the defaults for `reproject_adaptive` to use the Gaussian kernel, with the Hann left as an option. This is the most significant change in this PR series, as anyone using `reproject_adaptive` in their code will see very different results after updating to a version of `reproject` with this change. Their output images will be a bit blurrier, but better anti-aliased. (To be sure, every output image will also change due to the bug fixes, though those changes will hopefully be much smaller.) I'll argue that making this kernel the default is the right choice, though, because it strengthens the anti-aliasing quite a bit, and that anti-aliasing is what sets this algorithm apart from the interpolating and exact algorithms. Using the Gaussian by default offers the best anti-aliasing by default when a user comes to this function for anti-aliasing. I'm happy to discuss this point further and offer plots and examples.

As discussed, this should probably wait until after some sort of deprecation period.

EDIT: To avoid a bunch of merge conflicts, I've moved into this PR from #293 the commit that changes the default kernel. This PR now also removes the warnings we added about these future changes, removes the now-deprecated order argument, and makes notes in CHANGES.md. Should be ready to go for the next-next release.