### PR TITLE
Add support for efficiently reprojecting multiple images with the same wcs

### DIFF
--- a/reproject/adaptive/core.py
+++ b/reproject/adaptive/core.py
@@ -121,9 +121,9 @@ def _reproject_adaptive_2d(
     if wcs_in.low_level_wcs.pixel_n_dim != wcs_out.low_level_wcs.pixel_n_dim:
         raise ValueError("Number of dimensions between input and output WCS should match")
     elif len(shape_out) < wcs_out.low_level_wcs.pixel_n_dim:
-        raise ValueError("Length of shape_out too small for number of dimensions in wcs_out")
+        raise ValueError("Too few dimensions in shape_out")
     elif len(array_in.shape) < wcs_in.low_level_wcs.pixel_n_dim:
-        raise ValueError("Too few input-data dimensions for number of dimensions in wcs_out")
+        raise ValueError("Too few dimensions in input data")
     elif len(array_in.shape) != len(shape_out):
         raise ValueError("Number of dimensions in input and output data should match")
 

--- a/reproject/adaptive/high_level.py
+++ b/reproject/adaptive/high_level.py
@@ -47,6 +47,12 @@ def reproject_adaptive(
             * An `~astropy.nddata.NDData` object from which the ``.data`` and
               ``.wcs`` attributes will be used as the input data.
 
+        If the data array contains more dimensions than are described by the
+        input header or WCS, the extra dimensions (assumed to be the first
+        dimensions) are taken to represent multiple images with the same
+        coordinate information. The coordinate transformation will be computed
+        once and then each image will be reprojected, offering a speedup over
+        reprojecting each image individually.
     output_projection : `~astropy.wcs.WCS` or `~astropy.io.fits.Header`
         The output projection, which can be either a `~astropy.wcs.WCS`
         or a `~astropy.io.fits.Header` instance.
@@ -153,7 +159,9 @@ def reproject_adaptive(
     # TODO: add support for output_array
 
     array_in, wcs_in = parse_input_data(input_data, hdu_in=hdu_in)
-    wcs_out, shape_out = parse_output_projection(output_projection, shape_out=shape_out)
+    wcs_out, shape_out = parse_output_projection(
+        output_projection, shape_in=array_in.shape, shape_out=shape_out
+    )
 
     return _reproject_adaptive_2d(
         array_in,

--- a/reproject/interpolation/core.py
+++ b/reproject/interpolation/core.py
@@ -15,12 +15,7 @@ def _validate_wcs(wcs_in, wcs_out, shape_in, shape_out):
         raise ValueError("Too few dimensions in shape_out")
     elif len(shape_in) < wcs_in.low_level_wcs.pixel_n_dim:
         raise ValueError("Too few dimensions in input data")
-
-    if len(shape_out) < len(shape_in) and len(shape_out) == wcs_out.low_level_wcs.pixel_n_dim:
-        # Add the broadcast dimensions to the output shape, which does not
-        # currently have any broadcast dims
-        shape_out = (*shape_in[:-len(shape_out)], *shape_out)
-    if len(shape_in) != len(shape_out):
+    elif len(shape_in) != len(shape_out):
         raise ValueError("Number of dimensions in input and output data should match")
 
     # Separate the "extra" dimensions that don't correspond to a WCS axis and
@@ -50,7 +45,6 @@ def _validate_wcs(wcs_in, wcs_out, shape_in, shape_out):
             raise ValueError("Input WCS has a spectral component but output WCS does not")
         elif wcs_out.wcs.spec >= 0:
             raise ValueError("Output WCS has a spectral component but input WCS does not")
-    return shape_out
 
 
 def _validate_array_out(array_out, array, shape_out):
@@ -100,9 +94,7 @@ def _reproject_full(
     array = np.asarray(array, dtype=float)
     # shape_out must be exactly a tuple type
     shape_out = tuple(shape_out)
-    # shape_out may be updated by _validate_wcs if the transformation is being
-    # broadcast
-    shape_out = _validate_wcs(wcs_in, wcs_out, array.shape, shape_out)
+    _validate_wcs(wcs_in, wcs_out, array.shape, shape_out)
     _validate_array_out(array_out, array, shape_out)
 
     if array_out is None:

--- a/reproject/interpolation/high_level.py
+++ b/reproject/interpolation/high_level.py
@@ -108,7 +108,7 @@ def reproject_interp(
 
     array_in, wcs_in = parse_input_data(input_data, hdu_in=hdu_in)
     wcs_out, shape_out = parse_output_projection(
-        output_projection, shape_out=shape_out, output_array=output_array
+        output_projection, shape_in=array_in.shape, shape_out=shape_out, output_array=output_array
     )
 
     if isinstance(order, str):
@@ -119,9 +119,9 @@ def reproject_interp(
         # if parallel is set but block size isn't, we'll choose
         # block size so each thread gets one block each
         if parallel is not False and block_size is None:
-            block_size = shape_out.copy()
+            block_size = list(shape_out)
             # each thread gets an equal sized strip of output area to process
-            block_size[0] = shape_out[0] // os.cpu_count()
+            block_size[-2] = shape_out[-2] // os.cpu_count()
 
         # given we have cases where modern system have many cpu cores some sanity clamping is
         # to avoid 0 length block sizes when num_cpu_cores is greater than the side of the image

--- a/reproject/interpolation/high_level.py
+++ b/reproject/interpolation/high_level.py
@@ -50,6 +50,12 @@ def reproject_interp(
             * An `~astropy.nddata.NDData` object from which the ``.data`` and
               ``.wcs`` attributes will be used as the input data.
 
+        If the data array contains more dimensions than are described by the
+        input header or WCS, the extra dimensions (assumed to be the first
+        dimensions) are taken to represent multiple images with the same
+        coordinate information. The coordinate transformation will be computed
+        once and then each image will be reprojected, offering a speedup over
+        reprojecting each image individually.
     output_projection : `~astropy.wcs.WCS` or `~astropy.io.fits.Header`
         The output projection, which can be either a `~astropy.wcs.WCS`
         or a `~astropy.io.fits.Header` instance.

--- a/reproject/spherical_intersect/high_level.py
+++ b/reproject/spherical_intersect/high_level.py
@@ -30,6 +30,12 @@ def reproject_exact(
             * An `~astropy.nddata.NDData` object from which the ``.data`` and
               ``.wcs`` attributes will be used as the input data.
 
+        If the data array contains more dimensions than are described by the
+        input header or WCS, the extra dimensions (assumed to be the first
+        dimensions) are taken to represent multiple images with the same
+        coordinate information. The coordinate transformation will be computed
+        once and then each image will be reprojected, offering a speedup over
+        reprojecting each image individually.
     output_projection : `~astropy.wcs.WCS` or `~astropy.io.fits.Header`
         The output projection, which can be either a `~astropy.wcs.WCS`
         or a `~astropy.io.fits.Header` instance.
@@ -59,7 +65,9 @@ def reproject_exact(
     """
 
     array_in, wcs_in = parse_input_data(input_data, hdu_in=hdu_in)
-    wcs_out, shape_out = parse_output_projection(output_projection, shape_out=shape_out)
+    wcs_out, shape_out = parse_output_projection(
+        output_projection, shape_in=array_in.shape, shape_out=shape_out
+    )
 
     if has_celestial(wcs_in) and wcs_in.pixel_n_dim == 2 and wcs_in.world_n_dim == 2:
         return _reproject_celestial(

--- a/reproject/spherical_intersect/tests/test_high_level.py
+++ b/reproject/spherical_intersect/tests/test_high_level.py
@@ -91,3 +91,94 @@ def test_reproject_precision_warning():
             with warnings.catch_warnings(record=True) as w:
                 reproject_exact((array, wcs1), wcs2, shape_out=(5, 5))
             assert len(w) == 0
+
+
+def _setup_for_broadcast_test():
+    with fits.open(get_pkg_data_filename("data/galactic_2d.fits", package="reproject.tests")) as pf:
+        hdu_in = pf[0]
+        header_in = hdu_in.header.copy()
+        header_out = hdu_in.header.copy()
+        header_out["CTYPE1"] = "RA---TAN"
+        header_out["CTYPE2"] = "DEC--TAN"
+        header_out["CRVAL1"] = 266.39311
+        header_out["CRVAL2"] = -28.939779
+
+        data = hdu_in.data
+
+    image_stack = np.stack((data, data.T, data[::-1], data[:, ::-1]))
+
+    # Build the reference array through un-broadcast reprojections
+    array_ref = []
+    footprint_ref = []
+    for i in range(len(image_stack)):
+        array_out, footprint_out = reproject_exact((image_stack[i], header_in), header_out)
+        array_ref.append(array_out)
+        footprint_ref.append(footprint_out)
+    array_ref = np.stack(array_ref)
+    footprint_ref = np.stack(footprint_ref)
+
+    return image_stack, array_ref, footprint_ref, header_in, header_out
+
+
+@pytest.mark.parametrize("input_extra_dims", (1, 2))
+@pytest.mark.parametrize("output_shape", (None, "single", "full"))
+@pytest.mark.parametrize("input_as_wcs", (True, False))
+@pytest.mark.parametrize("output_as_wcs", (True, False))
+def test_broadcast_reprojection(input_extra_dims, output_shape, input_as_wcs, output_as_wcs):
+    image_stack, array_ref, footprint_ref, header_in, header_out = _setup_for_broadcast_test()
+    # Test both single and multiple dimensions being broadcast
+    if input_extra_dims == 2:
+        image_stack = image_stack.reshape((2, 2, *image_stack.shape[-2:]))
+        array_ref.shape = image_stack.shape
+        footprint_ref.shape = image_stack.shape
+
+    # Test different ways of providing the output shape
+    if output_shape == "single":
+        # Have the broadcast dimensions be auto-added to the output shape
+        output_shape = image_stack.shape[-2:]
+    elif output_shape == "full":
+        # Provide the broadcast dimensions as part of the output shape
+        output_shape = image_stack.shape
+
+    # Ensure logic works with WCS inputs as well as Header inputs
+    if input_as_wcs:
+        header_in = WCS(header_in)
+    if output_as_wcs:
+        header_out = WCS(header_out)
+        if output_shape is None:
+            # This combination of parameter values is not valid
+            return
+
+    array_broadcast, footprint_broadcast = reproject_exact(
+        (image_stack, header_in), header_out, output_shape
+    )
+
+    np.testing.assert_allclose(footprint_broadcast, footprint_ref)
+    np.testing.assert_allclose(array_broadcast, array_ref)
+
+
+@pytest.mark.parametrize("input_extra_dims", (1, 2))
+@pytest.mark.parametrize("output_shape", (None, "single", "full"))
+@pytest.mark.parametrize("parallel", (2, False))
+def test_broadcast_parallel_reprojection(input_extra_dims, output_shape, parallel):
+    image_stack, array_ref, footprint_ref, header_in, header_out = _setup_for_broadcast_test()
+    # Test both single and multiple dimensions being broadcast
+    if input_extra_dims == 2:
+        image_stack = image_stack.reshape((2, 2, *image_stack.shape[-2:]))
+        array_ref.shape = image_stack.shape
+        footprint_ref.shape = image_stack.shape
+
+    # Test different ways of providing the output shape
+    if output_shape == "single":
+        # Have the broadcast dimensions be auto-added to the output shape
+        output_shape = image_stack.shape[-2:]
+    elif output_shape == "full":
+        # Provide the broadcast dimensions as part of the output shape
+        output_shape = image_stack.shape
+
+    array_broadcast, footprint_broadcast = reproject_exact(
+        (image_stack, header_in), header_out, output_shape, parallel=parallel
+    )
+
+    np.testing.assert_allclose(footprint_broadcast, footprint_ref)
+    np.testing.assert_allclose(array_broadcast, array_ref)


### PR DESCRIPTION
This addresses #296. @entaylor, want to take a look?

This PR adds support for reprojecting multiple images that share the exact same coordinate information---e.g. a data array and a corresponding error array, or an L1 and L2 image pair. By providing multiple images in one reproject call, the coordinate transformation work can be done only once before reprojecting each image, offering a speedup.

I chose the syntax of
```python
data, header = fits.getdata('data.fits', header=True)
uncertainty = fits.getdata('uncertainty.fits')
header_out = [...]

image_stack = np.stack((data, uncertainty))
reproject.reproject_adaptive((image_stack, header), header_out)
```
i.e. multiple images passed as an extra input array dimension. There's no support for doing this by passing some sort of mult-HDU FITS files directly to the reproject function---it seems like it would be too much work to verify each HDU has the same WCS.

I tried to mimic the way numpy handles broadcasting operations between two arrays---the trailing dimensions are matched up, while extra leading dimensions are looped over. For reproject, I'm taking the trailing dimensions of the input and output arrays to correspond to the WCS dimensions, and any extra leading dimensions beyond what the WCS contains are looped over. Any number of extra leading dimensions is supported---maybe a user with data and uncertainty arrays from both L1 and L2 wants to do a `2 × 2 × nx × ny` input array.

When `shape_out` is provided, it can contain the extra dimensions that the input array contains (and they must match exactly), or `shape_out` can be just the shape of a single output image, and the extra dimensions are prepended automatically.

The implementation is a bit different for each of the interpolation, adaptive, and exact algorithms:

For interpolation, I'm computing the pixel-to-pixel mapping once, and then looping over the extra dimensions, calling `map_coordinates` once for each image. To support the new blocked mode (which is only in this algorithm), I did change how that mode approaches 3+ dimensional WCSes. It breaks up the data in only two dimensions---those were originally the first two dimensions, but I changed it to be the last two dimensions, since those will always be WCS dimensions. (The alternatives would be "the first two WCS dimensions, which are not necessarily the first two array dimensions" or "the first two array dimensions, which are not necessarily WCS dimensions", which would both complicate the logic a bit.)

For adaptive, I made the changes at the Cython level, since that's where some of the coordinate work occurs. The few spots that update the output array (the inner-most part of the loop) are modified to do everything along the extra dimension.

For exact, the changes are at the Python level, similar to interpolation with a loop over the extra dimensions after calculating the coordinates once. This algorithm has a parallel-processing mode which could in principle parallelize across the extra dimensions, but then there would have to be separate parallel modes depending on whether there are extra dimensions, so I've left the parallelization inside the loop over extra dimensions.

My speed test results with two PSP/WISPR images, each about 1k x 1k:
```
>>> two_images = np.stack((d1, d2))

>>> %%timeit
... dout = reproject.reproject_interp((two_images, w1), wout, d1.shape, return_footprint=False)
831 ms ± 8.38 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

>>> %%timeit
... dout1 = reproject.reproject_interp((d1, w1), wout, d1.shape, return_footprint=False)
... dout2 = reproject.reproject_interp((d2, w1), wout, d1.shape, return_footprint=False)
1.75 s ± 21.2 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)


>>> %%time
... dout = reproject.reproject_adaptive((two_images, w1), wout, d1.shape, return_footprint=False)
1.58 s ± 23.1 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

>>> %%timeit
... dout1 = reproject.reproject_adaptive((d1, w1), wout, d1.shape, return_footprint=False)
... dout2 = reproject.reproject_adaptive((d2, w1), wout, d1.shape, return_footprint=False)
3.27 s ± 45.9 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)


>>> %%timeit
... dout = reproject.reproject_exact((two_images, w1), wout, d1.shape, return_footprint=False)
19 s ± 961 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

>>> %%timeit
... dout1 = reproject.reproject_exact((d1, w1), wout, d1.shape, return_footprint=False)
... dout2 = reproject.reproject_exact((d2, w1), wout, d1.shape, return_footprint=False)
19.7 s ± 733 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```
tl;dr A 2x speedup for two images in interpolating or adaptive reprojection

(There's one pre-existing test failure that's gonna tank CI.)