### PR TITLE
Refactor blocked/parallel reprojection

### DIFF
--- a/docs/celestial.rst
+++ b/docs/celestial.rst
@@ -385,12 +385,9 @@ reprojection using the spherical polygon intersection of input and output pixels
 
     >>> from reproject import reproject_exact
 
-In addition to the arguments described in :ref:`common`, an optional
-``parallel=`` option can be used to control whether to parallelize the
-reprojection, and if so how many cores to use (see
-:func:`~reproject.reproject_exact` for more details). For this algorithm, the
-footprint array returned gives the exact fractional overlap of new pixels with
-the original image (see :doc:`footprints` for more details).
+For this algorithm, the footprint array returned gives the exact fractional
+overlap of new pixels with the original image (see :doc:`footprints` for more
+details).
 
 .. warning:: The :func:`~reproject.reproject_exact` is currently known to
              have precision issues for images with resolutions <0.05". For

--- a/docs/dask.rst
+++ b/docs/dask.rst
@@ -1,0 +1,108 @@
+Integration with dask and parallel processing
+=============================================
+
+The following functions all integrate well with the `dask <https://www.dask.org/>`_ library.
+
+* :func:`~reproject.reproject_interp`
+* :func:`~reproject.reproject_adaptive`
+* :func:`~reproject.reproject_exact`
+
+This integration has several aspects that we will discuss in the following sections.
+
+.. testsetup::
+
+    >>> import numpy as np
+    >>> import dask.array as da
+    >>> input_array = np.random.random((1024, 1024))
+    >>> dask_array = da.from_array(input_array, chunks=(128, 128))
+    >>> from astropy.wcs import WCS
+    >>> wcs_in = WCS(naxis=2)
+    >>> wcs_out = WCS(naxis=2)
+
+Input dask arrays
+-----------------
+
+The three reprojection functions mentioned above can accept dask arrays as
+inputs, e.g. assuming you have already constructed a dask array named
+``dask_array``::
+
+    >>> dask_array
+    dask.array<array, shape=(1024, 1024), dtype=float64, chunksize=(128, 128), chunktype=numpy.ndarray>
+
+you can pass this in as part of the first argument to one of the reprojection
+functions::
+
+    >>> from reproject import reproject_interp
+    >>> array, footprint = reproject_interp((dask_array, wcs_in), wcs_out,
+    ...                                     shape_out=(2048, 2048))
+
+In general however, we cannot benefit much from the chunking of the input arrays
+because any input pixel might in principle contribute to any output pixel.
+Therefore, for now, when a dask array is passed as input, it is computed using
+the current default scheduler and converted to a Numpy memory-mapped array. This
+is done efficiently in terms of memory and never results in the whole dataset
+being loaded into memory at any given time. However, this does require
+sufficient space on disk to store the array.
+
+Chunk by chunk reprojection and parallel processing
+---------------------------------------------------
+
+Regardless of whether a dask or Numpy array is passed in as input to the
+reprojection functions, you can specify a block size to use for the
+reprojection, and this is used to iterate over chunks in the output array in
+chunks. For instance, if you pass in a (1024, 1024) array and specify that the
+shape of the output should be a (2048, 2048) array (e.g., via ``shape_out``),
+then if you set ``block_size=(256, 256)``::
+
+    >>> input_array.shape
+    (1024, 1024)
+    >>> array, footprint = reproject_interp((input_array, wcs_in), wcs_out,
+    ...                                     shape_out=(2048, 2048), block_size=(256, 256))
+
+the reprojection will be done in 64 separate output chunks. Note however that
+this does not break up the input array into chunks since in the general case any
+input pixel may contribute to any output pixel.
+
+By default, the iteration over the output chunks is done in a single
+process/thread, but you may specify ``parallel=True`` to process these in
+parallel. If you do this, reproject will use multiple processes (rather than
+threads) to parallelize the computation (this is because the core reprojection
+algorithms we use are not currently thread-safe). If you specify
+``parallel=True``, then ``block_size`` will be automatically set to a sensible
+default, but you can also set ``block_size`` manually for more control. Note
+that you can also set ``parallel=`` to an integer to indicate the number of
+processes to use.
+
+Output dask arrays
+------------------
+
+By default, the reprojection functions will do the computation immmediately and
+return Numpy arrays for the reprojected array and optionally the footprint (this
+is regardless of whether dask or Numpy arrays were passed in, or any of the
+parallelization options above). However, by setting ``return_type='dask'``, you
+can make the functions delay any computation and return dask arrays::
+
+    >>> array, footprint = reproject_interp((input_array, wcs_in), wcs_out,
+    ...                                     shape_out=(2048, 2048), block_size=(256, 256),
+    ...                                     return_type='dask')
+    >>> array
+    dask.array<getitem, shape=(2048, 2048), dtype=float64, chunksize=(256, 256), ...>
+
+You can then compute the array or a section of the array yourself whenever you need, or use the
+result in further dask expressions.
+
+.. warning:: The reprojection does not currently work reliably when using multiple threads, so
+             it is important to make sure you use a dask scheduler that is not multi-threaded.
+             At the time of writing, the default dask scheduler is ``threads``, so the scheduler
+             needs to be explicitly set to a different one.
+
+Using dask.distributed
+----------------------
+
+The `dask.distributed <https://distributed.dask.org/en/stable/>`_ package makes it
+possible to use distributed schedulers for dask. In order to compute
+reprojections with dask.distributed, you should make use of the
+``return_type='dask'`` option mentioned above so that you can compute the dask
+array once the distributed scheduler has been set up. As mentioned in `Output
+dask arrays`_, you should make sure that you limit any cluster to have one
+thread per process or the results may be unreliable.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -137,6 +137,7 @@ that you want to reproject.
    noncelestial
    footprints
    mosaicking
+   dask
 
 Reference/API
 =============

--- a/reproject/adaptive/core.py
+++ b/reproject/adaptive/core.py
@@ -30,6 +30,8 @@ def _reproject_adaptive_2d(
     wcs_in,
     wcs_out,
     shape_out,
+    array_out=None,
+    output_footprint=None,
     return_footprint=True,
     center_jacobian=False,
     despike_jacobian=False,
@@ -130,8 +132,11 @@ def _reproject_adaptive_2d(
     if extra_dimens_in != extra_dimens_out:
         raise ValueError("Dimensions to be looped over must match exactly")
 
-    # Create output array
-    array_out = np.zeros(shape_out)
+    if array_out is None:
+        array_out = np.empty(shape_out)
+
+    if output_footprint is None:
+        output_footprint = np.empty(shape_out)
 
     if len(array_in.shape) == wcs_in.low_level_wcs.pixel_n_dim:
         # We don't need to broadcast the transformation over any extra
@@ -167,6 +172,7 @@ def _reproject_adaptive_2d(
     array_out.shape = shape_out
 
     if return_footprint:
-        return array_out, (~np.isnan(array_out)).astype(float)
+        output_footprint[:] = (~np.isnan(array_out)).astype(float)
+        return array_out, output_footprint
     else:
         return array_out

--- a/reproject/adaptive/high_level.py
+++ b/reproject/adaptive/high_level.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+from ..common import _reproject_dispatcher
 from ..utils import parse_input_data, parse_output_projection
 from .core import _reproject_adaptive_2d
 
@@ -11,7 +12,12 @@ def reproject_adaptive(
     output_projection,
     shape_out=None,
     hdu_in=0,
+    output_array=None,
     return_footprint=True,
+    output_footprint=None,
+    block_size=None,
+    parallel=False,
+    return_type=None,
     center_jacobian=False,
     despike_jacobian=False,
     roundtrip_coords=True,
@@ -182,22 +188,30 @@ def reproject_adaptive(
         output_projection, shape_in=array_in.shape, shape_out=shape_out
     )
 
-    return _reproject_adaptive_2d(
-        array_in,
-        wcs_in,
-        wcs_out,
-        shape_out,
+    return _reproject_dispatcher(
+        _reproject_adaptive_2d,
+        array_in=array_in,
+        wcs_in=wcs_in,
+        wcs_out=wcs_out,
+        shape_out=shape_out,
+        array_out=output_array,
+        parallel=parallel,
+        block_size=block_size,
         return_footprint=return_footprint,
-        center_jacobian=center_jacobian,
-        despike_jacobian=despike_jacobian,
-        roundtrip_coords=roundtrip_coords,
-        conserve_flux=conserve_flux,
-        kernel=kernel,
-        kernel_width=kernel_width,
-        sample_region_width=sample_region_width,
-        boundary_mode=boundary_mode,
-        boundary_fill_value=boundary_fill_value,
-        boundary_ignore_threshold=boundary_ignore_threshold,
-        x_cyclic=x_cyclic,
-        y_cyclic=y_cyclic,
+        output_footprint=output_footprint,
+        reproject_func_kwargs=dict(
+            center_jacobian=center_jacobian,
+            despike_jacobian=despike_jacobian,
+            roundtrip_coords=roundtrip_coords,
+            conserve_flux=conserve_flux,
+            kernel=kernel,
+            kernel_width=kernel_width,
+            sample_region_width=sample_region_width,
+            boundary_mode=boundary_mode,
+            boundary_fill_value=boundary_fill_value,
+            boundary_ignore_threshold=boundary_ignore_threshold,
+            x_cyclic=x_cyclic,
+            y_cyclic=y_cyclic,
+        ),
+        return_type=return_type,
     )

--- a/reproject/common.py
+++ b/reproject/common.py
@@ -224,10 +224,13 @@ def _reproject_dispatcher(
             if wcs_in.low_level_wcs.pixel_n_dim < len(shape_out):
                 chunks = (-1,) * (len(shape_out) - wcs_in.low_level_wcs.pixel_n_dim)
                 chunks += ("auto",) * wcs_in.low_level_wcs.pixel_n_dim
+                rechunk_kwargs = {"chunks": chunks}
             else:
-                chunks = None
+                rechunk_kwargs = {}
             array_out_dask = da.empty(shape_out)
-            array_out_dask = array_out_dask.rechunk(block_size_limit=8 * 1024**2, chunks=chunks)
+            array_out_dask = array_out_dask.rechunk(
+                block_size_limit=8 * 1024**2, **rechunk_kwargs
+            )
 
         result = da.map_blocks(
             reproject_single_block,

--- a/reproject/common.py
+++ b/reproject/common.py
@@ -127,7 +127,7 @@ def _reproject_dispatcher(
                     "been specified"
                 )
 
-            if isinstance(array_in.data, da.core.Array):
+            if isinstance(array_in, da.core.Array):
                 _, array_in = _dask_to_numpy_memmap(array_in, tmp_dir)
 
             return reproject_func(
@@ -234,7 +234,10 @@ def _reproject_dispatcher(
             # to be done in parallel.
 
             if isinstance(parallel, int):
-                workers = {"num_workers": parallel}
+                if parallel > 0:
+                    workers = {"num_workers": parallel}
+                else:
+                    raise ValueError("The number of processors to use must be strictly positive")
             else:
                 workers = {}
 

--- a/reproject/common.py
+++ b/reproject/common.py
@@ -107,7 +107,11 @@ def _reproject_dispatcher(
             raise ValueError(
                 f"Output array shape {array_out.shape} should match " f"shape_out={shape_out}"
             )
-        elif array_out.dtype != array_in.dtype:
+        elif (array_out.dtype.kind, array_out.dtype.itemsize) != (
+            array_in.dtype.kind,
+            array_in.dtype.itemsize,
+        ):
+            # Note that here we don't care if the endians don't match
             raise ValueError(
                 f"Output array dtype {array_out.dtype} should match "
                 f"input array dtype ({array_in.dtype})"

--- a/reproject/common.py
+++ b/reproject/common.py
@@ -1,0 +1,159 @@
+import tempfile
+
+import dask
+import dask.array as da
+import numpy as np
+from astropy.wcs.wcsapi import BaseHighLevelWCS, SlicedLowLevelWCS
+from astropy.wcs.wcsapi.high_level_wcs_wrapper import HighLevelWCSWrapper
+
+__all__ = ['_reproject_dispatcher']
+
+
+def _reproject_dispatcher(
+    reproject_func,
+    array_in,
+    wcs_in,
+    shape_out,
+    wcs_out,
+    block_size,
+    output_array=None,
+    return_footprint=True,
+    output_footprint=None,
+    parallel=True,
+):
+    """
+    Main function that handles either calling the core algorithms directly or
+    parallelizing or operating in chunks, using dask.
+
+    Parameters
+    ----------
+    reproject_func
+        One the existing reproject functions implementing a reprojection algorithm
+        that that will be used be used to perform reprojection
+    array_in
+        Data following the same format as expected by underlying reproject_func,
+        expected to `~numpy.ndarray` when used from _reproject_blocked()
+    wcs_in: `~astropy.wcs.WCS`
+        WCS object corresponding to array_in
+    shape_out: tuple
+        Passed to reproject_func() alongside WCS out to determine image size
+    wcs_out: `~astropy.wcs.WCS`
+        Output WCS image will be projected to. Normally will correspond to subset of
+        total output image when used by _reproject_blocked()
+    block_size: tuple
+        The size of blocks in terms of output array pixels that each block will handle
+        reprojecting. Extending out from (0,0) coords positively, block sizes
+        are clamped to output space edges when a block would extend past edge
+    output_array : None or `~numpy.ndarray`
+        An array in which to store the reprojected data.  This can be any numpy
+        array including a memory map, which may be helpful when dealing with
+        extremely large files.
+    return_footprint : bool
+        Whether to return the footprint in addition to the output array.
+    output_footprint : None or `~numpy.ndarray`
+        An array in which to store the footprint of reprojected data.  This can be
+        any numpy array including a memory map, which may be helpful when dealing with
+        extremely large files.
+    parallel : bool or int
+        Flag for parallel implementation. If ``True``, a parallel implementation
+        is chosen, the number of processes selected automatically to be equal to
+        the number of logical CPUs detected on the machine. If ``False``, a
+        serial implementation is chosen. If the flag is a positive integer ``n``
+        greater than one, a parallel implementation using ``n`` processes is chosen.
+    """
+
+    if output_array is None:
+        output_array = np.zeros(shape_out, dtype=float)
+    if output_footprint is None and return_footprint:
+        output_footprint = np.zeros(shape_out, dtype=float)
+
+    if block_size is not None and len(block_size) < len(shape_out):
+        block_size = [-1] * (len(shape_out) - len(block_size)) + list(block_size)
+
+    shape_in = array_in.shape
+
+    # When in parallel mode, we want to make sure we avoid having to copy the
+    # input array to all processes for each chunk, so instead we write out
+    # the input array to a Numpy memory map and load it in inside each process
+    # as a memory-mapped array. We need to be careful how this gets passed to
+    # reproject_single_block so we pass a variable that can be either a string
+    # or the array itself (for synchronous mode).
+    if parallel:
+        array_in_or_path = tempfile.mktemp()
+        array_in_memmapped = np.memmap(
+            array_in_or_path, dtype=float, shape=array_in.shape, mode="w+"
+        )
+        array_in_memmapped[:] = array_in[:]
+    else:
+        array_in_or_path = array_in
+
+    def reproject_single_block(a, block_info=None):
+        if a.ndim == 0 or block_info is None or block_info == []:
+            return np.array([a, a])
+        slices = [slice(*x) for x in block_info[None]["array-location"][-wcs_out.pixel_n_dim :]]
+
+        if isinstance(wcs_out, BaseHighLevelWCS):
+            low_level_wcs = SlicedLowLevelWCS(wcs_out.low_level_wcs, slices=slices)
+        else:
+            low_level_wcs = SlicedLowLevelWCS(wcs_out, slices=slices)
+        wcs_out_sub = HighLevelWCSWrapper(low_level_wcs)
+        if isinstance(array_in_or_path, str):
+            array_in = np.memmap(array_in_or_path, dtype=float, shape=shape_in)
+        else:
+            array_in = array_in_or_path
+        array, footprint = reproject_func(
+            array_in, wcs_in, wcs_out_sub, block_info[None]["chunk-shape"][1:]
+        )
+        return np.array([array, footprint])
+
+    # NOTE: the following array is just used to set up the iteration in map_blocks
+    # but isn't actually used otherwise - this is deliberate.
+    if block_size:
+        output_array_dask = da.empty(shape_out, chunks=block_size)
+    else:
+        output_array_dask = da.empty(shape_out).rechunk(block_size_limit=8 * 1024**2)
+
+    result = da.map_blocks(
+        reproject_single_block,
+        output_array_dask,
+        dtype=float,
+        new_axis=0,
+        chunks=(2,) + output_array_dask.chunksize,
+    )
+
+    # Truncate extra elements
+    result = result[tuple([slice(None)] + [slice(s) for s in shape_out])]
+
+    if parallel:
+        # As discussed in https://github.com/dask/dask/issues/9556, da.store
+        # will not work well in multiprocessing mode when the destination is a
+        # Numpy array. Instead, in this case we save the dask array to a zarr
+        # array on disk which can be done in parallel, and re-load it as a dask
+        # array. We can then use da.store in the next step using the
+        # 'synchronous' scheduler since that is I/O limited so does not need
+        # to be done in parallel.
+        filename = tempfile.mktemp()
+        if isinstance(parallel, int):
+            workers = {"num_workers": parallel}
+        else:
+            workers = {}
+        with dask.config.set(scheduler="processes", **workers):
+            result.to_zarr(filename)
+        result = da.from_zarr(filename)
+
+    if return_footprint:
+        da.store(
+            [result[0], result[1]],
+            [output_array, output_footprint],
+            compute=True,
+            scheduler="synchronous",
+        )
+        return output_array, output_footprint
+    else:
+        da.store(
+            result[0],
+            output_array,
+            compute=True,
+            scheduler="synchronous",
+        )
+        return output_array

--- a/reproject/interpolation/core.py
+++ b/reproject/interpolation/core.py
@@ -47,24 +47,6 @@ def _validate_wcs(wcs_in, wcs_out, shape_in, shape_out):
             raise ValueError("Output WCS has a spectral component but input WCS does not")
 
 
-def _validate_array_out(array_out, array, shape_out):
-    if array_out is None:
-        return
-
-    if array_out.shape != tuple(shape_out):
-        raise ValueError(
-            "Array sizes don't match.  Output array shape "
-            "should be {}".format(str(tuple(shape_out)))
-        )
-    elif array_out.dtype != array.dtype:
-        raise ValueError(
-            "An output array of a different type than the "
-            "input array was specified, which will create an "
-            "undesired duplicate copy of the input array "
-            "in memory."
-        )
-
-
 def _reproject_full(
     array,
     wcs_in,
@@ -96,10 +78,6 @@ def _reproject_full(
     # shape_out must be exactly a tuple type
     shape_out = tuple(shape_out)
     _validate_wcs(wcs_in, wcs_out, array.shape, shape_out)
-    _validate_array_out(array_out, array, shape_out)
-
-    if array_out is None:
-        array_out = np.empty(shape_out)
 
     if output_footprint is None:
         output_footprint = np.empty(shape_out)

--- a/reproject/interpolation/core.py
+++ b/reproject/interpolation/core.py
@@ -79,6 +79,9 @@ def _reproject_full(
     shape_out = tuple(shape_out)
     _validate_wcs(wcs_in, wcs_out, array.shape, shape_out)
 
+    if array_out is None:
+        array_out = np.empty(shape_out)
+
     if output_footprint is None:
         output_footprint = np.empty(shape_out)
 

--- a/reproject/interpolation/high_level.py
+++ b/reproject/interpolation/high_level.py
@@ -3,8 +3,8 @@ import os
 
 from astropy.utils import deprecated_renamed_argument
 
-from ..utils import parse_input_data, parse_output_projection
 from ..common import _reproject_dispatcher
+from ..utils import parse_input_data, parse_output_projection
 from .core import _reproject_full
 
 __all__ = ["reproject_interp"]
@@ -16,20 +16,19 @@ ORDER["biquadratic"] = 2
 ORDER["bicubic"] = 3
 
 
-@deprecated_renamed_argument("independent_celestial_slices", None, since="0.6")
 def reproject_interp(
     input_data,
     output_projection,
     shape_out=None,
     hdu_in=0,
     order="bilinear",
-    independent_celestial_slices=False,
     output_array=None,
     return_footprint=True,
     output_footprint=None,
     block_size=None,
     parallel=False,
     roundtrip_coords=True,
+    return_type=None,
 ):
     """
     Reproject data to a new projection using interpolation (this is typically
@@ -98,6 +97,8 @@ def reproject_interp(
     roundtrip_coords : bool
         Whether to verify that coordinate transformations are defined in both
         directions.
+    return_type : {'numpy', 'dask'}, optional
+        Whether to return numpy or dask arrays - defaults to 'numpy'.
 
     Returns
     -------
@@ -117,29 +118,22 @@ def reproject_interp(
     if isinstance(order, str):
         order = ORDER[order]
 
-    # if either of these are not default, it means a blocked method must be used
-    if block_size is not None or parallel is not False:
-        return _reproject_dispatcher(
-            _reproject_full,
-            array_in=array_in,
-            wcs_in=wcs_in,
-            wcs_out=wcs_out,
-            shape_out=shape_out,
-            output_array=output_array,
-            parallel=parallel,
-            block_size=block_size,
-            return_footprint=return_footprint,
-            output_footprint=output_footprint,
-        )
-    else:
-        return _reproject_full(
-            array_in,
-            wcs_in,
-            wcs_out,
-            shape_out=shape_out,
-            order=order,
-            array_out=output_array,
-            return_footprint=return_footprint,
-            roundtrip_coords=roundtrip_coords,
-            output_footprint=output_footprint,
-        )
+    # TODO: add tests that actually ensure that order and roundtrip_coords work
+
+    return _reproject_dispatcher(
+        _reproject_full,
+        array_in=array_in,
+        wcs_in=wcs_in,
+        wcs_out=wcs_out,
+        shape_out=shape_out,
+        array_out=output_array,
+        parallel=parallel,
+        block_size=block_size,
+        return_footprint=return_footprint,
+        output_footprint=output_footprint,
+        reproject_func_kwargs={
+            "order": order,
+            "roundtrip_coords": roundtrip_coords,
+        },
+        return_type=return_type,
+    )

--- a/reproject/interpolation/high_level.py
+++ b/reproject/interpolation/high_level.py
@@ -3,7 +3,8 @@ import os
 
 from astropy.utils import deprecated_renamed_argument
 
-from ..utils import _reproject_blocked, parse_input_data, parse_output_projection
+from ..utils import parse_input_data, parse_output_projection
+from ..common import _reproject_dispatcher
 from .core import _reproject_full
 
 __all__ = ["reproject_interp"]
@@ -118,7 +119,7 @@ def reproject_interp(
 
     # if either of these are not default, it means a blocked method must be used
     if block_size is not None or parallel is not False:
-        return _reproject_blocked(
+        return _reproject_dispatcher(
             _reproject_full,
             array_in=array_in,
             wcs_in=wcs_in,

--- a/reproject/interpolation/high_level.py
+++ b/reproject/interpolation/high_level.py
@@ -21,14 +21,14 @@ def reproject_interp(
     output_projection,
     shape_out=None,
     hdu_in=0,
-    order="bilinear",
     output_array=None,
     return_footprint=True,
     output_footprint=None,
     block_size=None,
     parallel=False,
-    roundtrip_coords=True,
     return_type=None,
+    order="bilinear",
+    roundtrip_coords=True,
 ):
     """
     Reproject data to a new projection using interpolation (this is typically
@@ -131,9 +131,9 @@ def reproject_interp(
         block_size=block_size,
         return_footprint=return_footprint,
         output_footprint=output_footprint,
-        reproject_func_kwargs={
-            "order": order,
-            "roundtrip_coords": roundtrip_coords,
-        },
+        reproject_func_kwargs=dict(
+            order=order,
+            roundtrip_coords=roundtrip_coords,
+        ),
         return_type=return_type,
     )

--- a/reproject/interpolation/tests/test_core.py
+++ b/reproject/interpolation/tests/test_core.py
@@ -2,6 +2,7 @@
 
 import itertools
 
+import dask.array as da
 import numpy as np
 import pytest
 from astropy import units as u
@@ -879,3 +880,16 @@ def test_reproject_order(block_size):
 
         with pytest.raises(AssertionError):
             assert_allclose(array_out_bilinear, array_out_biquadratic)
+
+
+def test_reproject_block_size_broadcasting():
+    # Regression test for a bug that caused the default chunk size to be
+    # inadequate when using broadcasting in parallel mode
+
+    array_in = np.ones((200, 200, 200))
+    wcs_in = WCS(naxis=2)
+    wcs_out = WCS(naxis=2)
+
+    array_out = reproject_interp(
+        (array_in, wcs_in), wcs_out, shape_out=(300, 300), parallel=1, return_footprint=False
+    )

--- a/reproject/spherical_intersect/core.py
+++ b/reproject/spherical_intersect/core.py
@@ -19,7 +19,6 @@ def _reproject_celestial(
     output_footprint=None,
     return_footprint=True,
 ):
-
     if array_out is None:
         array_out = np.empty(shape_out)
 
@@ -119,6 +118,8 @@ def _reproject_celestial(
         # to loop over
         broadcasting = True
         array = array.reshape((-1, *array.shape[-wcs_in.low_level_wcs.pixel_n_dim :]))
+        array_out = array_out.reshape((-1, *shape_out[-2:]))
+        output_footprint = output_footprint.reshape((-1, *shape_out[-2:]))
     else:
         raise ValueError("Too few dimensions for input array")
 
@@ -146,6 +147,7 @@ def _reproject_celestial(
             array_new /= weights
 
         if broadcasting:
+            print(array_out.shape, array_new.shape)
             array_out[i] = array_new
             if return_footprint:
                 output_footprint[i] = weights
@@ -153,6 +155,11 @@ def _reproject_celestial(
             array_out[:] = array_new
             if return_footprint:
                 output_footprint[:] = weights
+
+    if broadcasting:
+        array_out = array_out.reshape(shape_out)
+        if return_footprint:
+            output_footprint = output_footprint.reshape(shape_out)
 
     if return_footprint:
         return array_out, output_footprint

--- a/reproject/spherical_intersect/core.py
+++ b/reproject/spherical_intersect/core.py
@@ -22,7 +22,23 @@ def _reproject_slice(args):
     return _reproject_slice_cython(*args)
 
 
-def _reproject_celestial(array, wcs_in, wcs_out, shape_out, parallel=True, return_footprint=True):
+def _reproject_celestial(
+    array,
+    wcs_in,
+    wcs_out,
+    shape_out,
+    array_out=None,
+    output_footprint=None,
+    parallel=True,
+    return_footprint=True,
+):
+
+    if array_out is None:
+        array_out = np.empty(shape_out)
+
+    if output_footprint is None:
+        output_footprint = np.empty(shape_out)
+
     # Check the parallel flag.
     if type(parallel) != bool and type(parallel) != int:
         raise TypeError("The 'parallel' flag must be a boolean or integral value")
@@ -216,7 +232,11 @@ def _reproject_celestial(array, wcs_in, wcs_out, shape_out, parallel=True, retur
             output_weights = np.stack(output_weights)
             output_weights.shape = shape_out
 
+    # TODO: we should be able to make use of the output arrays more efficiently
+
+    array_out[:] = outputs
     if return_footprint:
-        return outputs, output_weights
+        output_footprint[:] = output_weights
+        return array_out, output_footprint
     else:
-        return outputs
+        return array_out

--- a/reproject/spherical_intersect/core.py
+++ b/reproject/spherical_intersect/core.py
@@ -1,6 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-import signal
 import warnings
 
 import numpy as np
@@ -8,18 +7,7 @@ from astropy import units as u
 from astropy.wcs import WCS
 from astropy.wcs.utils import proj_plane_pixel_area
 
-
-def _init_worker():
-    """
-    Function to disable ctrl+c in the worker processes.
-    """
-    signal.signal(signal.SIGINT, signal.SIG_IGN)
-
-
-def _reproject_slice(args):
-    from ._overlap import _reproject_slice_cython
-
-    return _reproject_slice_cython(*args)
+from ._overlap import _reproject_slice_cython
 
 
 def _reproject_celestial(
@@ -29,7 +17,6 @@ def _reproject_celestial(
     shape_out,
     array_out=None,
     output_footprint=None,
-    parallel=True,
     return_footprint=True,
 ):
 
@@ -38,20 +25,6 @@ def _reproject_celestial(
 
     if output_footprint is None:
         output_footprint = np.empty(shape_out)
-
-    # Check the parallel flag.
-    if type(parallel) != bool and type(parallel) != int:
-        raise TypeError("The 'parallel' flag must be a boolean or integral value")
-
-    if type(parallel) == int:
-        # parallel is a number of processes.
-        if parallel <= 0:
-            raise ValueError("The number of processors to use must be strictly positive")
-        nproc = parallel
-    else:
-        # parallel is a boolean flag. nproc = None here means automatically selected
-        # number of processes.
-        nproc = None if parallel else 1
 
     # There are currently precision issues below certain resolutions, so we
     # emit a warning if this is the case. For more details, see:
@@ -139,104 +112,49 @@ def _reproject_celestial(
         # We don't need to broadcast the transformation over any extra
         # axes---add an extra axis of length one just so we have something
         # to loop over in all cases.
+        broadcasting = False
         array = array.reshape((1, *array.shape))
     elif len(array.shape) > wcs_in.low_level_wcs.pixel_n_dim:
         # We're broadcasting. Flatten the extra dimensions so there's just one
         # to loop over
+        broadcasting = True
         array = array.reshape((-1, *array.shape[-wcs_in.low_level_wcs.pixel_n_dim :]))
     else:
         raise ValueError("Too few dimensions for input array")
 
-    # Put together the parameters common both to the serial and parallel implementations. The aca
-    # function is needed to enforce that the array will be contiguous when passed to the low-level
-    # raw C function, otherwise Cython might complain.
+    array = np.ascontiguousarray(array)
 
-    aca = np.ascontiguousarray
-    common_func_par = [
-        0,
-        ny_in,
-        nx_out,
-        ny_out,
-        aca(xp_inout),
-        aca(yp_inout),
-        aca(xw_in),
-        aca(yw_in),
-        aca(xw_out),
-        aca(yw_out),
-        None,  # input data
-        shape_out[-2:],
-    ]
-    array = aca(array)
-
-    if nproc is None or nproc > 1:
-        # Spin up our process pool outside the loop over broadcast dimensions
-        from multiprocessing import Pool, cpu_count
-
-        # If needed, establish the number of processors to use.
-        if nproc is None:
-            nproc = cpu_count()
-
-        # Prime each process in the pool with a small function that disables
-        # the ctrl+c signal in the child process.
-        pool = Pool(nproc, _init_worker)
-
-    outputs = []
-    output_weights = []
     for i in range(len(array)):
-        common_func_par[-2] = array[i]
+        array_new, weights = _reproject_slice_cython(
+            0,
+            nx_in,
+            0,
+            ny_in,
+            nx_out,
+            ny_out,
+            np.ascontiguousarray(xp_inout),
+            np.ascontiguousarray(yp_inout),
+            np.ascontiguousarray(xw_in),
+            np.ascontiguousarray(yw_in),
+            np.ascontiguousarray(xw_out),
+            np.ascontiguousarray(yw_out),
+            array[i],
+            shape_out[-2:],
+        )
 
-        if nproc == 1:
-            array_new, weights = _reproject_slice([0, nx_in] + common_func_par)
+        with np.errstate(invalid="ignore"):
+            array_new /= weights
 
-            with np.errstate(invalid="ignore"):
-                array_new /= weights
-
-            outputs.append(array_new)
+        if broadcasting:
+            array_out[i] = array_new
             if return_footprint:
-                output_weights.append(weights)
-
-        elif nproc > 1:
-            inputs = []
-            for i in range(nproc):
-                start = int(nx_in) // nproc * i
-                end = int(nx_in) if i == nproc - 1 else int(nx_in) // nproc * (i + 1)
-                inputs.append([start, end] + common_func_par)
-
-            results = pool.map(_reproject_slice, inputs)
-
-            array_new, weights = zip(*results)
-
-            array_new = sum(array_new)
-            weights = sum(weights)
-
-            with np.errstate(invalid="ignore"):
-                array_new /= weights
-
-            outputs.append(array_new)
+                output_footprint[i] = weights
+        else:
+            array_out[:] = array_new
             if return_footprint:
-                output_weights.append(weights)
+                output_footprint[:] = weights
 
-    if nproc > 1:
-        pool.close()
-
-    if len(shape_out) == wcs_out.low_level_wcs.pixel_n_dim:
-        # We weren't broadcasting, so don't return any extra dimensions
-        outputs = outputs[0]
-        if return_footprint:
-            output_weights = output_weights[0]
-    else:
-        outputs = np.stack(outputs)
-        # If we're broadcasting over multiple dimensions, impose them here
-        outputs.shape = shape_out
-        if return_footprint:
-            output_weights = np.stack(output_weights)
-            output_weights.shape = shape_out
-
-    # TODO: we should be able to make use of the output arrays more efficiently
-
-    array_out[:] = outputs
     if return_footprint:
-        output_footprint[:] = output_weights
         return array_out, output_footprint
     else:
         return array_out

--- a/reproject/spherical_intersect/high_level.py
+++ b/reproject/spherical_intersect/high_level.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+from ..common import _reproject_dispatcher
 from ..utils import parse_input_data, parse_output_projection
 from ..wcs_utils import has_celestial
 from .core import _reproject_celestial
@@ -8,7 +9,16 @@ __all__ = ["reproject_exact"]
 
 
 def reproject_exact(
-    input_data, output_projection, shape_out=None, hdu_in=0, parallel=False, return_footprint=True
+    input_data,
+    output_projection,
+    shape_out=None,
+    hdu_in=0,
+    output_array=None,
+    return_footprint=True,
+    output_footprint=None,
+    block_size=None,
+    parallel=False,
+    return_type=None,
 ):
     """
     Reproject data to a new projection using flux-conserving spherical
@@ -72,13 +82,18 @@ def reproject_exact(
     )
 
     if has_celestial(wcs_in) and wcs_in.pixel_n_dim == 2 and wcs_in.world_n_dim == 2:
-        return _reproject_celestial(
-            array_in,
-            wcs_in,
-            wcs_out,
+        return _reproject_dispatcher(
+            _reproject_celestial,
+            array_in=array_in,
+            wcs_in=wcs_in,
+            wcs_out=wcs_out,
             shape_out=shape_out,
+            array_out=output_array,
             parallel=parallel,
+            block_size=block_size,
             return_footprint=return_footprint,
+            output_footprint=output_footprint,
+            return_type=return_type,
         )
     else:
         raise NotImplementedError(

--- a/reproject/spherical_intersect/tests/test_high_level.py
+++ b/reproject/spherical_intersect/tests/test_high_level.py
@@ -41,6 +41,20 @@ class TestReprojectExact:
             reproject_exact((self.array_in, self.header_in), self.header_out, parallel=-1)
         assert exc.value.args[0] == "The number of processors to use must be strictly positive"
 
+    def test_reproject_parallel_consistency(self):
+        reproject_exact((self.array_in, self.header_in), self.header_out, parallel=1)
+
+        array1, footprint1 = reproject_exact(
+            (self.array_in, self.header_in), self.header_out, parallel=False
+        )
+        array2, footprint2 = reproject_exact(
+            (self.array_in, self.header_in), self.header_out, parallel=4
+        )
+
+        np.testing.assert_allclose(array1, array2, rtol=1.0e-5)
+
+        np.testing.assert_allclose(footprint1, footprint2, rtol=3.0e-5)
+
 
 def test_identity():
     # Reproject an array and WCS to itself

--- a/reproject/spherical_intersect/tests/test_reproject.py
+++ b/reproject/spherical_intersect/tests/test_reproject.py
@@ -67,20 +67,6 @@ MONTAGE_REF = np.array(
 )
 
 
-def test_reproject_celestial_consistency():
-    # Consistency between the different modes
-
-    wcs_in = WCS(fits.Header.fromstring(INPUT_HDR, sep="\n"))
-    wcs_out = WCS(fits.Header.fromstring(OUTPUT_HDR, sep="\n"))
-
-    array1, footprint1 = _reproject_celestial(DATA, wcs_in, wcs_out, (4, 4), parallel=False)
-    array2, footprint2 = _reproject_celestial(DATA, wcs_in, wcs_out, (4, 4), parallel=True)
-
-    np.testing.assert_allclose(array1, array2, rtol=1.0e-5)
-
-    np.testing.assert_allclose(footprint1, footprint2, rtol=3.0e-5)
-
-
 @pytest.mark.parametrize("wcsapi", (False, True))
 def test_reproject_celestial_montage(wcsapi):
     # Accuracy compared to Montage
@@ -91,7 +77,7 @@ def test_reproject_celestial_montage(wcsapi):
     if wcsapi:  # Enforce a pure wcsapi API
         wcs_in, wcs_out = as_high_level_wcs(wcs_in), as_high_level_wcs(wcs_out)
 
-    array, footprint = _reproject_celestial(DATA, wcs_in, wcs_out, (4, 4), parallel=False)
+    array, footprint = _reproject_celestial(DATA, wcs_in, wcs_out, (4, 4))
 
     # TODO: improve agreement with Montage - at the moment agreement is ~10%
     np.testing.assert_allclose(array, MONTAGE_REF, rtol=0.09)
@@ -103,21 +89,19 @@ def test_reproject_flipping():
 
     wcs_in = WCS(fits.Header.fromstring(INPUT_HDR, sep="\n"))
     wcs_out = WCS(fits.Header.fromstring(OUTPUT_HDR, sep="\n"))
-    array1, footprint1 = _reproject_celestial(DATA, wcs_in, wcs_out, (4, 4), parallel=False)
+    array1, footprint1 = _reproject_celestial(DATA, wcs_in, wcs_out, (4, 4))
 
     # Repeat with an input that is flipped horizontally with the equivalent WCS
     wcs_in_flipped = WCS(fits.Header.fromstring(INPUT_HDR, sep="\n"))
     wcs_in_flipped.wcs.cdelt[0] = -wcs_in_flipped.wcs.cdelt[0]
     wcs_in_flipped.wcs.crpix[0] = 3 - wcs_in_flipped.wcs.crpix[0]
-    array2, footprint2 = _reproject_celestial(
-        DATA[:, ::-1], wcs_in_flipped, wcs_out, (4, 4), parallel=False
-    )
+    array2, footprint2 = _reproject_celestial(DATA[:, ::-1], wcs_in_flipped, wcs_out, (4, 4))
 
     # Repeat with an output that is flipped horizontally with the equivalent WCS
     wcs_out_flipped = WCS(fits.Header.fromstring(OUTPUT_HDR, sep="\n"))
     wcs_out_flipped.wcs.cdelt[0] = -wcs_out_flipped.wcs.cdelt[0]
     wcs_out_flipped.wcs.crpix[0] = 5 - wcs_out_flipped.wcs.crpix[0]
-    array3, footprint3 = _reproject_celestial(DATA, wcs_in, wcs_out_flipped, (4, 4), parallel=False)
+    array3, footprint3 = _reproject_celestial(DATA, wcs_in, wcs_out_flipped, (4, 4))
     array3, footprint3 = array3[:, ::-1], footprint3[:, ::-1]
 
     np.testing.assert_allclose(array1, array2, rtol=1.0e-5)

--- a/reproject/tests/test_utils.py
+++ b/reproject/tests/test_utils.py
@@ -1,3 +1,4 @@
+import dask.array as da
 import numpy as np
 import pytest
 from astropy.io import fits
@@ -16,7 +17,7 @@ def test_parse_input_data(tmpdir, valid_celestial_input_data, request):
     array_ref, wcs_ref, input_value, kwargs = valid_celestial_input_data
 
     data, wcs = parse_input_data(input_value, **kwargs)
-    assert isinstance(data, np.ndarray)
+    assert isinstance(data, (da.Array, np.ndarray))
     np.testing.assert_allclose(data, array_ref)
     assert_wcs_allclose(wcs, wcs_ref)
 

--- a/reproject/utils.py
+++ b/reproject/utils.py
@@ -1,17 +1,14 @@
 import tempfile
 from pathlib import Path
-from concurrent import futures
 
 import astropy.nddata
-import dask
 import dask.array as da
 import numpy as np
 from astropy.io import fits
 from astropy.io.fits import CompImageHDU, HDUList, Header, ImageHDU, PrimaryHDU
 from astropy.wcs import WCS
-from astropy.wcs.wcsapi import BaseHighLevelWCS, BaseLowLevelWCS, SlicedLowLevelWCS
+from astropy.wcs.wcsapi import BaseHighLevelWCS, BaseLowLevelWCS
 from astropy.wcs.wcsapi.high_level_wcs_wrapper import HighLevelWCSWrapper
-from dask.utils import SerializableLock
 
 __all__ = [
     "parse_input_data",
@@ -250,153 +247,3 @@ def parse_output_projection(output_projection, shape_in=None, shape_out=None, ou
         # currently have any broadcast dims
         shape_out = (*shape_in[: -len(shape_out)], *shape_out)
     return wcs_out, tuple(shape_out)
-
-
-def _reproject_blocked(
-    reproject_func,
-    array_in,
-    wcs_in,
-    shape_out,
-    wcs_out,
-    block_size,
-    output_array=None,
-    return_footprint=True,
-    output_footprint=None,
-    parallel=True,
-):
-    """
-    Implementation function that handles reprojecting subsets blocks of pixels
-    from an input image and holds metadata about where to reinsert when done.
-
-    Parameters
-    ----------
-    reproject_func
-        One the existing reproject functions implementing a reprojection algorithm
-        that that will be used be used to perform reprojection
-    array_in
-        Data following the same format as expected by underlying reproject_func,
-        expected to `~numpy.ndarray` when used from _reproject_blocked()
-    wcs_in: `~astropy.wcs.WCS`
-        WCS object corresponding to array_in
-    shape_out: tuple
-        Passed to reproject_func() alongside WCS out to determine image size
-    wcs_out: `~astropy.wcs.WCS`
-        Output WCS image will be projected to. Normally will correspond to subset of
-        total output image when used by _reproject_blocked()
-    block_size: tuple
-        The size of blocks in terms of output array pixels that each block will handle
-        reprojecting. Extending out from (0,0) coords positively, block sizes
-        are clamped to output space edges when a block would extend past edge
-    output_array : None or `~numpy.ndarray`
-        An array in which to store the reprojected data.  This can be any numpy
-        array including a memory map, which may be helpful when dealing with
-        extremely large files.
-    return_footprint : bool
-        Whether to return the footprint in addition to the output array.
-    output_footprint : None or `~numpy.ndarray`
-        An array in which to store the footprint of reprojected data.  This can be
-        any numpy array including a memory map, which may be helpful when dealing with
-        extremely large files.
-    parallel : bool or int
-        Flag for parallel implementation. If ``True``, a parallel implementation
-        is chosen, the number of processes selected automatically to be equal to
-        the number of logical CPUs detected on the machine. If ``False``, a
-        serial implementation is chosen. If the flag is a positive integer ``n``
-        greater than one, a parallel implementation using ``n`` processes is chosen.
-    """
-
-    if output_array is None:
-        output_array = np.zeros(shape_out, dtype=float)
-    if output_footprint is None and return_footprint:
-        output_footprint = np.zeros(shape_out, dtype=float)
-
-    if block_size is not None and len(block_size) < len(shape_out):
-        block_size = [-1] * (len(shape_out) - len(block_size)) + list(block_size)
-
-    shape_in = array_in.shape
-
-    # When in parallel mode, we want to make sure we avoid having to copy the
-    # input array to all processes for each chunk, so instead we write out
-    # the input array to a Numpy memory map and load it in inside each process
-    # as a memory-mapped array. We need to be careful how this gets passed to
-    # reproject_single_block so we pass a variable that can be either a string
-    # or the array itself (for synchronous mode).
-    if parallel:
-        array_in_or_path = tempfile.mktemp()
-        array_in_memmapped = np.memmap(
-            array_in_or_path, dtype=float, shape=array_in.shape, mode="w+"
-        )
-        array_in_memmapped[:] = array_in[:]
-    else:
-        array_in_or_path = array_in
-
-    def reproject_single_block(a, block_info=None):
-        if a.ndim == 0 or block_info is None or block_info == []:
-            return np.array([a, a])
-        slices = [slice(*x) for x in block_info[None]["array-location"][-wcs_out.pixel_n_dim :]]
-
-        if isinstance(wcs_out, BaseHighLevelWCS):
-            low_level_wcs = SlicedLowLevelWCS(wcs_out.low_level_wcs, slices=slices)
-        else:
-            low_level_wcs = SlicedLowLevelWCS(wcs_out, slices=slices)
-        wcs_out_sub = HighLevelWCSWrapper(low_level_wcs)
-        if isinstance(array_in_or_path, str):
-            array_in = np.memmap(array_in_or_path, dtype=float, shape=shape_in)
-        else:
-            array_in = array_in_or_path
-        array, footprint = reproject_func(
-            array_in, wcs_in, wcs_out_sub, block_info[None]["chunk-shape"][1:]
-        )
-        return np.array([array, footprint])
-
-    # NOTE: the following array is just used to set up the iteration in map_blocks
-    # but isn't actually used otherwise - this is deliberate.
-    if block_size:
-        output_array_dask = da.empty(shape_out, chunks=block_size)
-    else:
-        output_array_dask = da.empty(shape_out).rechunk(block_size_limit=8 * 1024**2)
-
-    result = da.map_blocks(
-        reproject_single_block,
-        output_array_dask,
-        dtype=float,
-        new_axis=0,
-        chunks=(2,) + output_array_dask.chunksize,
-    )
-
-    # Truncate extra elements
-    result = result[tuple([slice(None)] + [slice(s) for s in shape_out])]
-
-    if parallel:
-        # As discussed in https://github.com/dask/dask/issues/9556, da.store
-        # will not work well in multiprocessing mode when the destination is a
-        # Numpy array. Instead, in this case we save the dask array to a zarr
-        # array on disk which can be done in parallel, and re-load it as a dask
-        # array. We can then use da.store in the next step using the
-        # 'synchronous' scheduler since that is I/O limited so does not need
-        # to be done in parallel.
-        filename = tempfile.mktemp()
-        if isinstance(parallel, int):
-            workers = {"num_workers": parallel}
-        else:
-            workers = {}
-        with dask.config.set(scheduler="processes", **workers):
-            result.to_zarr(filename)
-        result = da.from_zarr(filename)
-
-    if return_footprint:
-        da.store(
-            [result[0], result[1]],
-            [output_array, output_footprint],
-            compute=True,
-            scheduler="synchronous",
-        )
-        return output_array, output_footprint
-    else:
-        da.store(
-            result[0],
-            output_array,
-            compute=True,
-            scheduler="synchronous",
-        )
-        return output_array

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ install_requires =
   astropy>=5.0
   astropy-healpix>=0.6
   scipy>=1.5
-  dask[array]>=2020
+  dask[array]>=2021.8
   cloudpickle
   zarr
   fsspec

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ deps =
     oldestdeps: astropy==5.0.*
     oldestdeps: astropy-healpix==0.6
     oldestdeps: scipy==1.5.*
-    oldestdeps: dask==2020.12.*
+    oldestdeps: dask==2021.8.*
 
     devdeps: numpy>=0.0.dev0
     devdeps: scipy>=0.0.dev0


### PR DESCRIPTION
This refactors the handling of blocked/parallel reprojection with dask following a conversation with @Cadair.

* [x] Ensure that we clean up all temporary directories with Numpy memmaps and zarr arrays
* [x] Add a ``return_type`` option to ``reproject_interp`` which can be ``'numpy'`` (default) or ``'dask'``. When the latter is used, nothing is computed when ``reproject_interp`` is called so this is very fast
* [x] Document that to use schedulers other than synchronous or processes, users should set ``return_type`` to ``'dask'`` and then compute it with the desired scheduler (e.g. a dask distributed scheduler). However, we need to make it very clear that the code is not thread-safe, so that multi-threaded schedulers can't be used (I don't think there is a way for us to check that)
* [x] Expand the blocked/parallel reprojection to the adaptive and spherical intersect algorithms
* [x] Make sure we properly test ``roundtrip_coords`` and ``order`` - these were not getting passed through to the blocked/parallel reprojection so were getting ignored, but need to add tests to make sure these options do something