### PR TITLE
Dask support improvements

### DIFF
--- a/reproject/utils.py
+++ b/reproject/utils.py
@@ -27,6 +27,11 @@ def _dask_to_numpy_memmap(dask_array):
     memmap array.
     """
 
+    # Sometimes compute() has to be called twice to return a Numpy array,
+    # so we need to check here if this is the case and call the first compute()
+    if isinstance(dask_array.ravel()[0].compute(), da.Array):
+        dask_array = dask_array.compute()
+
     with tempfile.TemporaryDirectory() as zarr_tmp:
         # First compute and store the dask array to zarr using whatever
         # the default scheduler is at this point
@@ -340,7 +345,10 @@ def _reproject_blocked(
 
     # NOTE: the following array is just used to set up the iteration in map_blocks
     # but isn't actually used otherwise - this is deliberate.
-    output_array_dask = da.empty(shape_out, chunks=block_size or "auto")
+    if block_size:
+        output_array_dask = da.empty(shape_out, chunks=block_size)
+    else:
+        output_array_dask = da.empty(shape_out).rechunk(block_size_limit=8 * 1024**2)
 
     result = da.map_blocks(
         reproject_single_block,


### PR DESCRIPTION
This is a work in progress as I try and improve the performance of the parallelization

Issues I'm still seeing:

* When using the progress bar, for some reason it stays stuck at low values and then very quickly fills up to 100%, whereas normally to_zarr should really just operate chunk by chunk. This might be to do with returning the footprint and array and also the trimming of the image, which might add a layer of chunks to the whole thing. To be investigated.
* We should really clean up *all* temp files as it's easy to fill one's /tmp directory otherwise

Performance notes:

* I have tried reprojecting a (32000, 8600) array to a similar WCS and when using parallel mode, it is quite a bit faster (56 seconds with 16 processes, instead of 4m26s in synchronous mode). When using (2048, 2048) chunks, using 4 processes (... s) is almost as fast as 16 processes (1m26s instead of 56s). Using (4096, 4096) chunks (to try and reduce overhead) actually makes things slower for 16 processes, presumably because it's not an efficient division of the data. Using (1024, 1024) chunks makes things a little faster (52s) with 16 processes. Using (512, 512) chunks makes things a little faster still (49s), and going all the way down to (256, 256) is surprisingly still ok (49s).

* Using dask-distributed works well but one needs (for now) to change:

```python
        if isinstance(parallel, int):
            workers = {"num_workers": parallel}
        else:
            workers = {}
        with dask.config.set(scheduler="processes", **workers):
            result.to_zarr(filename)
```

to

```python
        result.to_zarr(filename)
```

With these changes, using 16 single-threaded local workers and the above large array example, with (1024, 1024) chunks, the runtime is 1 minute (compared to 52s with the regular processes scheduler). With (2048, 2048) chunks, the runtime is 1m6s, so similar. It would be interesting to try out an example with multiple machines to see how efficient the network communication is.

* I'm struggling to get more than a factor of 2x improvement in performance with @Cadair's DKIST coadd example, which might be due to the size of the images (4096, 4096). This does make me wonder whether we might want to consider having a separate parallelization implementation in the coadd function, with one image per process rather than trying to split it up. I don't fully understand why I can't get better than 2x improvement though. In synchronous mode, and with (512, 512) chunks, the code takes 1m22s whereas with 16 processes it takes 45s. If I replace:

```python
        array, footprint = reproject_func(
            array_in, wcs_in, wcs_out_sub, block_info[None]["chunk-shape"][1:]
        )
```

with

```python
        array = np.random.random(block_info[None]["chunk-shape"][1:])
        footprint = np.random.random(block_info[None]["chunk-shape"][1:])
```

inside ``reproject_single_block``, the synchronous mode takes 13s, and parallel with 16 processes takes 15s, so that gives us an idea of the overhead of the chunking itself before any reprojection. Taking that into account, the main parallelizable part of the code then takes 30s in parallel compared to 1m07s, so still not massively faster.

* One weird thing I've seen with @Cadair's example mentioned above is that the individual processes seem to use >> 100% each, so for some reason something is multi-threaded and I can't figure out what it is. This could explain why it's hard to get significant performance improvements with more processes. I don't see this issue with the large mosaic example I was trying out, all processes max out at 100%. If I load up @Cadair's example using the FITS files directly I don't see this issue, all processes max out at 100%. If I use the same example again but changing *just* the WCS to the GWCSes and keep the data as numpy arrays read in from the FITS files, I see the multi-threading again.
 
TODOs:

* [ ] Figure out how to properly support dask distributed without having to comment out the above code. Perhaps we need a way to pass in a scheduler, though we need to warn people not to use multi-threaded schedulers since those can cause issues with some of the reprojection algorithms.
* [ ] Make it possible to return dask arrays from ``reproject_interp``