### PR TITLE
Fix weird quotation marks from Black auto-formatting

### DIFF
--- a/reproject/healpix/high_level.py
+++ b/reproject/healpix/high_level.py
@@ -141,5 +141,5 @@ def reproject_to_healpix(
         )
     else:
         raise NotImplementedError(
-            "Only data with a 2-d celestial WCS can be " "reprojected to a HEALPIX projection"
+            "Only data with a 2-d celestial WCS can be reprojected to a HEALPIX projection"
         )

--- a/reproject/healpix/tests/test_utils.py
+++ b/reproject/healpix/tests/test_utils.py
@@ -54,5 +54,5 @@ def test_parse_input_healpix_data(tmpdir):
     with pytest.raises(TypeError) as exc:
         parse_input_healpix_data(data)
     assert exc.value.args[0] == (
-        "input_data should either be an HDU object or " "a tuple of (array, frame)"
+        "input_data should either be an HDU object or a tuple of (array, frame)"
     )

--- a/reproject/interpolation/tests/test_core.py
+++ b/reproject/interpolation/tests/test_core.py
@@ -226,7 +226,7 @@ def test_celestial_mismatch_2d(roundtrip_coords):
         wcs2 = WCS(header_out)
 
         with pytest.raises(
-            ValueError, match="Input WCS has celestial components but output WCS " "does not"
+            ValueError, match="Input WCS has celestial components but output WCS does not"
         ):
             array_out, footprint_out = reproject_interp(
                 (data, wcs1), wcs2, shape_out=(2, 2), roundtrip_coords=roundtrip_coords
@@ -255,14 +255,14 @@ def test_celestial_mismatch_3d(roundtrip_coords):
         wcs2 = WCS(header_out)
 
         with pytest.raises(
-            ValueError, match="Input WCS has celestial components but output WCS " "does not"
+            ValueError, match="Input WCS has celestial components but output WCS does not"
         ):
             array_out, footprint_out = reproject_interp(
                 (data, wcs1), wcs2, shape_out=(1, 2, 3), roundtrip_coords=roundtrip_coords
             )
 
         with pytest.raises(
-            ValueError, match="Output WCS has celestial components but input WCS " "does not"
+            ValueError, match="Output WCS has celestial components but input WCS does not"
         ):
             array_out, footprint_out = reproject_interp(
                 (data, wcs2), wcs1, shape_out=(1, 2, 3), roundtrip_coords=roundtrip_coords
@@ -301,14 +301,14 @@ def test_spectral_mismatch_3d(roundtrip_coords):
         wcs2 = WCS(header_out)
 
         with pytest.raises(
-            ValueError, match="Input WCS has a spectral component but output WCS " "does not"
+            ValueError, match="Input WCS has a spectral component but output WCS does not"
         ):
             array_out, footprint_out = reproject_interp(
                 (data, wcs1), wcs2, shape_out=(1, 2, 3), roundtrip_coords=roundtrip_coords
             )
 
         with pytest.raises(
-            ValueError, match="Output WCS has a spectral component but input WCS " "does not"
+            ValueError, match="Output WCS has a spectral component but input WCS does not"
         ):
             array_out, footprint_out = reproject_interp(
                 (data, wcs2), wcs1, shape_out=(1, 2, 3), roundtrip_coords=roundtrip_coords
@@ -326,7 +326,7 @@ def test_naxis_mismatch(roundtrip_coords):
     wcs_out = WCS(naxis=2)
 
     with pytest.raises(
-        ValueError, match="Number of dimensions between input and output WCS " "should match"
+        ValueError, match="Number of dimensions between input and output WCS should match"
     ):
         array_out, footprint_out = reproject_interp(
             (data, wcs_in), wcs_out, shape_out=(1, 2), roundtrip_coords=roundtrip_coords
@@ -398,7 +398,7 @@ def test_4d_fails(roundtrip_coords):
     array_in = np.zeros((2, 3, 4, 5))
 
     with pytest.raises(
-        ValueError, match="Length of shape_out should match number of dimensions " "in wcs_out"
+        ValueError, match="Length of shape_out should match number of dimensions in wcs_out"
     ):
         x_out, y_out, z_out = reproject_interp(
             (array_in, w_in), w_out, shape_out=[2, 4, 5, 6], roundtrip_coords=roundtrip_coords
@@ -421,7 +421,7 @@ def test_inequal_wcs_dims(roundtrip_coords):
     wcs_out = WCS(header_out)
 
     with pytest.raises(
-        ValueError, match="Output WCS has a spectral component but input WCS " "does not"
+        ValueError, match="Output WCS has a spectral component but input WCS does not"
     ):
         out_cube, out_cube_valid = reproject_interp(
             (inp_cube, header_in), wcs_out, shape_out=(2, 4, 5), roundtrip_coords=roundtrip_coords

--- a/reproject/mosaicking/coadd.py
+++ b/reproject/mosaicking/coadd.py
@@ -97,7 +97,7 @@ def reproject_and_coadd(
 
     if reproject_function is None:
         raise ValueError(
-            "reprojection function should be specified with " "the reproject_function argument"
+            "reprojection function should be specified with the reproject_function argument"
         )
 
     # Parse the output projection to avoid having to do it for each
@@ -234,6 +234,6 @@ def reproject_and_coadd(
         # Here we need to operate in chunks since we could otherwise run
         # into memory issues
 
-        raise NotImplementedError("combine_function='median' is " "not yet implemented")
+        raise NotImplementedError("combine_function='median' is not yet implemented")
 
     return final_array, final_footprint

--- a/reproject/spherical_intersect/tests/test_high_level.py
+++ b/reproject/spherical_intersect/tests/test_high_level.py
@@ -84,7 +84,7 @@ def test_reproject_precision_warning():
 
         if res < 0.05 / 3600:
             with pytest.warns(
-                UserWarning, match="The reproject_exact function " "currently has precision"
+                UserWarning, match="The reproject_exact function currently has precision"
             ):
                 reproject_exact((array, wcs1), wcs2, shape_out=(5, 5))
         else:

--- a/reproject/tests/test_utils.py
+++ b/reproject/tests/test_utils.py
@@ -28,7 +28,7 @@ def test_parse_input_data(tmpdir):
     with pytest.raises(ValueError) as exc:
         array, coordinate_system = parse_input_data(filename)
     assert exc.value.args[0] == (
-        "More than one HDU is present, please specify " "HDU to use with ``hdu_in=`` option"
+        "More than one HDU is present, please specify HDU to use with ``hdu_in=`` option"
     )
 
     array, coordinate_system = parse_input_data(filename, hdu_in=1)
@@ -52,7 +52,7 @@ def test_parse_input_data(tmpdir):
     with pytest.raises(TypeError) as exc:
         parse_input_data(data)
     assert exc.value.args[0] == (
-        "input_data should either be an HDU object or " "a tuple of (array, WCS) or (array, Header)"
+        "input_data should either be an HDU object or a tuple of (array, WCS) or (array, Header)"
     )
 
 
@@ -78,7 +78,7 @@ def test_parse_input_shape(tmpdir):
     with pytest.raises(ValueError) as exc:
         shape, coordinate_system = parse_input_shape(filename)
     assert exc.value.args[0] == (
-        "More than one HDU is present, please specify " "HDU to use with ``hdu_in=`` option"
+        "More than one HDU is present, please specify HDU to use with ``hdu_in=`` option"
     )
 
     shape, coordinate_system = parse_input_shape(filename, hdu_in=1)
@@ -125,7 +125,7 @@ def test_parse_output_projection(tmpdir):
     with pytest.raises(ValueError) as exc:
         parse_output_projection(header)
     assert exc.value.args[0] == (
-        "Need to specify shape since output header " "does not contain complete shape information"
+        "Need to specify shape since output header does not contain complete shape information"
     )
 
     parse_output_projection(header, shape_out=(200, 200))
@@ -141,7 +141,7 @@ def test_parse_output_projection(tmpdir):
     with pytest.raises(ValueError) as exc:
         parse_output_projection(wcs)
     assert exc.value.args[0] == (
-        "Need to specify shape_out when specifying " "output_projection as WCS object"
+        "Need to specify shape_out when specifying output_projection as WCS object"
     )
 
     parse_output_projection(wcs, shape_out=(200, 200))

--- a/reproject/utils.py
+++ b/reproject/utils.py
@@ -138,7 +138,7 @@ def parse_output_projection(output_projection, shape_out=None, output_array=None
         wcs_out = output_projection
         if shape_out is None:
             raise ValueError(
-                "Need to specify shape_out when specifying " "output_projection as WCS object"
+                "Need to specify shape_out when specifying output_projection as WCS object"
             )
     elif isinstance(output_projection, str):
         hdu_list = fits.open(output_projection)
@@ -147,12 +147,10 @@ def parse_output_projection(output_projection, shape_out=None, output_array=None
         wcs_out = WCS(header)
         hdu_list.close()
     else:
-        raise TypeError(
-            "output_projection should either be a Header, a WCS " "object, or a filename"
-        )
+        raise TypeError("output_projection should either be a Header, a WCS object, or a filename")
 
     if len(shape_out) == 0:
-        raise ValueError("The shape of the output image should not be an " "empty tuple")
+        raise ValueError("The shape of the output image should not be an empty tuple")
     return wcs_out, shape_out
 
 


### PR DESCRIPTION
Noticed another little thing---a commit a few months ago auto-reformatted the code with Black. Black must have been imposing a new, larger maximum line length and it reflowed some strings that had been broken across multiple lines, but it left extra quotation marks in place while it did that

(CI failure appears to be pre-existing)