### PR TITLE
Remove the 32bit wheel build

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -34,7 +34,6 @@ jobs:
       test_extras: test
       test_command: pytest -p no:warnings --pyargs reproject
       targets: |
-        - cp*-manylinux_i686
         - cp*-manylinux_x86_64
         - cp*-manylinux_aarch64
         - cp*-macosx_x86_64


### PR DESCRIPTION
Numpy and pyyaml are not publishing wheels for 32bit any more, so our build timesout.