### PR TITLE
Add despike_jacobian option for adaptive resampling

### DIFF
--- a/docs/celestial.rst
+++ b/docs/celestial.rst
@@ -243,6 +243,20 @@ points. This is more efficient, and the loss of accuracy is extremely small for
 transformations that vary smoothly between pixels. The default (``False``) is
 to use the faster option.
 
+In some situations (e.g. an all-sky map, with a wrap point in the longitude),
+extremely large Jacobian values may be computed which are artifacts of the
+coordinate system definition, rather than reflecting the actual nature of the
+coordinate transformation. This may result in a band of ``nan`` pixels in the
+output image. In these situations, if the actual transformation is
+approximately constant in the region of these artifacts, the
+``despike_jacobian`` option should be enabled. If enabled, the typical
+magnitude (distance from the determinant) of the Jacobian matrix, ``Jmag2 =
+sum_j sum_i (J_ij**2)``, is computed for each pixel and compared to the 25th
+percentile of that value in the local 3x3 neighborhood (i.e. the third-lowest
+value). If it exceeds that percentile value by more than 10 times, the Jacobian
+matrix is deemed to be "spiking" and it is replaced by the average of the
+non-spiking values in the 3x3 neighborhood.
+
 When, for any one output pixel, the sampling region in the input image
 straddles the boundary of the input image or lies entirely outside the input
 image, a range of boundary modes can be applied, and this is set with the

--- a/reproject/adaptive/core.py
+++ b/reproject/adaptive/core.py
@@ -32,6 +32,7 @@ def _reproject_adaptive_2d(
     shape_out,
     return_footprint=True,
     center_jacobian=False,
+    despike_jacobian=False,
     roundtrip_coords=True,
     conserve_flux=False,
     kernel="Gaussian",
@@ -62,6 +63,8 @@ def _reproject_adaptive_2d(
         Whether to return the footprint in addition to the output array.
     center_jacobian : bool
         Whether to compute centered Jacobians
+    despike_jacobian : bool
+        Whether to despike the Jacobians
     roundtrip_coords : bool
         Whether to veryfiy that coordinate transformations are defined in both
         directions.
@@ -97,13 +100,6 @@ def _reproject_adaptive_2d(
     .. [1] C. E. DeForest, "On Re-sampling of Solar Images"
        Solar Physics volume 219, pages 3–23 (2004),
        https://doi.org/10.1023/B:SOLA.0000021743.24248.b0
-
-    Warnings
-    --------
-    Coordinates that lie exactly on the edge of an all-sky map may be subject
-    to numerical issues, causing a band of NaN values around the edge of the
-    final image (when reprojecting from helioprojective to heliographic).
-    See https://github.com/astropy/reproject/issues/195 for more information.
 
     Note
     ----
@@ -156,6 +152,7 @@ def _reproject_adaptive_2d(
         transformer,
         out_of_range_nan=True,
         center_jacobian=center_jacobian,
+        despiked_jacobian=despike_jacobian,
         conserve_flux=conserve_flux,
         kernel=kernel,
         kernel_width=kernel_width,

--- a/reproject/adaptive/high_level.py
+++ b/reproject/adaptive/high_level.py
@@ -13,6 +13,7 @@ def reproject_adaptive(
     hdu_in=0,
     return_footprint=True,
     center_jacobian=False,
+    despike_jacobian=False,
     roundtrip_coords=True,
     conserve_flux=False,
     kernel="gaussian",
@@ -82,6 +83,22 @@ def reproject_adaptive(
         efficient, and the loss of accuracy is extremely small for
         transformations that vary smoothly between pixels. Defaults to
         ``False``.
+    despike_jacobian : bool
+        Whether to despike the computed Jacobian values. In some situations
+        (e.g. an all-sky map, with a wrap point in the longitude), extremely
+        large Jacobian values may be computed which are artifacts of the
+        coordinate system definition, rather than reflecting the actual nature
+        of the coordinate transformation. This may result in a band of ``nan``
+        pixels in the output image. In these situations, if the actual
+        transformation is approximately constant in the region of these
+        artifacts, this option should be enabled. If enabled, the typical
+        magnitude (distance from the determinant) of the Jacobian matrix,
+        ``Jmag2 = sum_j sum_i (J_ij**2)``, is computed for each pixel and
+        compared to the 25th percentile of that value in the local 3x3
+        neighborhood (i.e. the third-lowest value). If it exceeds that
+        percentile value by more than 10 times, the Jacobian matrix is deemed
+        to be "spiking" and it is replaced by the average of the non-spiking
+        values in the 3x3 neighborhood.
     roundtrip_coords : bool
         Whether to verify that coordinate transformations are defined in both
         directions.
@@ -135,7 +152,7 @@ def reproject_adaptive(
               ``boundary_ignore_threshold`` argument. In that case, acts as
               ``strict``.
             * ``nearest`` --- Samples outside the input image are replaced by
-              the nearst in-bounds input pixel.
+              the nearest in-bounds input pixel.
 
     boundary_fill_value : double
         The constant value used by the ``constant`` boundary mode.
@@ -172,6 +189,7 @@ def reproject_adaptive(
         shape_out,
         return_footprint=return_footprint,
         center_jacobian=center_jacobian,
+        despike_jacobian=despike_jacobian,
         roundtrip_coords=roundtrip_coords,
         conserve_flux=conserve_flux,
         kernel=kernel,


### PR DESCRIPTION
This adds an option to smooth over numerical quirkiness when, for example, the longitude wraps around in an all-sky map. The quirk occurs when computing the Jacobian, which is d(input-image pixel) / d(output-image pixel). This is done by finite differences, so when the input coordinates jump from one side of the map to the other, the Jacobian comes out extremely large, despite the actual transformation being unremarkable at that location. The new option looks for outlier Jacobian values, measured relative to a 3x3 local neighborhood, and replaces those outliers with a mean of the non-outlier values in the neighborhood.

Before this PR, the extremely-large Jacobian would cause the input-image region that is to be sampled to be extremely large---larger than a safety-valve threshold in the code that just outputs a `nan` for that output pixel. This caused a band of `nans` near the wrap-point's location in the output image. With this change, that seam is handled correctly.

Looks like this might close #195.

```python
starfield_sample, _ = reproject.reproject_adaptive(
    (all_sky_map, all_sky_wcs), data_wcs, data.shape,
    x_cyclic=True, despike_jacobian=False)
starfield_sample_despiked, _ = reproject.reproject_adaptive(
    (all_sky_map, all_sky_wcs), data_wcs, data.shape,
    x_cyclic=True, despike_jacobian=True)

plt.figure(figsize=(10,5))
plt.subplot(121, projection=data_wcs)
plt.imshow(np.isnan(starfield_sample))
plt.title("np.isnan(starfield_sample)")

plt.subplot(122, projection=data_wcs)
plt.imshow(np.isnan(starfield_sample_despiked))
plt.title("np.isnan(starfield_sample_despiked)")
```
![image](https://github.com/astropy/reproject/assets/23462789/9495555b-b8ad-4613-8eb4-3091c29139b1)