### PR TITLE
Add a new 'all' extras for shapely

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,10 +27,12 @@ install_requires =
   fsspec
 
 [options.extras_require]
+all =
+    shapely
 test =
     pytest-astropy
 testall =
-    shapely;sys_platform!='win32' and python_version!='3.8'
+    shapely
     sunpy[map]>=2.1;platform_machine!='i686'
     asdf
     gwcs


### PR DESCRIPTION
Looks like they have wheels for all platforms now so we could even require it in future - but for now just at least making an 'all' extras