### PR TITLE
Add modes for nan and inf handling to adaptive algo

### DIFF
--- a/docs/celestial.rst
+++ b/docs/celestial.rst
@@ -288,7 +288,7 @@ will wrap around to the opposite side of the image, ignoring the
 ``boundary_mode`` for that axis.
 
 This implementation includes several options for handling ``nan`` and ``inf``
-values in the input data, set via the ``bad_val_mode`` argument:
+values in the input data, set via the ``bad_value_mode`` argument:
 
 * ``strict`` --- Values of ``nan`` or ``inf`` in the input data are propagated
   to every output value which samples them.

--- a/docs/celestial.rst
+++ b/docs/celestial.rst
@@ -173,7 +173,7 @@ integer or a string giving the order of the interpolation. Supported strings
 include:
 
 * ``'nearest-neighbor'``: zeroth order interpolation
-* ``'bilinear'``: fisst order interpolation
+* ``'bilinear'``: first order interpolation
 * ``'biquadratic'``: second order interpolation
 * ``'bicubic'``: third order interpolation
 
@@ -279,13 +279,24 @@ image, a range of boundary modes can be applied, and this is set with the
   would have been assigned to the ignored samples exceeds a set fraction of the
   total weight across the entire sampling region, set by the
   ``boundary_ignore_threshold`` argument. In that case, acts as ``strict``.
-* ``nearest`` --- Samples outside the input image are replaced by the nearst
+* ``nearest`` --- Samples outside the input image are replaced by the nearest
   in-bounds input pixel.
 
 The input image can also be marked as being cyclic or periodic in the x and/or
 y axes with the ``x_cyclic`` and ``y_cyclic`` flags. If these are set, samples
 will wrap around to the opposite side of the image, ignoring the
 ``boundary_mode`` for that axis.
+
+This implementation includes several options for handling ``nan`` and ``inf``
+values in the input data, set via the ``bad_val_mode`` argument:
+
+* ``strict`` --- Values of ``nan`` or ``inf`` in the input data are propagated
+  to every output value which samples them.
+* ``ignore`` --- When a sampled input value is ``nan`` or ``inf``, that input
+  pixel is ignored (affected neither the accumulated sum of weighted samples
+  nor the accumulated sum of weights).
+* ``constant`` --- Input values of ``nan`` and ``inf`` are replaced with a
+  constant value, set via the ``bad_fill_value`` argument.
 
 
 Algorithm Description

--- a/reproject/adaptive/core.py
+++ b/reproject/adaptive/core.py
@@ -45,7 +45,7 @@ def _reproject_adaptive_2d(
     boundary_ignore_threshold=0.5,
     x_cyclic=False,
     y_cyclic=False,
-    bad_val_mode="strict",
+    bad_value_mode="strict",
     bad_fill_value=0,
 ):
     """
@@ -89,7 +89,7 @@ def _reproject_adaptive_2d(
         Threshold for 'ignore_threshold' boundary mode, ranging from 0 to 1.
     x_cyclic, y_cyclic : bool
         Marks in input-image axis as cyclic.
-    bad_val_mode : str
+    bad_value_mode : str
         NaN and inf handling mode
     bad_fill_value : float
         Fill value for 'constant' bad value mode
@@ -173,7 +173,7 @@ def _reproject_adaptive_2d(
         boundary_ignore_threshold=boundary_ignore_threshold,
         x_cyclic=x_cyclic,
         y_cyclic=y_cyclic,
-        bad_val_mode=bad_val_mode,
+        bad_value_mode=bad_value_mode,
         bad_fill_value=bad_fill_value,
     )
 

--- a/reproject/adaptive/core.py
+++ b/reproject/adaptive/core.py
@@ -45,6 +45,8 @@ def _reproject_adaptive_2d(
     boundary_ignore_threshold=0.5,
     x_cyclic=False,
     y_cyclic=False,
+    bad_val_mode="strict",
+    bad_fill_value=0,
 ):
     """
     Reproject celestial slices from an n-d array from one WCS to another
@@ -87,6 +89,10 @@ def _reproject_adaptive_2d(
         Threshold for 'ignore_threshold' boundary mode, ranging from 0 to 1.
     x_cyclic, y_cyclic : bool
         Marks in input-image axis as cyclic.
+    bad_val_mode : str
+        NaN and inf handling mode
+    bad_fill_value : float
+        Fill value for 'constant' bad value mode
 
     Returns
     -------
@@ -167,6 +173,8 @@ def _reproject_adaptive_2d(
         boundary_ignore_threshold=boundary_ignore_threshold,
         x_cyclic=x_cyclic,
         y_cyclic=y_cyclic,
+        bad_val_mode=bad_val_mode,
+        bad_fill_value=bad_fill_value,
     )
 
     array_out.shape = shape_out

--- a/reproject/adaptive/deforest.pyx
+++ b/reproject/adaptive/deforest.pyx
@@ -352,10 +352,10 @@ BOUNDARY_MODES['ignore'] = 4
 BOUNDARY_MODES['ignore_threshold'] = 5
 BOUNDARY_MODES['nearest'] = 6
 
-BAD_VAL_MODES = {}
-BAD_VAL_MODES['strict'] = 1
-BAD_VAL_MODES['constant'] = 2
-BAD_VAL_MODES['ignore'] = 3
+BAD_VALUE_MODES = {}
+BAD_VALUE_MODES['strict'] = 1
+BAD_VALUE_MODES['constant'] = 2
+BAD_VALUE_MODES['ignore'] = 3
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
@@ -368,7 +368,7 @@ def map_coordinates(double[:,:,:] source, double[:,:,:] target, Ci, int max_samp
                     str kernel='gaussian', double kernel_width=1.3,
                     double sample_region_width=4, str boundary_mode="strict",
                     double boundary_fill_value=0, double boundary_ignore_threshold=0.5,
-                    str bad_val_mode="strict", double bad_fill_value=0,
+                    str bad_value_mode="strict", double bad_fill_value=0,
                     ):
     # n.b. the source and target arrays are expected to contain three
     # dimensions---the last two are the image dimensions, while the first
@@ -391,10 +391,10 @@ def map_coordinates(double[:,:,:] source, double[:,:,:] target, Ci, int max_samp
 
     cdef int bad_val_flag
     try:
-        bad_val_flag = BAD_VAL_MODES[bad_val_mode.lower()]
+        bad_val_flag = BAD_VALUE_MODES[bad_value_mode.lower()]
     except KeyError:
         raise ValueError(
-                f"bad_val_mode '{bad_val_mode}' not recognized") from None
+                f"bad_value_mode '{bad_value_mode}' not recognized") from None
 
     cdef np.ndarray[np.float64_t, ndim=3] pixel_target
     cdef int delta

--- a/reproject/adaptive/high_level.py
+++ b/reproject/adaptive/high_level.py
@@ -30,7 +30,7 @@ def reproject_adaptive(
     boundary_ignore_threshold=0.5,
     x_cyclic=False,
     y_cyclic=False,
-    bad_val_mode="strict",
+    bad_value_mode="strict",
     bad_fill_value=0,
 ):
     """
@@ -171,7 +171,7 @@ def reproject_adaptive(
         Indicates that the x or y axis of the input image should be treated as
         cyclic or periodic. Overrides the boundary mode for that axis, so that
         out-of-bounds samples wrap to the other side of the image.
-    bad_val_mode : str
+    bad_value_mode : str
         How to handle values of ``nan`` and ``inf`` in the input data. The
         default is ``strct``. Allowed values are:
 
@@ -227,7 +227,7 @@ def reproject_adaptive(
             boundary_ignore_threshold=boundary_ignore_threshold,
             x_cyclic=x_cyclic,
             y_cyclic=y_cyclic,
-            bad_val_mode=bad_val_mode,
+            bad_value_mode=bad_value_mode,
             bad_fill_value=bad_fill_value,
         ),
         return_type=return_type,

--- a/reproject/adaptive/high_level.py
+++ b/reproject/adaptive/high_level.py
@@ -30,6 +30,8 @@ def reproject_adaptive(
     boundary_ignore_threshold=0.5,
     x_cyclic=False,
     y_cyclic=False,
+    bad_val_mode="strict",
+    bad_fill_value=0,
 ):
     """
     Reproject a 2D array from one WCS to another using the DeForest (2004)
@@ -169,6 +171,20 @@ def reproject_adaptive(
         Indicates that the x or y axis of the input image should be treated as
         cyclic or periodic. Overrides the boundary mode for that axis, so that
         out-of-bounds samples wrap to the other side of the image.
+    bad_val_mode : str
+        How to handle values of ``nan`` and ``inf`` in the input data. The
+        default is ``strct``. Allowed values are:
+
+            * ``strict`` --- Values of ``nan`` or ``inf`` in the input data are
+              propagated to every output value which samples them.
+            * ``ignore`` --- When a sampled input value is ``nan`` or ``inf``,
+              that input pixel is ignored (affected neither the accumulated sum
+              of weighted samples nor the accumulated sum of weights).
+            * ``constant`` --- Input values of ``nan`` and ``inf`` are replaced
+              with a constant value, set via the ``bad_fill_value`` argument.
+
+    bad_fill_value : double
+        The constant value used by the ``constant`` bad-value mode.
 
     Returns
     -------
@@ -211,6 +227,8 @@ def reproject_adaptive(
             boundary_ignore_threshold=boundary_ignore_threshold,
             x_cyclic=x_cyclic,
             y_cyclic=y_cyclic,
+            bad_val_mode=bad_val_mode,
+            bad_fill_value=bad_fill_value,
         ),
         return_type=return_type,
     )

--- a/reproject/adaptive/tests/test_core.py
+++ b/reproject/adaptive/tests/test_core.py
@@ -680,7 +680,7 @@ def test_boundary_modes(x_cyclic, y_cyclic, rotated):
 
 
 @pytest.mark.parametrize("bad_val", (np.nan, np.inf))
-def test_bad_val_modes(bad_val):
+def test_bad_value_modes(bad_val):
     bad_val_checker = np.isnan if np.isnan(bad_val) else np.isinf
     data_in = np.ones((30, 30))
     data_in[15, 15] = bad_val
@@ -701,7 +701,7 @@ def test_bad_val_modes(bad_val):
         return_footprint=False,
         boundary_mode="ignore",
         sample_region_width=3,
-        bad_val_mode="strict",
+        bad_value_mode="strict",
     )
 
     # With a sample_region_width of 3, we expect a 3x3 box of nans centered on
@@ -717,7 +717,7 @@ def test_bad_val_modes(bad_val):
         return_footprint=False,
         boundary_mode="ignore",
         sample_region_width=3,
-        bad_val_mode="constant",
+        bad_value_mode="constant",
         bad_fill_value=10,
     )
 
@@ -734,14 +734,14 @@ def test_bad_val_modes(bad_val):
         return_footprint=False,
         boundary_mode="ignore",
         sample_region_width=3,
-        bad_val_mode="ignore",
+        bad_value_mode="ignore",
     )
 
     # Now the nan should be ignored and we should only get 1s coming out
     np.testing.assert_equal(data_out, 1)
 
 
-def test_invald_bad_val_mode():
+def test_invald_bad_value_mode():
     data_in = np.ones((30, 30))
 
     wcs_in = WCS(naxis=2)
@@ -751,7 +751,7 @@ def test_invald_bad_val_mode():
 
     wcs_out = wcs_in.deepcopy()
 
-    with pytest.raises(ValueError, match="bad_val_mode 'invalid_mode' not recognized"):
+    with pytest.raises(ValueError, match="bad_value_mode 'invalid_mode' not recognized"):
         reproject_adaptive(
             (data_in, wcs_in),
             wcs_out,
@@ -759,7 +759,7 @@ def test_invald_bad_val_mode():
             return_footprint=False,
             boundary_mode="ignore",
             sample_region_width=3,
-            bad_val_mode="invalid_mode",
+            bad_value_mode="invalid_mode",
         )
 
 
@@ -845,7 +845,7 @@ def _setup_for_broadcast_test(
     boundary_mode="strict",
     kernel="gaussian",
     center_jacobian=False,
-    bad_val_mode="strict",
+    bad_value_mode="strict",
 ):
     with fits.open(get_pkg_data_filename("data/galactic_2d.fits", package="reproject.tests")) as pf:
         hdu_in = pf[0]
@@ -875,7 +875,7 @@ def _setup_for_broadcast_test(
             boundary_mode=boundary_mode,
             kernel=kernel,
             center_jacobian=center_jacobian,
-            bad_val_mode=bad_val_mode,
+            bad_value_mode=bad_value_mode,
         )
         array_ref[i] = array_out
         footprint_ref[i] = footprint_out
@@ -930,14 +930,14 @@ def _test_broadcast_reprojection_algo_specific_options(
     boundary_mode="strict",
     kernel="gaussian",
     center_jacobian=False,
-    bad_val_mode="strict",
+    bad_value_mode="strict",
 ):
     image_stack, array_ref, footprint_ref, header_in, header_out = _setup_for_broadcast_test(
         conserve_flux=conserve_flux,
         boundary_mode=boundary_mode,
         kernel=kernel,
         center_jacobian=center_jacobian,
-        bad_val_mode=bad_val_mode,
+        bad_value_mode=bad_value_mode,
     )
 
     array_broadcast, footprint_broadcast = reproject_adaptive(
@@ -948,7 +948,7 @@ def _test_broadcast_reprojection_algo_specific_options(
         boundary_mode=boundary_mode,
         kernel=kernel,
         center_jacobian=center_jacobian,
-        bad_val_mode=bad_val_mode,
+        bad_value_mode=bad_value_mode,
     )
 
     np.testing.assert_array_equal(footprint_broadcast, footprint_ref)
@@ -978,9 +978,9 @@ def test_broadcast_reprojection_center_jacobian(center_jacobian):
     _test_broadcast_reprojection_algo_specific_options(center_jacobian=center_jacobian)
 
 
-@pytest.mark.parametrize("bad_val_mode", ("strict", "ignore", "constant"))
-def test_broadcast_reprojection_bad_val_mode(bad_val_mode):
-    _test_broadcast_reprojection_algo_specific_options(bad_val_mode=bad_val_mode)
+@pytest.mark.parametrize("bad_value_mode", ("strict", "ignore", "constant"))
+def test_broadcast_reprojection_bad_value_mode(bad_value_mode):
+    _test_broadcast_reprojection_algo_specific_options(bad_value_mode=bad_value_mode)
 
 
 def test_adaptive_input_output_types(


### PR DESCRIPTION
I found myself reprojecting images with NaNs and infs, so I added a few modes for how to deal with them. The default remains the previous behavior, which just propagates these values with no special handling.

The `constant` mode isn't strictly necessary, as one could use `np.nan_to_num` on the input array before reprojecting, but implementing this in `reproject` avoids having to copy the array---maybe that's important for `dask` use cases.