### PR TITLE
Use "strict" boundaries by default for adaptive resampling

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+0.10 (unreleased)
+-----------------
+
+- Changed default boundary mode from ``ignore`` to ``strict`` for
+  ``reproject_adaptive``.
+
 0.9 (unreleased)
 ----------------
 

--- a/reproject/adaptive/core.py
+++ b/reproject/adaptive/core.py
@@ -36,7 +36,7 @@ def _reproject_adaptive_2d(array, wcs_in, wcs_out, shape_out,
                            roundtrip_coords=True, conserve_flux=False,
                            kernel='Hann', kernel_width=1.3,
                            sample_region_width=4,
-                           boundary_mode='ignore', boundary_fill_value=0,
+                           boundary_mode='strict', boundary_fill_value=0,
                            boundary_ignore_threshold=0.5,
                            x_cyclic=False, y_cyclic=False):
     """

--- a/reproject/adaptive/deforest.pyx
+++ b/reproject/adaptive/deforest.pyx
@@ -186,7 +186,7 @@ def map_coordinates(double[:,:] source, double[:,:] target, Ci, int max_samples_
                     int conserve_flux=False, int progress=False, int singularities_nan=False,
                     int x_cyclic=False, int y_cyclic=False, int out_of_range_nan=False,
                     bint center_jacobian=False, str kernel='Hann', double kernel_width=1.3,
-                    double sample_region_width=4, str boundary_mode="ignore",
+                    double sample_region_width=4, str boundary_mode="strict",
                     double boundary_fill_value=0, double boundary_ignore_threshold=0.5):
     cdef int kernel_flag
     try:

--- a/reproject/adaptive/high_level.py
+++ b/reproject/adaptive/high_level.py
@@ -15,7 +15,7 @@ def reproject_adaptive(input_data, output_projection, shape_out=None, hdu_in=0,
                        roundtrip_coords=True, conserve_flux=False,
                        kernel=None, kernel_width=1.3,
                        sample_region_width=4,
-                       boundary_mode=None, boundary_fill_value=0,
+                       boundary_mode='strict', boundary_fill_value=0,
                        boundary_ignore_threshold=0.5, x_cyclic=False,
                        y_cyclic=False):
     """

--- a/reproject/adaptive/tests/test_core.py
+++ b/reproject/adaptive/tests/test_core.py
@@ -52,7 +52,8 @@ def test_reproject_adaptive_2d(wcsapi, center_jacobian, roundtrip_coords):
     array_out, footprint_out = reproject_adaptive(
             (data_in, wcs_in), wcs_out, shape_out=(60, 60),
             center_jacobian=center_jacobian,
-            roundtrip_coords=roundtrip_coords)
+            roundtrip_coords=roundtrip_coords,
+            boundary_mode='ignore')
 
     # Check that surface brightness is conserved in the unrotated case
     assert_allclose(np.nansum(data_in), np.nansum(array_out) * (256 / 60) ** 2, rtol=0.1)
@@ -94,7 +95,8 @@ def test_reproject_adaptive_2d_rotated(center_jacobian, roundtrip_coords):
     array_out, footprint_out = reproject_adaptive(
             (data_in, wcs_in), wcs_out, shape_out=(60, 60),
             center_jacobian=center_jacobian,
-            roundtrip_coords=roundtrip_coords)
+            roundtrip_coords=roundtrip_coords,
+            boundary_mode='ignore')
 
     # ASTROPY_LT_40: astropy v4.0 introduced new default header keywords,
     # once we support only astropy 4.0 and later we can update the reference
@@ -292,7 +294,9 @@ def test_reproject_adaptive_flux_conservation():
         # The Gaussian kernel does a better job at flux conservation, so
         # choosing it here allows a tighter tolerance. Increasing the sample
         # region width also allows a tighter tolerance---less room for bugs to
-        # hide!
+        # hide! Setting the boundary mode to 'ignore' avoids excessive clipping
+        # of the edges of our small output image, letting us use a smaller
+        # image and do more tests in the same time.
         array_out = reproject_adaptive((data_in, wcs_in),
                                        wcs_out, shape_out=(30, 30),
                                        return_footprint=False,
@@ -300,7 +304,8 @@ def test_reproject_adaptive_flux_conservation():
                                        center_jacobian=False,
                                        kernel='gaussian',
                                        sample_region_width=5,
-                                       conserve_flux=True)
+                                       conserve_flux=True,
+                                       boundary_mode='ignore')
 
         # The degree of flux-conservation we end up seeing isn't necessarily
         # something that we can constrain a priori, so here we test for

--- a/reproject/tests/test_high_level.py
+++ b/reproject/tests/test_high_level.py
@@ -132,8 +132,10 @@ def test_surface_brightness(projection_type, dtype):
     if projection_type == 'flux-conserving':
         data_out, footprint = reproject_exact((data_in, header_in), header_out)
     elif projection_type.startswith('adaptive'):
-        data_out, footprint = reproject_adaptive((data_in, header_in), header_out,
-                                                 kernel=projection_type.split('-', 1)[1])
+        data_out, footprint = reproject_adaptive(
+                (data_in, header_in), header_out,
+                kernel=projection_type.split('-', 1)[1],
+                boundary_mode='ignore')
     else:
         data_out, footprint = reproject_interp((data_in, header_in), header_out,
                                                order=projection_type)
@@ -174,8 +176,10 @@ def test_identity_projection(projection_type):
     if projection_type == 'flux-conserving':
         data_out, footprint = reproject_exact((data_in, header_in), header_in)
     elif projection_type.startswith('adaptive'):
-        data_out, footprint = reproject_adaptive((data_in, header_in), header_in,
-                                                 kernel=projection_type.split('-', 1)[1])
+        data_out, footprint = reproject_adaptive(
+                (data_in, header_in), header_in,
+                kernel=projection_type.split('-', 1)[1],
+                boundary_mode='ignore')
     else:
         data_out, footprint = reproject_interp((data_in, header_in), header_in,
                                                order=projection_type)


### PR DESCRIPTION
Split from #279

After the discussion around defaults changes, I'm separating out this commit as well. After adding a menu of boundary-handling options in #279, the old behavior can be had with the "ignore" option, and a new "strict" option gives `NaN`s for any output pixels that aren't fully determined by the input data (which generally has the effect of trimming the edges of the output image if the input image doesn't fully span the output plane). The "strict" option seems like the safest default, but I don't feel too strongly if changing this default is more work than it's worth.

Until things are merged and rebased, "Set default boundary mode to 'strict' for adaptive algo" is the only commit belonging to this PR.