### PR TITLE
Split aarch64 builds to avoid timeouts

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -34,7 +34,9 @@ jobs:
       test_command: pytest -p no:warnings --pyargs reproject
       targets: |
         - cp*-manylinux_x86_64
-        - cp*-manylinux_aarch64
+        - cp38-manylinux_aarch64
+        - cp39-manylinux_aarch64
+        - cp31*-manylinux_aarch64
         - cp*-macosx_x86_64
         - cp*-macosx_arm64
         - cp*-win*


### PR DESCRIPTION
For Python 3.10, I used a wildcard so we don't forget to add 3.11 etc in future but for now it should be a single build.