### PR TITLE
Close fits files after loading

### DIFF
--- a/reproject/utils.py
+++ b/reproject/utils.py
@@ -22,8 +22,8 @@ def parse_input_data(input_data, hdu_in=None):
     """
 
     if isinstance(input_data, str):
-        # NOTE: File handler is not closed here.
-        return parse_input_data(fits.open(input_data), hdu_in=hdu_in)
+        with fits.open(input_data) as hdul:
+            return parse_input_data(hdul, hdu_in=hdu_in)
     elif isinstance(input_data, HDUList):
         if hdu_in is None:
             if len(input_data) > 1:


### PR DESCRIPTION
I noticed a comment pointing out that when FITS file names are passed for the input data, the file is opened but never closed. Changing that looked like a quick fix, and should be safe---after the file is opened, `parse_input_data` calls itself a few times before eventually extracting the `.data` and `.header` attributes of the selected HDU and returning those, so the HDUL object never leaves `parse_input_data`. (Not sure if the garbage collector would have eventually closed everything anyway.)

While checking that this was covered by existing tests, I saw that the `parse_input_data` tests were checking the data array that gets returned but not the corresponding WCS, so I augmented those tests to check both.

(The CI failure appears to be pre-existing)