### PR TITLE
Add 'first' and 'last' moasicking modes to reproject_and_coadd

### DIFF
--- a/reproject/mosaicking/tests/test_coadd.py
+++ b/reproject/mosaicking/tests/test_coadd.py
@@ -41,11 +41,10 @@ class TestReprojectAndCoAdd:
 
         input_data = []
 
-        for jmin, jmax, imin, imax in views:
-            array = self.array[jmin:jmax, imin:imax].copy()
+        for view in views:
+            array = self.array[view].copy()
             wcs = self.wcs.deepcopy()
-            wcs.wcs.crpix[0] -= imin
-            wcs.wcs.crpix[1] -= jmin
+            wcs = wcs[view]
             input_data.append((array, wcs))
 
         return input_data
@@ -58,7 +57,7 @@ class TestReprojectAndCoAdd:
         views = []
         for i in range(4):
             for j in range(5):
-                views.append((je[j], je[j + 1], ie[i], ie[i + 1]))
+                views.append(np.s_[je[j] : je[j + 1], ie[i] : ie[i + 1]])
 
         return views
 
@@ -70,7 +69,7 @@ class TestReprojectAndCoAdd:
         views = []
         for i in range(4):
             for j in range(5):
-                views.append((je[j], je[j + 1] + 10, ie[i], ie[i + 1] + 10))
+                views.append(np.s_[je[j] : je[j + 1] + 10, ie[i] : ie[i + 1] + 10])
 
         return views
 


### PR DESCRIPTION
Again with WISPR and `reproject_and_coadd`, merging the image data in the overlap region isn't the most desirable thing to do, for two reasons. First, the WISPR L3 images don't always have a well-matched background level (because of how much processing it takes to get to L3), so at the small overlap region between the two FOVs, taking a mean of the two images gives a visible seam on either side. Second, there's sometimes a time offset between images from the two images, so if I'm building the composite in HPC coordinates, the stars are offset by a few pixels and produce ghosting in the overlap region. (If I build the composite in RA/Dec coordinates, that should stop being a problem, but then I need to think about how that offsets the coronal structures and how to make an HPC WCS for my RA/Dec composite frame.)

The `match_background` option helps hide the seams, but it's not perfect.

This PR adds `first` and `last` options for `combine_function`, which provide a simple stacking mode. In overlap regions, either the first or the last of the input images that cover any pixel determines the output value for that pixel. For the WISPR case, this artistic choice makes one seam more obvious, but hides the second seam and the star misalignment.

With `combine_function="mean"` (make it full-size to see the star ghosting):
![image](https://github.com/astropy/reproject/assets/23462789/308d8d82-65c2-4f2d-83ad-161118266001)

With `combine_function="first"`:
![image](https://github.com/astropy/reproject/assets/23462789/95e5dfa4-67ec-45f9-bb27-14764e812502)