### PR TITLE
Warn about future changes to adaptive defaults

### DIFF
--- a/reproject/adaptive/high_level.py
+++ b/reproject/adaptive/high_level.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import astropy.utils
+import warnings
 
 from ..utils import parse_input_data, parse_output_projection
 from .core import _reproject_adaptive_2d
@@ -12,8 +13,9 @@ def reproject_adaptive(input_data, output_projection, shape_out=None, hdu_in=0,
                        order=None,
                        return_footprint=True, center_jacobian=False,
                        roundtrip_coords=True, conserve_flux=False,
-                       kernel='Hann', kernel_width=1.3, sample_region_width=4,
-                       boundary_mode='ignore', boundary_fill_value=0,
+                       kernel=None, kernel_width=1.3,
+                       sample_region_width=4,
+                       boundary_mode=None, boundary_fill_value=0,
                        boundary_ignore_threshold=0.5, x_cyclic=False,
                        y_cyclic=False):
     """
@@ -78,7 +80,9 @@ def reproject_adaptive(input_data, output_projection, shape_out=None, hdu_in=0,
         The averaging kernel to use. Allowed values are 'Hann' and 'Gaussian'.
         Case-insensitive. The Gaussian kernel produces better photometric
         accuracy and stronger anti-aliasing at the cost of some blurring (on
-        the scale of a few pixels).
+        the scale of a few pixels). If not specified, the Hann kernel is used
+        by default, but this will change to the Gaussian kernel in a future
+        release.
     kernel_width : double
         The width of the kernel in pixels, measuring to +/- 1 sigma for the
         Gaussian window. Does not apply to the Hann window. Reducing this width
@@ -99,7 +103,8 @@ def reproject_adaptive(input_data, output_projection, shape_out=None, hdu_in=0,
         accuracy.
     boundary_mode : str
         How to handle when the sampling region includes regions outside the
-        bounds of the input image. Allowed values are:
+        bounds of the input image. The default is ``ignore``, but this will
+        change to ``strict`` in a future release. Allowed values are:
 
             * ``strict`` --- Output pixels will be NaN if any input sample
               falls outside the input image.
@@ -141,6 +146,22 @@ def reproject_adaptive(input_data, output_projection, shape_out=None, hdu_in=0,
         no coverage or valid values in the input image, while values of 1
         indicate valid values.
     """
+
+    if kernel is None:
+        kernel = 'hann'
+        warnings.warn(
+                "The default kernel will change from 'Hann' to "
+                " 'Gaussian' in a future release. To suppress this warning, "
+                "explicitly select a kernel with the 'kernel' argument.",
+                FutureWarning, stacklevel=3)
+
+    if boundary_mode is None:
+        boundary_mode = 'ignore'
+        warnings.warn(
+                "The default boundary mode will change from 'ignore' to "
+                " 'strict' in a future release. To suppress this warning, "
+                "explicitly select a mode with the 'boundary_mode' argument.",
+                FutureWarning, stacklevel=3)
 
     # TODO: add support for output_array
 

--- a/reproject/adaptive/tests/test_core.py
+++ b/reproject/adaptive/tests/test_core.py
@@ -20,6 +20,7 @@ def as_high_level_wcs(wcs):
     return HighLevelWCSWrapper(SlicedLowLevelWCS(wcs, Ellipsis))
 
 
+@pytest.mark.filterwarnings('ignore::FutureWarning')
 @pytest.mark.array_compare(single_reference=True)
 @pytest.mark.parametrize('wcsapi', (False, True))
 @pytest.mark.parametrize('center_jacobian', (False, True))
@@ -65,6 +66,7 @@ def test_reproject_adaptive_2d(wcsapi, center_jacobian, roundtrip_coords):
     return array_footprint_to_hdulist(array_out, footprint_out, header_out)
 
 
+@pytest.mark.filterwarnings('ignore::FutureWarning')
 @pytest.mark.array_compare(single_reference=True)
 @pytest.mark.parametrize('center_jacobian', (False, True))
 @pytest.mark.parametrize('roundtrip_coords', (False, True))
@@ -103,6 +105,7 @@ def test_reproject_adaptive_2d_rotated(center_jacobian, roundtrip_coords):
     return array_footprint_to_hdulist(array_out, footprint_out, header_out)
 
 
+@pytest.mark.filterwarnings('ignore::FutureWarning')
 @pytest.mark.parametrize('roundtrip_coords', (False, True))
 @pytest.mark.parametrize('center_jacobian', (False, True))
 @pytest.mark.parametrize('kernel', ('hann', 'gaussian'))
@@ -191,6 +194,7 @@ def test_reproject_adaptive_high_aliasing_potential_rotation(
     np.testing.assert_allclose(array_out, data_ref)
 
 
+@pytest.mark.filterwarnings('ignore::FutureWarning')
 @pytest.mark.parametrize('roundtrip_coords', (False, True))
 @pytest.mark.parametrize('center_jacobian', (False, True))
 def test_reproject_adaptive_high_aliasing_potential_shearing(
@@ -239,6 +243,7 @@ def test_reproject_adaptive_high_aliasing_potential_shearing(
             np.testing.assert_allclose(array_out, 0.5, atol=0.02, rtol=0)
 
 
+@pytest.mark.filterwarnings('ignore::FutureWarning')
 def test_reproject_adaptive_flux_conservation():
     # This is more than just testing the `conserve_flux` flag---the expectation
     # that flux should be conserved gives a very easy way to quantify how
@@ -586,6 +591,7 @@ def prepare_test_data(file_format):
     return data, wcs, target_wcs
 
 
+@pytest.mark.filterwarnings('ignore::FutureWarning')
 @pytest.mark.array_compare(single_reference=True)
 @pytest.mark.parametrize('file_format', ['fits', 'asdf'])
 def test_reproject_adaptive_roundtrip(file_format):
@@ -612,6 +618,7 @@ def test_reproject_adaptive_roundtrip(file_format):
     return array_footprint_to_hdulist(output, footprint, header_out)
 
 
+@pytest.mark.filterwarnings('ignore::FutureWarning')
 @pytest.mark.array_compare()
 def test_reproject_adaptive_uncentered_jacobian():
 

--- a/reproject/tests/test_high_level.py
+++ b/reproject/tests/test_high_level.py
@@ -55,6 +55,7 @@ class TestReproject:
         self.wcs_out = WCS(self.header_out)
         self.shape_out = (600, 550)
 
+    @pytest.mark.filterwarnings('ignore::FutureWarning')
     def test_hdu_header(self, reproject_function):
 
         with pytest.raises(ValueError) as exc:
@@ -64,9 +65,11 @@ class TestReproject:
 
         reproject_interp(self.hdu_in, self.header_out_size)
 
+    @pytest.mark.filterwarnings('ignore::FutureWarning')
     def test_hdu_wcs(self, reproject_function):
         reproject_function(self.hdu_in, self.wcs_out, shape_out=self.shape_out)
 
+    @pytest.mark.filterwarnings('ignore::FutureWarning')
     def test_array_wcs_header(self, reproject_function):
 
         with pytest.raises(ValueError) as exc:
@@ -76,12 +79,15 @@ class TestReproject:
 
         reproject_function((self.array_in, self.wcs_in), self.header_out_size)
 
+    @pytest.mark.filterwarnings('ignore::FutureWarning')
     def test_array_wcs_wcs(self, reproject_function):
         reproject_function((self.array_in, self.wcs_in), self.wcs_out, shape_out=self.shape_out)
 
+    @pytest.mark.filterwarnings('ignore::FutureWarning')
     def test_array_header_header(self, reproject_function):
         reproject_function((self.array_in, self.header_in), self.header_out_size)
 
+    @pytest.mark.filterwarnings('ignore::FutureWarning')
     def test_return_footprint(self, reproject_function):
         array = reproject_function(self.hdu_in, self.wcs_out,
                                    shape_out=self.shape_out, return_footprint=False)
@@ -105,6 +111,7 @@ LATPOLE =                 90.0 / [deg] Native latitude of celestial pole
 """
 
 
+@pytest.mark.filterwarnings('ignore::FutureWarning')
 @pytest.mark.parametrize('projection_type, dtype', itertools.product(ALL_MODES, ALL_DTYPES))
 def test_surface_brightness(projection_type, dtype):
 
@@ -158,6 +165,7 @@ CD2_2   = 5.92479929826863E-05 / WCS transform matrix element
 """
 
 
+@pytest.mark.filterwarnings('ignore::FutureWarning')
 @pytest.mark.parametrize('projection_type', ALL_MODES)
 def test_identity_projection(projection_type):
     """Sanity check: identical input & output headers should preserve image."""


### PR DESCRIPTION
(One new commit on top of the boundary-handling PR, will rebase later)

This warns the user if the default filter kernel or boundary handling mode is being used.

```
In [3]: reproject.reproject_adaptive((data, w), w, data.shape)
<ipython-input-3-6fbe9b99ba1d>:1: FutureWarning: The default kernel will change from 'Hann' to  'Gaussian' in a future release. To suppress this warning, explicitly select a kernel with the 'kernel' argument.
  reproject.reproject_adaptive((data, w), w, data.shape)
<ipython-input-3-6fbe9b99ba1d>:1: FutureWarning: The default boundary mode will change from 'ignore' to  'strict' in a future release. To suppress this warning, explicitly select a mode with the 'boundary_mode' argument.
  reproject.reproject_adaptive((data, w), w, data.shape)
Out[3]: 
...

In [4]: reproject.reproject_adaptive((data, w), w, data.shape, kernel='hann', boundary_mode='strict')
Out[4]: 
...
```

I set the default values for these two kwargs to `'default'` so we can tell whether the user is relying on the default behavior or explicitly requesting the old behavior. I haven't mentioned the literal value of `default` in the docs and intend to stop recognizing it in the same commit that changes the defaults, and I hope this temporarily-valid value of `default` doesn't itself need a deprecation period. LMK if there's a better way.