### PR TITLE
TST: Unpin coverage to grab 6.4

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -20,9 +20,6 @@ setenv =
 changedir =
     .tmp/{envname}
 deps =
-    # https://github.com/nedbat/coveragepy/issues/1310
-    cov: coverage==6.2.*
-
     numpy121: numpy==1.21.*
 
     oldestdeps: numpy==1.17.3


### PR DESCRIPTION
The multiprocessing bug should be gone now.

Fix #280 , undo #277