### PR TITLE
Started adding support for allowing dask arrays as input

### DIFF
--- a/reproject/array_utils.py
+++ b/reproject/array_utils.py
@@ -7,21 +7,23 @@ def map_coordinates(image, coords, **kwargs):
     # In the built-in scipy map_coordinates, the values are defined at the
     # center of the pixels. This means that map_coordinates does not
     # correctly treat pixels that are in the outer half of the outer pixels.
-    # We solve this by extending the array, updating the pixel coordinates,
-    # then getting rid of values that were sampled in the range -1 to -0.5
-    # and n to n - 0.5.
+    # We solve this by resetting any coordinates that are in the outer half of
+    # the border pixels to be at the center of the border pixels. We used to
+    # instead pad the array but this was not memory efficient as it ended up
+    # producing a copy of the output array.
 
     from scipy.ndimage import map_coordinates as scipy_map_coordinates
 
     original_shape = image.shape
 
+    # We copy the coordinates array as we then modify it in-place below
     coords = coords.copy()
-
     for i in range(coords.shape[0]):
         coords[i][(coords[i] < 0) & (coords[i] >= -0.5)] = 0
         coords[i][(coords[i] < original_shape[i] - 0.5) & (coords[i] >= original_shape[i] - 1)] = (
             original_shape[i] - 1
         )
+
     values = scipy_map_coordinates(image, coords, **kwargs)
 
     reset = np.zeros(coords.shape[1], dtype=bool)

--- a/reproject/array_utils.py
+++ b/reproject/array_utils.py
@@ -3,10 +3,6 @@ import numpy as np
 __all__ = ["map_coordinates"]
 
 
-def pad_edge_1(array):
-    return np.pad(array, 1, mode="edge")
-
-
 def map_coordinates(image, coords, **kwargs):
     # In the built-in scipy map_coordinates, the values are defined at the
     # center of the pixels. This means that map_coordinates does not
@@ -19,9 +15,14 @@ def map_coordinates(image, coords, **kwargs):
 
     original_shape = image.shape
 
-    image = pad_edge_1(image)
+    coords = coords.copy()
 
-    values = scipy_map_coordinates(image, coords + 1, **kwargs)
+    for i in range(coords.shape[0]):
+        coords[i][(coords[i] < 0) & (coords[i] >= -0.5)] = 0
+        coords[i][(coords[i] < original_shape[i] - 0.5) & (coords[i] >= original_shape[i] - 1)] = (
+            original_shape[i] - 1
+        )
+    values = scipy_map_coordinates(image, coords, **kwargs)
 
     reset = np.zeros(coords.shape[1], dtype=bool)
 

--- a/reproject/conftest.py
+++ b/reproject/conftest.py
@@ -7,6 +7,7 @@ import os
 
 import numpy as np
 import pytest
+import dask.array as da
 from astropy.io import fits
 from astropy.nddata import NDData
 from astropy.wcs import WCS
@@ -132,6 +133,8 @@ def valid_celestial_input(tmp_path, request, wcs):
         input_value = (array.shape, wcs)
     elif request.param == "data_wcs_tuple":
         input_value = (array, wcs)
+    elif request.param == "dask_wcs_tuple":
+        input_value = (da.from_array(array), wcs)
     elif request.param == "nddata":
         input_value = NDData(data=array, wcs=wcs)
     elif request.param == "wcs":
@@ -153,6 +156,7 @@ COMMON_PARAMS = [
     "image_hdu",
     "comp_image_hdu",
     "data_wcs_tuple",
+    "dask_wcs_tuple",
     "nddata",
 ]
 

--- a/reproject/conftest.py
+++ b/reproject/conftest.py
@@ -5,9 +5,9 @@
 
 import os
 
+import dask.array as da
 import numpy as np
 import pytest
-import dask.array as da
 from astropy.io import fits
 from astropy.nddata import NDData
 from astropy.wcs import WCS

--- a/reproject/interpolation/high_level.py
+++ b/reproject/interpolation/high_level.py
@@ -1,8 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import os
 
-from dask import array as da
 from astropy.utils import deprecated_renamed_argument
+from dask import array as da
 
 from ..utils import _reproject_blocked, parse_input_data, parse_output_projection
 from .core import _reproject_full

--- a/reproject/interpolation/high_level.py
+++ b/reproject/interpolation/high_level.py
@@ -2,7 +2,6 @@
 import os
 
 from astropy.utils import deprecated_renamed_argument
-from dask import array as da
 
 from ..utils import _reproject_blocked, parse_input_data, parse_output_projection
 from .core import _reproject_full

--- a/reproject/interpolation/high_level.py
+++ b/reproject/interpolation/high_level.py
@@ -117,9 +117,6 @@ def reproject_interp(
     if isinstance(order, str):
         order = ORDER[order]
 
-    if isinstance(array_in, da.core.Array) and block_size is None:
-        block_size = array_in.chunksize
-
     # if either of these are not default, it means a blocked method must be used
     if block_size is not None or parallel is not False:
         return _reproject_blocked(

--- a/reproject/interpolation/high_level.py
+++ b/reproject/interpolation/high_level.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import os
 
+from dask import array as da
 from astropy.utils import deprecated_renamed_argument
 
 from ..utils import _reproject_blocked, parse_input_data, parse_output_projection
@@ -115,6 +116,9 @@ def reproject_interp(
 
     if isinstance(order, str):
         order = ORDER[order]
+
+    if isinstance(array_in, da.core.Array) and block_size is None:
+        block_size = array_in.chunksize
 
     # if either of these are not default, it means a blocked method must be used
     if block_size is not None or parallel is not False:

--- a/reproject/tests/test_array_utils.py
+++ b/reproject/tests/test_array_utils.py
@@ -1,0 +1,42 @@
+import numpy as np
+from numpy.testing import assert_allclose
+from scipy.ndimage import map_coordinates as scipy_map_coordinates
+
+from reproject.array_utils import map_coordinates
+
+
+def test_custom_map_coordinates():
+    np.random.seed(1249)
+
+    data = np.random.random((3, 4))
+
+    coords = np.random.uniform(-2, 6, (2, 10000))
+
+    expected = scipy_map_coordinates(
+        np.pad(data, 1, mode="edge"),
+        coords + 1,
+        order=1,
+        cval=np.nan,
+        mode="constant",
+    )
+
+    reset = np.zeros(coords.shape[1], dtype=bool)
+
+    for i in range(coords.shape[0]):
+        reset |= coords[i] < -0.5
+        reset |= coords[i] > data.shape[i] - 0.5
+
+    expected[reset] = np.nan
+
+    result = map_coordinates(
+        data,
+        coords,
+        order=1,
+        cval=np.nan,
+        mode="constant",
+    )
+
+    for i in range(coords.shape[1]):
+        print(coords[:, i], expected[i], result[i])
+
+    assert_allclose(result, expected)

--- a/reproject/tests/test_utils.py
+++ b/reproject/tests/test_utils.py
@@ -16,6 +16,7 @@ def test_parse_input_data(tmpdir, valid_celestial_input_data, request):
     array_ref, wcs_ref, input_value, kwargs = valid_celestial_input_data
 
     data, wcs = parse_input_data(input_value, **kwargs)
+    assert isinstance(data, np.ndarray)
     np.testing.assert_allclose(data, array_ref)
     assert_wcs_allclose(wcs, wcs_ref)
 

--- a/reproject/utils.py
+++ b/reproject/utils.py
@@ -304,8 +304,6 @@ def _reproject_blocked(
 
     shape_in = array_in.shape
 
-    dask_input = isinstance(array_in, da.core.Array)
-
     # When in parallel mode, we want to make sure we avoid having to copy the
     # input array to all processes for each chunk, so instead we write out
     # the input array to a Numpy memory map and load it in inside each process
@@ -318,7 +316,6 @@ def _reproject_blocked(
             array_in_or_path, dtype=float, shape=array_in.shape, mode="w+"
         )
         array_in_memmapped[:] = array_in[:]
-
     else:
         array_in_or_path = array_in
 

--- a/reproject/utils.py
+++ b/reproject/utils.py
@@ -84,7 +84,7 @@ def parse_input_shape(input_shape, hdu_in=None):
         return parse_input_shape(input_shape[hdu_in])
     elif isinstance(input_shape, (PrimaryHDU, ImageHDU, CompImageHDU)):
         return input_shape.shape, WCS(input_shape.header)
-    elif isinstance(input_shape, tuple) and isinstance(input_shape[0], np.ndarray):
+    elif isinstance(input_shape, tuple) and isinstance(input_shape[0], (np.ndarray, da.core.Array)):
         if isinstance(input_shape[1], Header):
             return input_shape[0].shape, WCS(input_shape[1])
         else:


### PR DESCRIPTION
This PR adds support for specifying the input data as a dask array - this covers only the general case mentioned in  https://github.com/astropy/reproject/issues/362 of **Input where all dimensions are to be reprojected**

As mentioned in #362, the general case requires us to write out the dask array to disk and reload it as a Numpy memmap array. There will be ways of making common use cases more efficient as outlined in #362 but for now this PR implements the general approach.