### PR TITLE
Allow single inputs to find_optimal_celestial_wcs and add ability to specify HDU

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -9,24 +9,19 @@ Requirements
 
 This package has the following hard run time dependencies:
 
-* `Python <http://www.python.org/>`__ 3.7 or later
+* `Python <http://www.python.org/>`__ 3.8 or later
 
-* `Numpy <http://www.numpy.org/>`__ 1.14 or later
+* `Numpy <http://www.numpy.org/>`__ 1.20 or later
 
-* `Astropy <http://www.astropy.org/>`__ 3.2 or later
+* `Astropy <http://www.astropy.org/>`__ 5.0 or later
 
-* `Scipy <http://www.scipy.org/>`__ 1.1 or later
+* `Scipy <http://www.scipy.org/>`__ 1.5 or later
 
 * `astropy-healpix <https://astropy-healpix.readthedocs.io>`_ 0.6 or later for HEALPIX image reprojection
 
 and the following optional dependencies:
 
 * `shapely <https://toblerity.org/shapely/project.html>`_ 1.6 or later for some of the mosaicking functionality
-
-If you build the package from the source, the following additional packages
-are required:
-
-* `Cython <http://cython.org>`__
 
 and to run the tests, you will also need:
 

--- a/reproject/adaptive/high_level.py
+++ b/reproject/adaptive/high_level.py
@@ -41,6 +41,9 @@ def reproject_adaptive(
             * An image HDU object such as a `~astropy.io.fits.PrimaryHDU`,
               `~astropy.io.fits.ImageHDU`, or `~astropy.io.fits.CompImageHDU`
               instance
+            * A tuple where the first element is an Numpy array shape tuple
+              the second element is either a `~astropy.wcs.WCS` or a
+              `~astropy.io.fits.Header` object
             * A tuple where the first element is a `~numpy.ndarray` and the
               second element is either a `~astropy.wcs.WCS` or a
               `~astropy.io.fits.Header` object

--- a/reproject/conftest.py
+++ b/reproject/conftest.py
@@ -72,9 +72,6 @@ def valid_celestial_input(tmp_path, request):
         input_value = hdulist[1]
     elif request.param == "comp_image_hdu":
         input_value = hdulist[2]
-    elif request.param == "ape14_wcs":
-        input_value = wcs
-        input_value._naxis = list(array.shape[::-1])
     elif request.param == "shape_wcs_tuple":
         input_value = (array.shape, wcs)
     elif request.param == "data_wcs_tuple":
@@ -92,32 +89,26 @@ def valid_celestial_input(tmp_path, request):
     return array, wcs, input_value, kwargs
 
 
-@pytest.fixture(
-    params=[
-        "filename",
-        "path",
-        "hdulist",
-        "primary_hdu",
-        "image_hdu",
-        "comp_image_hdu",
-        "data_wcs_tuple",
-        "nddata",
-    ]
-)
+COMMON_PARAMS = [
+    "filename",
+    "path",
+    "hdulist",
+    "primary_hdu",
+    "image_hdu",
+    "comp_image_hdu",
+    "data_wcs_tuple",
+    "nddata",
+]
+
+
+@pytest.fixture(params=COMMON_PARAMS)
 def valid_celestial_input_data(tmp_path, request):
     return valid_celestial_input(tmp_path, request)
 
 
 @pytest.fixture(
-    params=[
-        "filename",
-        "path",
-        "hdulist",
-        "primary_hdu",
-        "image_hdu",
-        "comp_image_hdu",
-        "data_wcs_tuple",
-        "nddata",
+    params=COMMON_PARAMS
+    + [
         "ape14_wcs",
         "shape_wcs_tuple",
     ]

--- a/reproject/conftest.py
+++ b/reproject/conftest.py
@@ -5,11 +5,11 @@
 
 import os
 
-import pytest
 import numpy as np
-from astropy.wcs import WCS
+import pytest
 from astropy.io import fits
 from astropy.nddata import NDData
+from astropy.wcs import WCS
 
 try:
     from pytest_astropy_header.display import PYTEST_HEADER_MODULES, TESTED_VERSIONS
@@ -37,23 +37,7 @@ def pytest_configure(config):
         TESTED_VERSIONS["reproject"] = __version__
 
 
-@pytest.fixture(params=        [
-            "filename",
-            "path",
-            "hdulist",
-            "hdulist_all",
-            "primary_hdu",
-            "image_hdu",
-            "comp_image_hdu",
-            "ape14_wcs",
-            "shape_wcs_tuple",
-            "data_wcs_tuple",
-            "nddata",
-        ])
 def valid_celestial_input(tmp_path, request):
-
-    request.param
-
     array = np.ones((30, 40))
 
     wcs = WCS(naxis=2)
@@ -78,12 +62,10 @@ def valid_celestial_input(tmp_path, request):
         if request.param == "filename":
             input_value = str(input_value)
         hdulist.writeto(input_value)
-        kwargs['hdu_in'] = 0
+        kwargs["hdu_in"] = 0
     elif request.param == "hdulist":
         input_value = hdulist
-        kwargs['hdu_in'] = 1
-    elif request.param == "hdulist_all":
-        input_value = hdulist
+        kwargs["hdu_in"] = 1
     elif request.param == "primary_hdu":
         input_value = hdulist[0]
     elif request.param == "image_hdu":
@@ -99,7 +81,47 @@ def valid_celestial_input(tmp_path, request):
         input_value = (array, wcs)
     elif request.param == "nddata":
         input_value = NDData(data=array, wcs=wcs)
+    elif request.param == "ape14_wcs":
+        input_value = wcs
+        input_value._naxis = list(array.shape[::-1])
+    elif request.param == "shape_wcs_tuple":
+        input_value = (array.shape, wcs)
+
     else:
         raise ValueError(f"Unknown mode: {request.param}")
 
     return array, wcs, input_value, kwargs
+
+
+@pytest.fixture(
+    params=[
+        "filename",
+        "path",
+        "hdulist",
+        "primary_hdu",
+        "image_hdu",
+        "comp_image_hdu",
+        "data_wcs_tuple",
+        "nddata",
+    ]
+)
+def valid_celestial_input_data(tmp_path, request):
+    return valid_celestial_input(tmp_path, request)
+
+
+@pytest.fixture(
+    params=[
+        "filename",
+        "path",
+        "hdulist",
+        "primary_hdu",
+        "image_hdu",
+        "comp_image_hdu",
+        "data_wcs_tuple",
+        "nddata",
+        "ape14_wcs",
+        "shape_wcs_tuple",
+    ]
+)
+def valid_celestial_input_shapes(tmp_path, request):
+    return valid_celestial_input(tmp_path, request)

--- a/reproject/conftest.py
+++ b/reproject/conftest.py
@@ -86,7 +86,6 @@ def valid_celestial_input(tmp_path, request):
         input_value._naxis = list(array.shape[::-1])
     elif request.param == "shape_wcs_tuple":
         input_value = (array.shape, wcs)
-
     else:
         raise ValueError(f"Unknown mode: {request.param}")
 

--- a/reproject/interpolation/high_level.py
+++ b/reproject/interpolation/high_level.py
@@ -44,6 +44,9 @@ def reproject_interp(
             * An image HDU object such as a `~astropy.io.fits.PrimaryHDU`,
               `~astropy.io.fits.ImageHDU`, or `~astropy.io.fits.CompImageHDU`
               instance
+            * A tuple where the first element is an Numpy array shape tuple
+              the second element is either a `~astropy.wcs.WCS` or a
+              `~astropy.io.fits.Header` object
             * A tuple where the first element is a `~numpy.ndarray` and the
               second element is either a `~astropy.wcs.WCS` or a
               `~astropy.io.fits.Header` object

--- a/reproject/mosaicking/tests/test_wcs_helpers.py
+++ b/reproject/mosaicking/tests/test_wcs_helpers.py
@@ -181,9 +181,11 @@ class BaseTestOptimalWCS:
             "filename",
             "path",
             "hdulist",
+            "hdulist_all",
             "primary_hdu",
             "image_hdu",
             "comp_image_hdu",
+            "ape14_wcs",
             "shape_wcs_tuple",
             "data_wcs_tuple",
             "nddata",
@@ -216,18 +218,29 @@ class BaseTestOptimalWCS:
         elif input_type == "hdulist":
             input_value = hdulist
             hdu_in = 1
+        elif input_type == "hdulist_all":
+            # If a single HDUList is passed, the function will iterate over
+            # all HDUs. This test is only relevant in the non-iterable case
+            if iterable:
+                pytest.skip()
+            input_value = hdulist
         elif input_type == "primary_hdu":
             input_value = hdulist[0]
         elif input_type == "image_hdu":
             input_value = hdulist[1]
         elif input_type == "comp_image_hdu":
             input_value = hdulist[2]
+        elif input_type == "ape14_wcs":
+            input_value = self.wcs
+            input_value._naxis = list(shape_ref[::-1])
         elif input_type == "shape_wcs_tuple":
             input_value = (self.array.shape, self.wcs)
         elif input_type == "data_wcs_tuple":
             input_value = (self.array, self.wcs)
         elif input_type == "nddata":
             input_value = NDData(data=self.array, wcs=self.wcs)
+        else:
+            raise ValueError(f"Unknown mode: {input_type}")
 
         if iterable:
             input_value = [input_value]

--- a/reproject/mosaicking/tests/test_wcs_helpers.py
+++ b/reproject/mosaicking/tests/test_wcs_helpers.py
@@ -10,6 +10,8 @@ from astropy.wcs import WCS
 from astropy.wcs.wcsapi import HighLevelWCSWrapper
 from numpy.testing import assert_allclose, assert_equal
 
+from reproject.tests.helpers import assert_header_allclose
+
 from ..wcs_helpers import find_optimal_celestial_wcs
 
 try:
@@ -231,7 +233,10 @@ class BaseTestOptimalWCS:
             input_value = [input_value]
 
         wcs_test, shape_test = find_optimal_celestial_wcs(input_value, frame=FK5(), hdu_in=hdu_in)
-        assert wcs_test.to_header() == wcs_ref.to_header() and shape_test == shape_ref
+
+        assert_header_allclose(wcs_test.to_header(), wcs_ref.to_header())
+
+        assert shape_test == shape_ref
 
 
 class TestOptimalFITSWCS(BaseTestOptimalWCS):

--- a/reproject/mosaicking/tests/test_wcs_helpers.py
+++ b/reproject/mosaicking/tests/test_wcs_helpers.py
@@ -230,22 +230,23 @@ class TestOptimalAPE14WCS(TestOptimalFITSWCS):
 
 
 @pytest.mark.parametrize("iterable", [False, True])
-def test_input_types(valid_celestial_input, iterable):
-
+def test_input_types(valid_celestial_input_shapes, iterable):
     # Test different kinds of inputs and check the result is always the same
 
-    array, wcs, input_value, kwargs = valid_celestial_input
+    array, wcs, input_value, kwargs = valid_celestial_input_shapes
 
     wcs_ref, shape_ref = find_optimal_celestial_wcs([(array, wcs)], frame=FK5())
-
-    if isinstance(input_value, fits.HDUList) and iterable and kwargs == {}:
-        pytest.skip()
 
     if iterable:
         input_value = [input_value]
 
     wcs_test, shape_test = find_optimal_celestial_wcs(input_value, frame=FK5(), **kwargs)
-
     assert_header_allclose(wcs_test.to_header(), wcs_ref.to_header())
-
     assert shape_test == shape_ref
+
+    if isinstance(input_value, fits.HDUList) and not iterable:
+        # Also check case of not passing hdu_in and having all HDUs being included
+
+        wcs_test, shape_test = find_optimal_celestial_wcs(input_value, frame=FK5())
+        assert_header_allclose(wcs_test.to_header(), wcs_ref.to_header())
+        assert shape_test == shape_ref

--- a/reproject/spherical_intersect/high_level.py
+++ b/reproject/spherical_intersect/high_level.py
@@ -24,6 +24,9 @@ def reproject_exact(
             * An image HDU object such as a `~astropy.io.fits.PrimaryHDU`,
               `~astropy.io.fits.ImageHDU`, or `~astropy.io.fits.CompImageHDU`
               instance
+            * A tuple where the first element is an Numpy array shape tuple
+              the second element is either a `~astropy.wcs.WCS` or a
+              `~astropy.io.fits.Header` object
             * A tuple where the first element is a `~numpy.ndarray` and the
               second element is either a `~astropy.wcs.WCS` or a
               `~astropy.io.fits.Header` object

--- a/reproject/tests/helpers.py
+++ b/reproject/tests/helpers.py
@@ -1,4 +1,5 @@
 from astropy.io import fits
+from numpy.testing import assert_allclose
 
 
 def array_footprint_to_hdulist(array, footprint, header):
@@ -6,3 +7,13 @@ def array_footprint_to_hdulist(array, footprint, header):
     hdulist.append(fits.PrimaryHDU(array, header))
     hdulist.append(fits.ImageHDU(footprint, header, name="footprint"))
     return hdulist
+
+
+def assert_header_allclose(header1, header2, **kwargs):
+    assert sorted(header1) == sorted(header2)
+
+    for key1, value1 in header1.items():
+        if isinstance(value1, str):
+            assert value1 == header2[key1]
+        else:
+            assert_allclose(value1, header2[key1], **kwargs)

--- a/reproject/utils.py
+++ b/reproject/utils.py
@@ -1,4 +1,5 @@
 import tempfile
+from pathlib import Path
 from concurrent import futures
 
 import astropy.nddata
@@ -59,7 +60,7 @@ def parse_input_shape(input_shape, hdu_in=None):
     Parse input shape information to return an array shape tuple and WCS object.
     """
 
-    if isinstance(input_shape, str):
+    if isinstance(input_shape, (str, Path)):
         return parse_input_shape(fits.open(input_shape), hdu_in=hdu_in)
     elif isinstance(input_shape, HDUList):
         if hdu_in is None:

--- a/reproject/utils.py
+++ b/reproject/utils.py
@@ -9,7 +9,7 @@ import numpy as np
 from astropy.io import fits
 from astropy.io.fits import CompImageHDU, HDUList, Header, ImageHDU, PrimaryHDU
 from astropy.wcs import WCS
-from astropy.wcs.wcsapi import BaseLowLevelWCS, BaseHighLevelWCS, SlicedLowLevelWCS
+from astropy.wcs.wcsapi import BaseHighLevelWCS, BaseLowLevelWCS, SlicedLowLevelWCS
 from astropy.wcs.wcsapi.high_level_wcs_wrapper import HighLevelWCSWrapper
 from dask.utils import SerializableLock
 
@@ -26,7 +26,7 @@ def parse_input_data(input_data, hdu_in=None):
     Parse input data to return a Numpy array and WCS object.
     """
 
-    if isinstance(input_data, str):
+    if isinstance(input_data, (str, Path)):
         with fits.open(input_data) as hdul:
             return parse_input_data(hdul, hdu_in=hdu_in)
     elif isinstance(input_data, HDUList):

--- a/reproject/utils.py
+++ b/reproject/utils.py
@@ -9,7 +9,7 @@ import numpy as np
 from astropy.io import fits
 from astropy.io.fits import CompImageHDU, HDUList, Header, ImageHDU, PrimaryHDU
 from astropy.wcs import WCS
-from astropy.wcs.wcsapi import BaseHighLevelWCS, SlicedLowLevelWCS
+from astropy.wcs.wcsapi import BaseLowLevelWCS, BaseHighLevelWCS, SlicedLowLevelWCS
 from astropy.wcs.wcsapi.high_level_wcs_wrapper import HighLevelWCSWrapper
 from dask.utils import SerializableLock
 
@@ -46,6 +46,8 @@ def parse_input_data(input_data, hdu_in=None):
             return input_data[0], WCS(input_data[1])
         else:
             return input_data
+    elif isinstance(input_data, BaseLowLevelWCS) and input_data.array_shape is not None:
+        return input_data.array_shape, input_data
     elif isinstance(input_data, astropy.nddata.NDDataBase):
         return input_data.data, input_data.wcs
     else:
@@ -84,6 +86,8 @@ def parse_input_shape(input_shape, hdu_in=None):
             return input_shape[0], WCS(input_shape[1])
         else:
             return input_shape
+    elif isinstance(input_shape, BaseLowLevelWCS) and input_shape.array_shape is not None:
+        return input_shape.array_shape, input_shape
     elif isinstance(input_shape, astropy.nddata.NDDataBase):
         return input_shape.data.shape, input_shape.wcs
     else:

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ python_requires = >=3.8
 setup_requires = setuptools_scm
 install_requires =
   numpy>=1.20
-  astropy>=4.0
+  astropy>=5.0
   astropy-healpix>=0.6
   scipy>=1.5
   dask[array]>=2020

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ deps =
     numpy121: numpy==1.21.*
 
     oldestdeps: numpy==1.20.*
-    oldestdeps: astropy==4.0.*
+    oldestdeps: astropy==5.0.*
     oldestdeps: astropy-healpix==0.6
     oldestdeps: scipy==1.5.*
     oldestdeps: dask==2020.12.*


### PR DESCRIPTION
Still to do:

* [x] Make the generation of the different input types into a fixture and use it to check all the different reprojection functions
* [x] Properly test the case where a single HDUList is passed depending on whether hdu_in is specified or not
* [x] We could also support WCSes with APE 14 shapes specified (similar to https://github.com/astropy/reproject/issues/309)

Fixes https://github.com/astropy/reproject/issues/323