### PR TITLE
Skip wheel tests on manylinux_aarch64

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ write_to = "reproject/version.py"
 
 [tool.cibuildwheel]
 skip = "cp36-* pp* *-musllinux* cp310-win32"
+test-skip = "*-macosx_arm64 *-manylinux_aarch64"
 
 [tool.isort]
 extend_skip_glob = [


### PR DESCRIPTION
Tests run for hours on Linux aarch64 due to the emulation, so we skip these for now (tests are already skipped for arm64 on MacOS X)