### PR TITLE
Implement option to use dask to do image co-addition

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
+SPHINXOPTS    = -W
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = _build

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,6 +27,13 @@ exclude_patterns.append("_templates")
 rst_epilog += """
 """
 
+intersphinx_resolve_self = "astropy"
+intersphinx_mapping.update(
+    {
+        "dask": ("https://docs.dask.org/en/stable/", None),
+    }
+)
+
 # -- Project information ------------------------------------------------------
 
 package_info = metadata.metadata("reproject")

--- a/reproject/_array_utils.py
+++ b/reproject/_array_utils.py
@@ -1,3 +1,4 @@
+import dask.array as da
 import numpy as np
 from dask_image.ndinterp import map_coordinates as dask_image_map_coordinates
 from dask_image.ndinterp import spline_filter
@@ -287,6 +288,55 @@ def sample_array_edges(shape, *, n_samples):
             all_positions.append(positions)
     positions = np.unique(np.vstack(all_positions), axis=0).T
     return positions
+
+
+def pad_dask_array_to_grid(array, bounds, target_shape, target_chunks):
+    """
+    Pad a dask array with zeros so that it occupies the region given by
+    ``bounds`` (one ``(imin, imax)`` pair per dimension) within an array of
+    shape ``target_shape``, with chunk boundaries aligned to ``target_chunks``.
+
+    da.pad would chunk the pad region at the array's own chunk sizes, so a
+    later rechunk to the target chunking would have to split and recombine
+    chunks, making the number of tasks grow much faster than the number of
+    padded arrays being combined. With the chunks aligned here, that rechunk
+    only has to merge chunks at the edges of the original array.
+    """
+    for idim, (imin, imax) in enumerate(bounds):
+        edges = np.cumsum(target_chunks[idim])[:-1]
+
+        def aligned_chunks(lo, hi, edges=edges):
+            cuts = [lo] + [int(edge) for edge in edges if lo < edge < hi] + [hi]
+            return tuple(np.diff(cuts).tolist())
+
+        array = array.rechunk(
+            array.chunks[:idim] + (aligned_chunks(imin, imax),) + array.chunks[idim + 1 :]
+        )
+        pieces = [array]
+        if imin > 0:
+            pieces.insert(
+                0,
+                da.zeros(
+                    array.shape[:idim] + (imin,) + array.shape[idim + 1 :],
+                    chunks=array.chunks[:idim]
+                    + (aligned_chunks(0, imin),)
+                    + array.chunks[idim + 1 :],
+                    dtype=array.dtype,
+                ),
+            )
+        if imax < target_shape[idim]:
+            pieces.append(
+                da.zeros(
+                    array.shape[:idim] + (target_shape[idim] - imax,) + array.shape[idim + 1 :],
+                    chunks=array.chunks[:idim]
+                    + (aligned_chunks(imax, target_shape[idim]),)
+                    + array.chunks[idim + 1 :],
+                    dtype=array.dtype,
+                ),
+            )
+        if len(pieces) > 1:
+            array = da.concatenate(pieces, axis=idim)
+    return array
 
 
 class ArrayWrapper:

--- a/reproject/_common.py
+++ b/reproject/_common.py
@@ -346,7 +346,7 @@ def _reproject_dispatcher(
                 "to compute the blocks concurrently)"
             )
 
-        if output_footprint is None and return_footprint:
+        if output_footprint is None and return_footprint and return_type != "dask":
             output_footprint = np.zeros(shape_out, dtype=float)
 
         def reproject_single_block(a, array_or_path, block_info=None):

--- a/reproject/adaptive/_high_level.py
+++ b/reproject/adaptive/_high_level.py
@@ -284,4 +284,5 @@ def reproject_adaptive(
             bad_fill_value=bad_fill_value,
         ),
         return_type=return_type,
+        dask_method=dask_method,
     )

--- a/reproject/mosaicking/_coadd.py
+++ b/reproject/mosaicking/_coadd.py
@@ -666,7 +666,19 @@ def reproject_and_coadd(
         # linearly with the number of images (the co-addition appears to hang). Rechunk
         # every image to one common chunking first so the stack and reduction stay
         # small and the memory per chunk stays bounded.
-        target_chunks = da.core.normalize_chunks("auto", shape=tuple(shape_out), dtype=float)
+        #
+        # The chunking is chosen to split along the non-reprojected (leading)
+        # dimensions, so each output chunk is a single plane (or slab) rather than the
+        # whole non-reprojected extent. That keeps memory bounded to a plane per image
+        # and lets the reprojection and co-addition stream plane by plane instead of
+        # reprojecting every image in full before combining. The reprojected
+        # dimensions are chunked automatically.
+        if non_reprojected_dims is not None:
+            n_broadcast = len(non_reprojected_dims)
+        else:
+            n_broadcast = len(shape_out) - wcs_out.low_level_wcs.pixel_n_dim
+        chunk_spec = (1,) * n_broadcast + ("auto",) * (len(shape_out) - n_broadcast)
+        target_chunks = da.core.normalize_chunks(chunk_spec, shape=tuple(shape_out), dtype=float)
         dask_arrays = [array.rechunk(target_chunks) for array in dask_arrays]
         dask_footprints = [footprint.rechunk(target_chunks) for footprint in dask_footprints]
         stacked_array = da.stack(dask_arrays)

--- a/reproject/mosaicking/_coadd.py
+++ b/reproject/mosaicking/_coadd.py
@@ -10,7 +10,7 @@ import numpy as np
 from astropy.wcs import WCS
 from astropy.wcs.wcsapi import SlicedLowLevelWCS
 
-from .._array_utils import iterate_chunks
+from .._array_utils import iterate_chunks, pad_dask_array_to_grid
 from ..interpolation._core import _validate_wcs
 from ..utils import parse_input_data, parse_input_weights, parse_output_projection
 from ._background import determine_offset_matrix, solve_corrections_sgd
@@ -62,54 +62,6 @@ def _combine_array_into_output(combine_function, array, output_array, output_foo
             np.copyto(output_array[chunk.view_in_original_array], chunk.array, where=mask)
         else:
             raise ValueError(f"Unexpected combine_function: {combine_function}")
-
-
-def _pad_to_output_grid(array, bounds, shape_out, target_chunks):
-    """
-    Pad a lazily-reprojected cutout onto the full output grid, with chunk
-    boundaries aligned to the target output chunking.
-
-    da.pad would chunk the pad region at the cutout's own chunk sizes, so the
-    later rechunk to the output chunking would have to split and recombine
-    chunks, making the number of tasks grow much faster than the number of
-    images. With the chunks aligned here, the final rechunk only has to merge
-    chunks at the cutout edges.
-    """
-    for idim, (imin, imax) in enumerate(bounds):
-        edges = np.cumsum(target_chunks[idim])[:-1]
-
-        def aligned_chunks(lo, hi, edges=edges):
-            cuts = [lo] + [int(edge) for edge in edges if lo < edge < hi] + [hi]
-            return tuple(np.diff(cuts).tolist())
-
-        array = array.rechunk(
-            array.chunks[:idim] + (aligned_chunks(imin, imax),) + array.chunks[idim + 1 :]
-        )
-        pieces = [array]
-        if imin > 0:
-            pieces.insert(
-                0,
-                da.zeros(
-                    array.shape[:idim] + (imin,) + array.shape[idim + 1 :],
-                    chunks=array.chunks[:idim]
-                    + (aligned_chunks(0, imin),)
-                    + array.chunks[idim + 1 :],
-                    dtype=array.dtype,
-                ),
-            )
-        if imax < shape_out[idim]:
-            pieces.append(
-                da.zeros(
-                    array.shape[:idim] + (shape_out[idim] - imax,) + array.shape[idim + 1 :],
-                    chunks=array.chunks[:idim]
-                    + (aligned_chunks(imax, shape_out[idim]),)
-                    + array.chunks[idim + 1 :],
-                    dtype=array.dtype,
-                ),
-            )
-        if len(pieces) > 1:
-            array = da.concatenate(pieces, axis=idim)
-    return array
 
 
 def reproject_and_coadd(
@@ -589,9 +541,9 @@ def reproject_and_coadd(
                 if weights is not None:
                     footprint = footprint * da.where(reset, 0.0, weights)
 
-                dask_arrays.append(_pad_to_output_grid(array, bounds, shape_out, target_chunks))
+                dask_arrays.append(pad_dask_array_to_grid(array, bounds, shape_out, target_chunks))
                 dask_footprints.append(
-                    _pad_to_output_grid(footprint, bounds, shape_out, target_chunks)
+                    pad_dask_array_to_grid(footprint, bounds, shape_out, target_chunks)
                 )
                 continue
 

--- a/reproject/mosaicking/_coadd.py
+++ b/reproject/mosaicking/_coadd.py
@@ -5,6 +5,7 @@ import tempfile
 import uuid
 from logging import getLogger
 
+import dask.array as da
 import numpy as np
 from astropy.wcs import WCS
 from astropy.wcs.wcsapi import SlicedLowLevelWCS
@@ -81,6 +82,7 @@ def reproject_and_coadd(
     progress_bar=None,
     blank_pixel_value=0,
     intermediate_memmap=False,
+    return_type=None,
     **kwargs,
 ):
     """
@@ -172,6 +174,16 @@ def reproject_and_coadd(
     intermediate_memmap : bool, optional
         If `True`, use `numpy.memmap` to store intermediate output arrays for
         reprojected data.
+    return_type : {None, 'dask'}, optional
+        If ``'dask'``, reproject each image lazily (using ``return_type='dask'``
+        on the reprojection function), pad each onto the output grid, and combine
+        them with a single nan-aware reduction, returning the resulting
+        **uncomputed** dask arrays so the whole co-addition is deferred into one
+        computation. This currently supports ``combine_function`` of 'mean',
+        'sum', 'min' or 'max' (each weighting the images equally rather than by
+        footprint), and does not support ``match_background`` or
+        ``input_weights``. The default (`None`) uses the standard eager
+        co-addition.
 
     **kwargs
         Keyword arguments to be passed to the reprojection function.
@@ -234,21 +246,40 @@ def reproject_and_coadd(
         wcs_out = wcs_out.deepcopy()
         wcs_out.array_shape = shape_out[-wcs_out.low_level_wcs.pixel_n_dim :]
 
-    if output_array is None:
-        output_array = np.zeros(shape_out)
-    elif output_array.shape != shape_out:
-        raise ValueError(
-            "If you specify an output array, it must have a shape matching "
-            f"the output shape {shape_out}"
-        )
+    # When return_type='dask', we build the entire co-addition as a single deferred
+    # dask graph: each image is reprojected lazily, padded onto the output grid, and
+    # the images are combined with a nan-aware reduction. The uncomputed dask arrays
+    # are returned so the whole thing is computed once at the end, so we must not
+    # allocate the (potentially huge) output arrays here.
+    coadd_with_dask = return_type == "dask"
 
-    if output_footprint is None:
-        output_footprint = np.zeros(shape_out)
-    elif output_footprint.shape != shape_out:
-        raise ValueError(
-            "If you specify an output footprint array, it must have a shape matching "
-            f"the output shape {shape_out}"
-        )
+    if coadd_with_dask:
+        if match_background:
+            raise ValueError("Cannot use return_type='dask' together with match_background")
+        if input_weights is not None:
+            raise NotImplementedError("return_type='dask' does not yet support input_weights")
+        if combine_function not in ("mean", "sum", "min", "max"):
+            raise NotImplementedError(
+                "return_type='dask' currently only supports combine_function 'mean', "
+                "'sum', 'min' or 'max'"
+            )
+        dask_arrays = []
+    else:
+        if output_array is None:
+            output_array = np.zeros(shape_out)
+        elif output_array.shape != shape_out:
+            raise ValueError(
+                "If you specify an output array, it must have a shape matching "
+                f"the output shape {shape_out}"
+            )
+
+        if output_footprint is None:
+            output_footprint = np.zeros(shape_out)
+        elif output_footprint.shape != shape_out:
+            raise ValueError(
+                "If you specify an output footprint array, it must have a shape matching "
+                f"the output shape {shape_out}"
+            )
 
     logger.info(f"Output mosaic will have shape {shape_out}")
 
@@ -267,10 +298,11 @@ def reproject_and_coadd(
     if not on_the_fly:
         arrays = []
 
-    if combine_function == "min":
-        output_array[...] = np.inf
-    elif combine_function == "max":
-        output_array[...] = -np.inf
+    if not coadd_with_dask:
+        if combine_function == "min":
+            output_array[...] = np.inf
+        elif combine_function == "max":
+            output_array[...] = -np.inf
 
     with tempfile.TemporaryDirectory(ignore_cleanup_errors=IS_WIN) as local_tmp_dir:
 
@@ -405,6 +437,28 @@ def reproject_and_coadd(
                 )
             else:
                 block_size = global_block_size
+
+            if coadd_with_dask:
+                # Reproject this image lazily and pad the cutout back onto the full
+                # output grid (filling the uncovered region with NaN so the nan-aware
+                # reduction later ignores it). Nothing is computed here.
+                logger.info(
+                    f"Calling {reproject_function.__name__} lazily with "
+                    f"shape_out={shape_out_indiv} (return_type='dask')"
+                )
+                array = reproject_function(
+                    (array_in, wcs_in),
+                    output_projection=wcs_out_indiv,
+                    shape_out=shape_out_indiv,
+                    hdu_in=hdu_in,
+                    return_footprint=False,
+                    return_type="dask",
+                    block_size=block_size,
+                    **kwargs,
+                )
+                pad = [(imin, shape_out[idim] - imax) for idim, (imin, imax) in enumerate(bounds)]
+                dask_arrays.append(da.pad(array, pad, constant_values=np.nan))
+                continue
 
             # TODO: optimize handling of weights by making reprojection functions
             # able to handle weights, and make the footprint become the combined
@@ -555,7 +609,7 @@ def reproject_and_coadd(
             for array in arrays:
                 _combine_array_into_output(combine_function, array, output_array, output_footprint)
 
-        if combine_function == "mean":
+        if combine_function == "mean" and not coadd_with_dask:
             logger.info("Handle normalization of output array")
             with np.errstate(invalid="ignore"):
                 output_array /= output_footprint
@@ -566,6 +620,23 @@ def reproject_and_coadd(
             array = None
             footprint = None
             arrays = []
+
+    if coadd_with_dask:
+        # Combine all the lazily-reprojected, NaN-padded images with a single
+        # nan-aware reduction along the stacking axis. The result is returned
+        # uncomputed so the entire graph (reprojections and co-addition) is
+        # evaluated in one deferred computation by the caller.
+        stacked = da.stack(dask_arrays)
+        if combine_function == "mean":
+            output_array = da.nanmean(stacked, axis=0)
+        elif combine_function == "sum":
+            output_array = da.nansum(stacked, axis=0)
+        elif combine_function == "min":
+            output_array = da.nanmin(stacked, axis=0)
+        elif combine_function == "max":
+            output_array = da.nanmax(stacked, axis=0)
+        output_footprint = da.isfinite(stacked).sum(axis=0)
+        return output_array, output_footprint
 
     # We need to avoid potentially large memory allocation from output == 0 so
     # we operate in chunks.

--- a/reproject/mosaicking/_coadd.py
+++ b/reproject/mosaicking/_coadd.py
@@ -3,6 +3,7 @@ import os
 import sys
 import tempfile
 import uuid
+import warnings
 from collections import namedtuple
 from logging import getLogger
 
@@ -251,7 +252,26 @@ def _coadd_dask(
     dask_arrays = []
     dask_footprints = []
 
+    # Dask identifies arrays by their name, so two different input arrays that
+    # share a name (a bug seen in the wild for arrays built with a hard-coded
+    # graph layer name) are silently treated as the same array once everything
+    # is combined into a single graph, with one input's data used for all of
+    # them. Passing the same array object several times is fine.
+    seen_dask_arrays = {}
+
     for cutout in cutouts:
+        if isinstance(cutout.array_in, da.core.Array):
+            previous = seen_dask_arrays.setdefault(cutout.array_in.name, cutout.array_in)
+            if previous is not cutout.array_in:
+                warnings.warn(
+                    f"Two different input dask arrays share the name "
+                    f"{cutout.array_in.name!r}, so dask will treat them as the "
+                    "same array in the combined co-addition graph and the "
+                    "resulting mosaic will likely use one input's data for "
+                    "both. Make sure each input dask array has a unique name.",
+                    UserWarning,
+                    stacklevel=2,
+                )
         # Reproject this image (and its weights) lazily, mirroring the return_type='numpy'
         # per-image handling: NaNs are masked out of the array and footprint,
         # any weights are folded into the footprint, and both the array and

--- a/reproject/mosaicking/_coadd.py
+++ b/reproject/mosaicking/_coadd.py
@@ -667,17 +667,34 @@ def reproject_and_coadd(
         # every image to one common chunking first so the stack and reduction stay
         # small and the memory per chunk stays bounded.
         #
-        # The chunking is chosen to split along the non-reprojected (leading)
-        # dimensions, so each output chunk is a single plane (or slab) rather than the
-        # whole non-reprojected extent. That keeps memory bounded to a plane per image
-        # and lets the reprojection and co-addition stream plane by plane instead of
-        # reprojecting every image in full before combining. The reprojected
-        # dimensions are chunked automatically.
+        # When the user gave a block size, use it as the output chunking so they stay
+        # in control. Otherwise default to splitting along the non-reprojected
+        # (leading) dimensions, so each output chunk is a single plane rather than the
+        # whole non-reprojected extent -- that keeps memory bounded to a plane per
+        # image and lets the reprojection and co-addition stream plane by plane instead
+        # of reprojecting every image in full before combining.
         if non_reprojected_dims is not None:
             n_broadcast = len(non_reprojected_dims)
         else:
             n_broadcast = len(shape_out) - wcs_out.low_level_wcs.pixel_n_dim
-        chunk_spec = (1,) * n_broadcast + ("auto",) * (len(shape_out) - n_broadcast)
+        n_dim_reproject = len(shape_out) - n_broadcast
+
+        # block_sizes may be a single block size or a per-dataset list of them; only a
+        # single block size maps onto one output chunking.
+        block_size = None
+        if block_sizes is not None and not any(
+            isinstance(entry, (list, tuple)) for entry in block_sizes
+        ):
+            block_size = tuple(block_sizes)
+
+        if block_size is None:
+            chunk_spec = (1,) * n_broadcast + ("auto",) * n_dim_reproject
+        elif len(block_size) == n_dim_reproject:
+            # A block size given only for the reprojected dimensions; take one plane at
+            # a time along the non-reprojected ones.
+            chunk_spec = (1,) * n_broadcast + block_size
+        else:
+            chunk_spec = block_size
         target_chunks = da.core.normalize_chunks(chunk_spec, shape=tuple(shape_out), dtype=float)
         dask_arrays = [array.rechunk(target_chunks) for array in dask_arrays]
         dask_footprints = [footprint.rechunk(target_chunks) for footprint in dask_footprints]

--- a/reproject/mosaicking/_coadd.py
+++ b/reproject/mosaicking/_coadd.py
@@ -177,13 +177,16 @@ def reproject_and_coadd(
     return_type : {None, 'dask'}, optional
         If ``'dask'``, reproject each image lazily (using ``return_type='dask'``
         on the reprojection function), pad each onto the output grid, and combine
-        them with a single nan-aware reduction, returning the resulting
-        **uncomputed** dask arrays so the whole co-addition is deferred into one
-        computation. This currently supports ``combine_function`` of 'mean',
-        'sum', 'min' or 'max' (each weighting the images equally rather than by
-        footprint), and does not support ``match_background`` or
-        ``input_weights``. The default (`None`) uses the standard eager
-        co-addition.
+        them along a stacking axis, returning the resulting **uncomputed** dask
+        arrays so the whole co-addition is deferred into a single computation. The
+        combination matches the default ``return_type='numpy'`` path exactly
+        (footprint-weighted for 'mean' and 'sum', footprint-aware selection for
+        'first', 'last', 'min' and 'max'), and ``input_weights`` are supported. A
+        ``combine_function`` of 'median' is additionally available here (as an
+        unweighted median), which the ``return_type='numpy'`` path cannot compute.
+        ``match_background`` is not supported, since it requires all images up front
+        rather than a single deferred graph. The default (`None`) uses the standard
+        ``return_type='numpy'`` co-addition.
 
     **kwargs
         Keyword arguments to be passed to the reprojection function.
@@ -206,8 +209,13 @@ def reproject_and_coadd(
 
     # Validate inputs
 
-    if combine_function not in ("mean", "sum", "first", "last", "min", "max"):
-        raise ValueError("combine_function should be one of mean/sum/first/last/min/max")
+    # 'median' is only available for the deferred dask path (return_type='dask'); the
+    # return_type='numpy' path cannot compute a median on the fly.
+    allowed_combine = ("mean", "sum", "first", "last", "min", "max")
+    if return_type == "dask":
+        allowed_combine = allowed_combine + ("median",)
+    if combine_function not in allowed_combine:
+        raise ValueError(f"combine_function should be one of {'/'.join(allowed_combine)}")
 
     if reproject_function is None:
         raise ValueError(
@@ -256,14 +264,8 @@ def reproject_and_coadd(
     if coadd_with_dask:
         if match_background:
             raise ValueError("Cannot use return_type='dask' together with match_background")
-        if input_weights is not None:
-            raise NotImplementedError("return_type='dask' does not yet support input_weights")
-        if combine_function not in ("mean", "sum", "min", "max"):
-            raise NotImplementedError(
-                "return_type='dask' currently only supports combine_function 'mean', "
-                "'sum', 'min' or 'max'"
-            )
         dask_arrays = []
+        dask_footprints = []
     else:
         if output_array is None:
             output_array = np.zeros(shape_out)
@@ -439,25 +441,56 @@ def reproject_and_coadd(
                 block_size = global_block_size
 
             if coadd_with_dask:
-                # Reproject this image lazily and pad the cutout back onto the full
-                # output grid (filling the uncovered region with NaN so the nan-aware
-                # reduction later ignores it). Nothing is computed here.
+                # Reproject this image (and its weights) lazily, mirroring the return_type='numpy'
+                # per-image handling: NaNs are masked out of the array and footprint,
+                # any weights are folded into the footprint, and both the array and
+                # footprint are padded back onto the full output grid (the uncovered
+                # region gets a zero footprint so it drops out of the combine). The
+                # footprint is kept so that the combine below can weight by it exactly
+                # as the return_type='numpy' path does. Nothing is computed here.
                 logger.info(
                     f"Calling {reproject_function.__name__} lazily with "
                     f"shape_out={shape_out_indiv} (return_type='dask')"
                 )
-                array = reproject_function(
+                # A dask return requires the reprojection to run in blocks, so fall
+                # back to automatic block sizes if none was given for this image.
+                dask_block_size = block_size if block_size is not None else "auto"
+                array, footprint = reproject_function(
                     (array_in, wcs_in),
                     output_projection=wcs_out_indiv,
                     shape_out=shape_out_indiv,
                     hdu_in=hdu_in,
-                    return_footprint=False,
+                    return_footprint=True,
                     return_type="dask",
-                    block_size=block_size,
+                    block_size=dask_block_size,
                     **kwargs,
                 )
+
+                if weights_in is not None:
+                    weights = reproject_function(
+                        (weights_in, weights_wcs),
+                        output_projection=wcs_out_indiv,
+                        shape_out=shape_out_indiv,
+                        hdu_in=hdu_in,
+                        return_footprint=False,
+                        return_type="dask",
+                        block_size=dask_block_size,
+                        **kwargs,
+                    )
+                else:
+                    weights = None
+
+                reset = da.isnan(array)
+                if weights is not None:
+                    reset = reset | da.isnan(weights)
+                array = da.where(reset, 0.0, array)
+                footprint = da.where(reset, 0.0, footprint)
+                if weights is not None:
+                    footprint = footprint * da.where(reset, 0.0, weights)
+
                 pad = [(imin, shape_out[idim] - imax) for idim, (imin, imax) in enumerate(bounds)]
-                dask_arrays.append(da.pad(array, pad, constant_values=np.nan))
+                dask_arrays.append(da.pad(array, pad, constant_values=0.0))
+                dask_footprints.append(da.pad(footprint, pad, constant_values=0.0))
                 continue
 
             # TODO: optimize handling of weights by making reprojection functions
@@ -622,20 +655,58 @@ def reproject_and_coadd(
             arrays = []
 
     if coadd_with_dask:
-        # Combine all the lazily-reprojected, NaN-padded images with a single
-        # nan-aware reduction along the stacking axis. The result is returned
-        # uncomputed so the entire graph (reprojections and co-addition) is
+        # Combine all the lazily-reprojected images along the stacking axis, matching
+        # the return_type='numpy' _combine_array_into_output semantics exactly, and return the
+        # result uncomputed so the whole graph (reprojections and co-addition) is
         # evaluated in one deferred computation by the caller.
-        stacked = da.stack(dask_arrays)
-        if combine_function == "mean":
-            output_array = da.nanmean(stacked, axis=0)
-        elif combine_function == "sum":
-            output_array = da.nansum(stacked, axis=0)
-        elif combine_function == "min":
-            output_array = da.nanmin(stacked, axis=0)
-        elif combine_function == "max":
-            output_array = da.nanmax(stacked, axis=0)
-        output_footprint = da.isfinite(stacked).sum(axis=0)
+        stacked_array = da.stack(dask_arrays)
+        stacked_footprint = da.stack(dask_footprints)
+        covered = stacked_footprint > 0
+
+        if combine_function in ("mean", "sum"):
+            # Footprint-weighted sum: output = sum(array * footprint), footprint =
+            # sum(footprint), and for the mean divide the two (as the return_type='numpy' path does).
+            numerator = da.where(covered, stacked_array * stacked_footprint, 0.0).sum(axis=0)
+            output_footprint = stacked_footprint.sum(axis=0)
+            if combine_function == "sum":
+                output_array = numerator
+            else:
+                with np.errstate(invalid="ignore"):
+                    output_array = numerator / output_footprint
+        elif combine_function == "median":
+            # Unweighted median of the covered images. This is only available for the
+            # dask path (the return_type='numpy' path cannot compute a median on the fly); the median
+            # needs the whole stacking axis at once, so it is collapsed to one chunk.
+            masked = da.where(covered, stacked_array, np.nan).rechunk({0: -1})
+            output_array = da.nanmedian(masked, axis=0)
+            output_footprint = stacked_footprint.sum(axis=0)
+        else:
+            # first/last/min/max select one image per pixel; we find its index along
+            # the stacking axis and take both the value and the footprint from there.
+            n_images = stacked_array.shape[0]
+            axis_index = da.arange(n_images).reshape((n_images,) + (1,) * (stacked_array.ndim - 1))
+            if combine_function == "first":
+                selected = da.where(covered, axis_index, n_images).min(axis=0)
+            elif combine_function == "last":
+                selected = da.where(covered, axis_index, -1).max(axis=0)
+            elif combine_function == "min":
+                selected = da.where(covered, stacked_array, np.inf).argmin(axis=0)
+            elif combine_function == "max":
+                selected = da.where(covered, stacked_array, -np.inf).argmax(axis=0)
+            else:
+                raise ValueError(f"Unexpected combine_function: {combine_function}")
+            any_covered = covered.any(axis=0)
+            selected = da.where(any_covered, selected, 0)
+            # Pick the value and footprint from the selected image with a one-hot
+            # mask along the stacking axis (dask has no take_along_axis).
+            onehot = axis_index == selected[np.newaxis]
+            output_array = da.where(onehot, stacked_array, 0.0).sum(axis=0)
+            output_footprint = da.where(onehot, stacked_footprint, 0.0).sum(axis=0)
+            output_footprint = da.where(any_covered, output_footprint, 0.0)
+
+        # Match the return_type='numpy' path's final step: set pixels with no coverage to the blank
+        # value (the return_type='numpy' loop does this at the end for output_footprint == 0).
+        output_array = da.where(output_footprint > 0, output_array, blank_pixel_value)
         return output_array, output_footprint
 
     # We need to avoid potentially large memory allocation from output == 0 so

--- a/reproject/mosaicking/_coadd.py
+++ b/reproject/mosaicking/_coadd.py
@@ -204,14 +204,15 @@ def _input_cutout_iterator(
 
         # If the block size matches the output shape along the reprojected
         # dimensions, we need to shrink those entries to match this cutout's
-        # size (keeping the broadcasted entries) so that the per-image
-        # reprojection parallelizes over the broadcasted dimensions.
+        # size (keeping any leading entries, which the block size may omit
+        # entirely if it only covers the reprojected dimensions) so that the
+        # per-image reprojection parallelizes over the broadcasted dimensions.
         if (
             global_block_size
             and not isinstance(global_block_size, str)
             and tuple(global_block_size[-n_dim_reproject:]) == tuple(shape_out[-n_dim_reproject:])
         ):
-            block_size = tuple(global_block_size[:n_broadcasted]) + tuple(
+            block_size = tuple(global_block_size[:-n_dim_reproject]) + tuple(
                 shape_out_indiv[n_broadcasted:]
             )
         else:
@@ -527,6 +528,7 @@ def _coadd_numpy(
                     shape_out=cutout.shape_out_indiv,
                     hdu_in=hdu_in,
                     output_array=weights,
+                    block_size=cutout.block_size,
                     return_footprint=False,
                     **reproject_kwargs,
                 )

--- a/reproject/mosaicking/_coadd.py
+++ b/reproject/mosaicking/_coadd.py
@@ -174,7 +174,7 @@ def reproject_and_coadd(
     intermediate_memmap : bool, optional
         If `True`, use `numpy.memmap` to store intermediate output arrays for
         reprojected data.
-    return_type : {None, 'dask'}, optional
+    return_type : {None, 'numpy', 'dask'}, optional
         If ``'dask'``, reproject each image lazily (using ``return_type='dask'``
         on the reprojection function), pad each onto the output grid, and combine
         them along a stacking axis, returning the resulting **uncomputed** dask
@@ -184,9 +184,10 @@ def reproject_and_coadd(
         'first', 'last', 'min' and 'max'), and ``input_weights`` are supported. A
         ``combine_function`` of 'median' is additionally available here (as an
         unweighted median), which the ``return_type='numpy'`` path cannot compute.
-        ``match_background`` is not supported, since it requires all images up front
-        rather than a single deferred graph. The default (`None`) uses the standard
-        ``return_type='numpy'`` co-addition.
+        ``match_background``, ``output_array``, ``output_footprint`` and
+        ``intermediate_memmap`` are not supported, since the result is a deferred
+        graph rather than arrays filled in place. The default (`None`, equivalent
+        to ``'numpy'``) uses the standard eager co-addition.
 
     **kwargs
         Keyword arguments to be passed to the reprojection function.
@@ -209,6 +210,13 @@ def reproject_and_coadd(
 
     # Validate inputs
 
+    # Validate return_type up front: a typo such as 'Dask' would otherwise
+    # silently select the eager numpy co-addition.
+    if return_type is None:
+        return_type = "numpy"
+    if return_type not in ("numpy", "dask"):
+        raise ValueError("return_type should be set to 'numpy' or 'dask'")
+
     # 'median' is only available for the deferred dask path (return_type='dask'); the
     # return_type='numpy' path cannot compute a median on the fly.
     allowed_combine = ("mean", "sum", "first", "last", "min", "max")
@@ -226,6 +234,25 @@ def reproject_and_coadd(
         if block_sizes is not None:
             raise ValueError("Cannot specify block_sizes= and block_size= at the same time")
         block_sizes = kwargs.pop("block_size")
+
+    # block_sizes may be a single block size to use for every dataset (a tuple
+    # of values or 'auto') or one block size per dataset (a list of lists or
+    # tuples). Normalize it once here to one entry per dataset, keeping track
+    # of the single common block size (if there is one), which is also used as
+    # the output chunking for the deferred return_type='dask' co-addition.
+    common_block_size = None
+    if block_sizes is None:
+        block_sizes = [None] * len(input_data)
+    elif isinstance(block_sizes, str) or not any(
+        isinstance(entry, (list, tuple)) for entry in block_sizes
+    ):
+        common_block_size = block_sizes if isinstance(block_sizes, str) else tuple(block_sizes)
+        block_sizes = [common_block_size] * len(input_data)
+    elif len(block_sizes) != len(input_data):
+        raise ValueError(
+            f"block_sizes should be a single block size or one per dataset "
+            f"({len(input_data)}), got {len(block_sizes)}"
+        )
 
     # non_reprojected_dims is used below to size the cutouts correctly and is
     # also forwarded to reproject_function for each individual reprojection.
@@ -264,6 +291,12 @@ def reproject_and_coadd(
     if coadd_with_dask:
         if match_background:
             raise ValueError("Cannot use return_type='dask' together with match_background")
+        if output_array is not None or output_footprint is not None:
+            raise ValueError(
+                "Cannot use return_type='dask' together with output_array or output_footprint"
+            )
+        if intermediate_memmap:
+            raise ValueError("Cannot use return_type='dask' together with intermediate_memmap")
         dask_arrays = []
         dask_footprints = []
     else:
@@ -284,6 +317,21 @@ def reproject_and_coadd(
             )
 
     logger.info(f"Output mosaic will have shape {shape_out}")
+
+    ndim_out = len(shape_out)
+
+    # Determine how many leading dimensions are broadcasted (i.e. not
+    # reprojected). If non_reprojected_dims is set these are given
+    # explicitly; otherwise they are the dimensions for which the output
+    # WCS has fewer pixel dimensions than the data.
+    if non_reprojected_dims is not None:
+        n_broadcasted = len(non_reprojected_dims)
+    else:
+        n_broadcasted = len(shape_out) - wcs_out.low_level_wcs.pixel_n_dim
+    n_dim_reproject = len(shape_out) - n_broadcasted
+    # Number of leading dimensions that the output WCS does not itself
+    # describe and which therefore have to be skipped when slicing it.
+    n_wcs_out_extra = len(shape_out) - wcs_out.low_level_wcs.pixel_n_dim
 
     # Define 'on-the-fly' mode: in the case where we don't need to match the
     # backgrounds, we don't have to keep track of the intermediate arrays and
@@ -364,21 +412,6 @@ def reproject_and_coadd(
             # such as all-sky images or full solar disk views. In this case we skip
             # this step and just use the full output WCS for reprojection.
 
-            ndim_out = len(shape_out)
-
-            # Determine how many leading dimensions are broadcasted (i.e. not
-            # reprojected). If non_reprojected_dims is set these are given
-            # explicitly; otherwise they are the dimensions for which the output
-            # WCS has fewer pixel dimensions than the data.
-            if non_reprojected_dims is not None:
-                n_broadcasted = len(non_reprojected_dims)
-            else:
-                n_broadcasted = len(shape_out) - wcs_out.low_level_wcs.pixel_n_dim
-            n_dim_reproject = len(shape_out) - n_broadcasted
-            # Number of leading dimensions that the output WCS does not itself
-            # describe and which therefore have to be skipped when slicing it.
-            n_wcs_out_extra = len(shape_out) - wcs_out.low_level_wcs.pixel_n_dim
-
             skip_data = False
             if np.any(np.isnan(edges_out)):
                 bounds = list(zip([0] * ndim_out, shape_out, strict=False))
@@ -417,22 +450,17 @@ def reproject_and_coadd(
 
             shape_out_indiv = tuple([imax - imin for (imin, imax) in bounds])
 
-            if block_sizes is not None:
-                if len(block_sizes) == len(input_data) and len(block_sizes[idata]) == len(
-                    shape_out
-                ):
-                    global_block_size = block_sizes[idata]
-                else:
-                    global_block_size = block_sizes
-            else:
-                global_block_size = None
+            global_block_size = block_sizes[idata]
 
             # If the block size matches the output shape along the reprojected
             # dimensions, we need to shrink those entries to match this cutout's
             # size (keeping the broadcasted entries) so that the per-image
             # reprojection parallelizes over the broadcasted dimensions.
-            if global_block_size and tuple(global_block_size[-n_dim_reproject:]) == tuple(
-                shape_out[-n_dim_reproject:]
+            if (
+                global_block_size
+                and not isinstance(global_block_size, str)
+                and tuple(global_block_size[-n_dim_reproject:])
+                == tuple(shape_out[-n_dim_reproject:])
             ):
                 block_size = tuple(global_block_size[:n_broadcasted]) + tuple(
                     shape_out_indiv[n_broadcasted:]
@@ -667,63 +695,78 @@ def reproject_and_coadd(
         # every image to one common chunking first so the stack and reduction stay
         # small and the memory per chunk stays bounded.
         #
-        # When the user gave a block size, use it as the output chunking so they stay
-        # in control. Otherwise default to splitting along the non-reprojected
-        # (leading) dimensions, so each output chunk is a single plane rather than the
-        # whole non-reprojected extent -- that keeps memory bounded to a plane per
-        # image and lets the reprojection and co-addition stream plane by plane instead
-        # of reprojecting every image in full before combining.
-        if non_reprojected_dims is not None:
-            n_broadcast = len(non_reprojected_dims)
-        else:
-            n_broadcast = len(shape_out) - wcs_out.low_level_wcs.pixel_n_dim
-        n_dim_reproject = len(shape_out) - n_broadcast
-
-        # block_sizes may be a single block size or a per-dataset list of them; only a
-        # single block size maps onto one output chunking.
+        # When the user gave a single common block size, use it as the output chunking
+        # so they stay in control (a per-dataset list of block sizes cannot map onto
+        # one output chunking, so it falls back to the default). Otherwise default to
+        # splitting along the non-reprojected (leading) dimensions, so each output
+        # chunk is a single plane rather than the whole non-reprojected extent -- that
+        # keeps memory bounded to a plane per image and lets the reprojection and
+        # co-addition stream plane by plane instead of reprojecting every image in
+        # full before combining.
         block_size = None
-        if block_sizes is not None and not any(
-            isinstance(entry, (list, tuple)) for entry in block_sizes
-        ):
-            block_size = tuple(block_sizes)
+        if common_block_size is not None and not isinstance(common_block_size, str):
+            block_size = common_block_size
 
         if block_size is None:
-            chunk_spec = (1,) * n_broadcast + ("auto",) * n_dim_reproject
+            chunk_spec = (1,) * n_broadcasted + ("auto",) * n_dim_reproject
         elif len(block_size) == n_dim_reproject:
             # A block size given only for the reprojected dimensions; take one plane at
             # a time along the non-reprojected ones.
-            chunk_spec = (1,) * n_broadcast + block_size
+            chunk_spec = (1,) * n_broadcasted + block_size
         else:
             chunk_spec = block_size
         target_chunks = da.core.normalize_chunks(chunk_spec, shape=tuple(shape_out), dtype=float)
+
+        if not dask_arrays:
+            # No image is predicted to overlap the output; return the same blank
+            # mosaic and zero footprint as the return_type='numpy' path, lazily.
+            output_array = da.full(
+                tuple(shape_out), float(blank_pixel_value), chunks=target_chunks
+            )
+            output_footprint = da.zeros(tuple(shape_out), chunks=target_chunks)
+            return output_array, output_footprint
+
         dask_arrays = [array.rechunk(target_chunks) for array in dask_arrays]
         dask_footprints = [footprint.rechunk(target_chunks) for footprint in dask_footprints]
         stacked_array = da.stack(dask_arrays)
         stacked_footprint = da.stack(dask_footprints)
-        covered = stacked_footprint > 0
 
         if combine_function in ("mean", "sum"):
             # Footprint-weighted sum: output = sum(array * footprint), footprint =
             # sum(footprint), and for the mean divide the two (as the
-            # return_type='numpy' path does). The numerator is zero wherever the
-            # footprint is zero, so divide by a footprint that has its zeros replaced
-            # by one to avoid a lazily-evaluated 0/0 (which would warn at compute time).
-            numerator = da.where(covered, stacked_array * stacked_footprint, 0.0).sum(axis=0)
+            # return_type='numpy' path does, including contributions where the
+            # footprint is negative, which can happen when reprojecting weight maps
+            # with interpolation orders that overshoot). The numerator is zero
+            # wherever the footprint is zero, so for the mean divide by a footprint
+            # that has its zeros replaced by one to avoid a lazily-evaluated 0/0
+            # (which would warn at compute time).
+            output_array = (stacked_array * stacked_footprint).sum(axis=0)
             output_footprint = stacked_footprint.sum(axis=0)
-            if combine_function == "sum":
-                output_array = numerator
-            else:
-                output_array = numerator / da.where(output_footprint > 0, output_footprint, 1.0)
+            if combine_function == "mean":
+                output_array = output_array / da.where(
+                    output_footprint == 0, 1.0, output_footprint
+                )
         elif combine_function == "median":
+            covered = stacked_footprint > 0
             # Unweighted median of the covered images. This is only available for the
-            # dask path (the return_type='numpy' path cannot compute a median on the fly); the median
-            # needs the whole stacking axis at once, so it is collapsed to one chunk.
-            masked = da.where(covered, stacked_array, np.nan).rechunk({0: -1})
-            output_array = da.nanmedian(masked, axis=0)
+            # dask path (the return_type='numpy' path cannot compute a median on the fly).
+            masked = da.where(covered, stacked_array, np.nan)
+            # Pixels covered by no image at all would be all-NaN slices, which would
+            # make nanmedian warn at compute time; give them a value of zero since
+            # they are set to blank_pixel_value below anyway.
+            masked = da.where(covered.any(axis=0)[np.newaxis], masked, 0.0)
+            # The median needs the whole stacking axis at once, so collapse it to a
+            # single chunk and let dask re-split the other axes so that the total
+            # chunk size stays bounded instead of growing with the number of images.
+            masked = masked.rechunk(
+                {0: -1, **{iaxis: "auto" for iaxis in range(1, masked.ndim)}}
+            )
+            output_array = da.nanmedian(masked, axis=0).rechunk(target_chunks)
             output_footprint = stacked_footprint.sum(axis=0)
         else:
             # first/last/min/max select one image per pixel; we find its index along
             # the stacking axis and take both the value and the footprint from there.
+            covered = stacked_footprint > 0
             n_images = stacked_array.shape[0]
             axis_index = da.arange(n_images).reshape((n_images,) + (1,) * (stacked_array.ndim - 1))
             if combine_function == "first":
@@ -736,18 +779,19 @@ def reproject_and_coadd(
                 selected = da.where(covered, stacked_array, -np.inf).argmax(axis=0)
             else:
                 raise ValueError(f"Unexpected combine_function: {combine_function}")
-            any_covered = covered.any(axis=0)
-            selected = da.where(any_covered, selected, 0)
             # Pick the value and footprint from the selected image with a one-hot
-            # mask along the stacking axis (dask has no take_along_axis).
+            # mask along the stacking axis (dask has no take_along_axis). For pixels
+            # covered by no image, the selected index either matches no image
+            # (first/last) or picks an image whose footprint there is zero (min/max),
+            # so the sums give a zero footprint and the pixel is blanked below.
             onehot = axis_index == selected[np.newaxis]
             output_array = da.where(onehot, stacked_array, 0.0).sum(axis=0)
             output_footprint = da.where(onehot, stacked_footprint, 0.0).sum(axis=0)
-            output_footprint = da.where(any_covered, output_footprint, 0.0)
 
-        # Match the return_type='numpy' path's final step: set pixels with no coverage to the blank
-        # value (the return_type='numpy' loop does this at the end for output_footprint == 0).
-        output_array = da.where(output_footprint > 0, output_array, blank_pixel_value)
+        # Match the return_type='numpy' path's final step: set pixels with no coverage
+        # to the blank value (the return_type='numpy' loop does this at the end where
+        # output_footprint == 0, keeping pixels with a negative summed footprint).
+        output_array = da.where(output_footprint == 0, blank_pixel_value, output_array)
         return output_array, output_footprint
 
     # We need to avoid potentially large memory allocation from output == 0 so

--- a/reproject/mosaicking/_coadd.py
+++ b/reproject/mosaicking/_coadd.py
@@ -82,7 +82,7 @@ _InputCutout = namedtuple(
 )
 
 
-def _iterate_input_cutouts(
+def _input_cutout_iterator(
     input_data,
     input_weights,
     hdu_in,
@@ -890,7 +890,7 @@ def reproject_and_coadd(
             chunk_spec = block_size
         target_chunks = da.core.normalize_chunks(chunk_spec, shape=tuple(shape_out), dtype=float)
 
-    cutouts = _iterate_input_cutouts(
+    cutouts = _input_cutout_iterator(
         input_data,
         input_weights,
         hdu_in,

--- a/reproject/mosaicking/_coadd.py
+++ b/reproject/mosaicking/_coadd.py
@@ -64,6 +64,54 @@ def _combine_array_into_output(combine_function, array, output_array, output_foo
             raise ValueError(f"Unexpected combine_function: {combine_function}")
 
 
+def _pad_to_output_grid(array, bounds, shape_out, target_chunks):
+    """
+    Pad a lazily-reprojected cutout onto the full output grid, with chunk
+    boundaries aligned to the target output chunking.
+
+    da.pad would chunk the pad region at the cutout's own chunk sizes, so the
+    later rechunk to the output chunking would have to split and recombine
+    chunks, making the number of tasks grow much faster than the number of
+    images. With the chunks aligned here, the final rechunk only has to merge
+    chunks at the cutout edges.
+    """
+    for idim, (imin, imax) in enumerate(bounds):
+        edges = np.cumsum(target_chunks[idim])[:-1]
+
+        def aligned_chunks(lo, hi, edges=edges):
+            cuts = [lo] + [int(edge) for edge in edges if lo < edge < hi] + [hi]
+            return tuple(np.diff(cuts).tolist())
+
+        array = array.rechunk(
+            array.chunks[:idim] + (aligned_chunks(imin, imax),) + array.chunks[idim + 1 :]
+        )
+        pieces = [array]
+        if imin > 0:
+            pieces.insert(
+                0,
+                da.zeros(
+                    array.shape[:idim] + (imin,) + array.shape[idim + 1 :],
+                    chunks=array.chunks[:idim]
+                    + (aligned_chunks(0, imin),)
+                    + array.chunks[idim + 1 :],
+                    dtype=array.dtype,
+                ),
+            )
+        if imax < shape_out[idim]:
+            pieces.append(
+                da.zeros(
+                    array.shape[:idim] + (shape_out[idim] - imax,) + array.shape[idim + 1 :],
+                    chunks=array.chunks[:idim]
+                    + (aligned_chunks(imax, shape_out[idim]),)
+                    + array.chunks[idim + 1 :],
+                    dtype=array.dtype,
+                ),
+            )
+        if len(pieces) > 1:
+            array = da.concatenate(pieces, axis=idim)
+    return array
+
+
 def reproject_and_coadd(
     input_data,
     output_projection,
@@ -333,6 +381,31 @@ def reproject_and_coadd(
     # describe and which therefore have to be skipped when slicing it.
     n_wcs_out_extra = len(shape_out) - wcs_out.low_level_wcs.pixel_n_dim
 
+    if coadd_with_dask:
+        # The deferred co-addition below stacks all the lazily-reprojected images,
+        # which requires a single common chunking. When the user gave a single
+        # common block size, use it as the output chunking so they stay in control
+        # (a per-dataset list of block sizes cannot map onto one output chunking,
+        # so it falls back to the default). Otherwise default to splitting along
+        # the non-reprojected (leading) dimensions, so each output chunk is a
+        # single plane rather than the whole non-reprojected extent -- that keeps
+        # memory bounded to a plane per image and lets the reprojection and
+        # co-addition stream plane by plane instead of reprojecting every image
+        # in full before combining.
+        block_size = None
+        if common_block_size is not None and not isinstance(common_block_size, str):
+            block_size = common_block_size
+
+        if block_size is None:
+            chunk_spec = (1,) * n_broadcasted + ("auto",) * n_dim_reproject
+        elif len(block_size) == n_dim_reproject:
+            # A block size given only for the reprojected dimensions; take one
+            # plane at a time along the non-reprojected ones.
+            chunk_spec = (1,) * n_broadcasted + block_size
+        else:
+            chunk_spec = block_size
+        target_chunks = da.core.normalize_chunks(chunk_spec, shape=tuple(shape_out), dtype=float)
+
     # Define 'on-the-fly' mode: in the case where we don't need to match the
     # backgrounds, we don't have to keep track of the intermediate arrays and
     # can just modify the output array on-the-fly
@@ -516,9 +589,10 @@ def reproject_and_coadd(
                 if weights is not None:
                     footprint = footprint * da.where(reset, 0.0, weights)
 
-                pad = [(imin, shape_out[idim] - imax) for idim, (imin, imax) in enumerate(bounds)]
-                dask_arrays.append(da.pad(array, pad, constant_values=0.0))
-                dask_footprints.append(da.pad(footprint, pad, constant_values=0.0))
+                dask_arrays.append(_pad_to_output_grid(array, bounds, shape_out, target_chunks))
+                dask_footprints.append(
+                    _pad_to_output_grid(footprint, bounds, shape_out, target_chunks)
+                )
                 continue
 
             # TODO: optimize handling of weights by making reprojection functions
@@ -687,35 +761,6 @@ def reproject_and_coadd(
         # the return_type='numpy' _combine_array_into_output semantics exactly, and
         # return the result uncomputed so the whole graph (reprojections and
         # co-addition) is evaluated in one deferred computation by the caller.
-        #
-        # Each image was padded to the full output grid, but with chunk boundaries
-        # that depend on where it landed. Stacking arrays with mismatched chunks makes
-        # dask unify them into an ever-finer grid, so the task count grows super-
-        # linearly with the number of images (the co-addition appears to hang). Rechunk
-        # every image to one common chunking first so the stack and reduction stay
-        # small and the memory per chunk stays bounded.
-        #
-        # When the user gave a single common block size, use it as the output chunking
-        # so they stay in control (a per-dataset list of block sizes cannot map onto
-        # one output chunking, so it falls back to the default). Otherwise default to
-        # splitting along the non-reprojected (leading) dimensions, so each output
-        # chunk is a single plane rather than the whole non-reprojected extent -- that
-        # keeps memory bounded to a plane per image and lets the reprojection and
-        # co-addition stream plane by plane instead of reprojecting every image in
-        # full before combining.
-        block_size = None
-        if common_block_size is not None and not isinstance(common_block_size, str):
-            block_size = common_block_size
-
-        if block_size is None:
-            chunk_spec = (1,) * n_broadcasted + ("auto",) * n_dim_reproject
-        elif len(block_size) == n_dim_reproject:
-            # A block size given only for the reprojected dimensions; take one plane at
-            # a time along the non-reprojected ones.
-            chunk_spec = (1,) * n_broadcasted + block_size
-        else:
-            chunk_spec = block_size
-        target_chunks = da.core.normalize_chunks(chunk_spec, shape=tuple(shape_out), dtype=float)
 
         if not dask_arrays:
             # No image is predicted to overlap the output; return the same blank
@@ -726,6 +771,13 @@ def reproject_and_coadd(
             output_footprint = da.zeros(tuple(shape_out), chunks=target_chunks)
             return output_array, output_footprint
 
+        # Each padded image has chunks aligned to the output chunking, with at most
+        # two extra chunk boundaries per dimension at the cutout edges. Rechunking to
+        # the common output chunking here therefore only merges those, and stacking
+        # identically-chunked arrays keeps the stack and reduction below small
+        # (stacking mismatched chunk grids would make dask unify them into an
+        # ever-finer grid, with the task count growing super-linearly with the
+        # number of images).
         dask_arrays = [array.rechunk(target_chunks) for array in dask_arrays]
         dask_footprints = [footprint.rechunk(target_chunks) for footprint in dask_footprints]
         stacked_array = da.stack(dask_arrays)

--- a/reproject/mosaicking/_coadd.py
+++ b/reproject/mosaicking/_coadd.py
@@ -3,6 +3,7 @@ import os
 import sys
 import tempfile
 import uuid
+from collections import namedtuple
 from logging import getLogger
 
 import dask.array as da
@@ -62,6 +63,539 @@ def _combine_array_into_output(combine_function, array, output_array, output_foo
             np.copyto(output_array[chunk.view_in_original_array], chunk.array, where=mask)
         else:
             raise ValueError(f"Unexpected combine_function: {combine_function}")
+
+
+# Everything the per-image reprojection needs to know about one input dataset
+# and the cutout of the output grid that it covers.
+_InputCutout = namedtuple(
+    "_InputCutout",
+    [
+        "array_in",
+        "wcs_in",
+        "weights_in",
+        "weights_wcs",
+        "bounds",
+        "wcs_out_indiv",
+        "shape_out_indiv",
+        "block_size",
+    ],
+)
+
+
+def _iterate_input_cutouts(
+    input_data,
+    input_weights,
+    hdu_in,
+    hdu_weights,
+    wcs_out,
+    shape_out,
+    block_sizes,
+    n_broadcasted,
+    n_dim_reproject,
+    n_wcs_out_extra,
+    progress_bar,
+):
+    """
+    Parse each input dataset (and its weights map) and compute the minimal
+    cutout of the output grid that it covers, yielding everything that the
+    per-image reprojection needs. Datasets with no predicted overlap with the
+    output are skipped. This is shared between the eager (numpy) and deferred
+    (dask) co-addition drivers so that the cutout logic exists only once.
+    """
+    logger = getLogger(__name__)
+
+    ndim_out = len(shape_out)
+
+    for idata in progress_bar(range(len(input_data))):
+
+        logger.info(f"Processing input data {idata + 1} of {len(input_data)}")
+
+        # We need to pre-parse the data here since we need to figure out how to
+        # optimize/minimize the size of each output tile (see below).
+        array_in, wcs_in = parse_input_data(input_data[idata], hdu_in=hdu_in)
+
+        # We also get the weights map, if specified
+        if input_weights is None:
+            weights_in = None
+            weights_wcs = None
+        else:
+            weights_in, weights_wcs = parse_input_weights(
+                input_weights[idata], hdu_weights=hdu_weights
+            )
+            if weights_wcs is None:
+                # if weights are passed as an array
+                weights_wcs = wcs_in
+            else:
+                try:
+                    _validate_wcs(weights_wcs, wcs_in, weights_in.shape, shape_out)
+                except ValueError:
+                    # WCS is not valid (most likely, it is blank?)
+                    weights_wcs = wcs_in
+            if np.any(np.isnan(weights_in)):
+                weights_in = np.nan_to_num(weights_in)
+
+        # Since we might be reprojecting small images into a large mosaic we
+        # want to make sure that for each image we reproject to an array with
+        # minimal footprint. We therefore find the pixel coordinates of the
+        # edges of the initial image and transform this to pixel coordinates in
+        # the final image to figure out the final WCS and shape to reproject to
+        # for each tile. We strike a balance between transforming only the
+        # input-image corners, which is fast but can cause clipping in cases of
+        # significant distortion (when the edges of the input image become
+        # convex in the output projection), and transforming every edge pixel,
+        # which provides a lot of redundant information.
+
+        try:
+            edges_out = sample_input_edges_in_output(array_in.shape, wcs_in, wcs_out)
+        except Exception as exc:
+            # If the edge coordinates cannot be transformed (for example if
+            # they fall outside the validity region of the WCS), fall back to
+            # assuming no predicted overlap so the full output is considered.
+            logger.info(
+                f"Could not determine cutout bounds for input data {idata + 1} "
+                f"({exc}), reprojecting to the full output instead"
+            )
+            edges_out = np.array([np.nan])
+
+        # Determine the cutout parameters
+
+        # In some cases, images might not have valid coordinates in the corners,
+        # such as all-sky images or full solar disk views. In this case we skip
+        # this step and just use the full output WCS for reprojection.
+
+        skip_data = False
+        if np.any(np.isnan(edges_out)):
+            bounds = list(zip([0] * ndim_out, shape_out, strict=False))
+        else:
+            bounds = []
+            if n_broadcasted > 0:
+                for idim in range(n_broadcasted):
+                    bounds.append((0, shape_out[idim]))
+            # Only the reprojected (trailing) dimensions get a cutout; the
+            # corresponding edge coordinates are the trailing components of
+            # edges_out (which has one entry per input WCS pixel dimension).
+            edges_out_reproject = edges_out[-n_dim_reproject:]
+            for idim in range(len(edges_out_reproject)):
+                imin = max(0, int(np.floor(edges_out_reproject[idim].min() + 0.5)))
+                imax = min(
+                    shape_out[n_broadcasted + idim],
+                    int(np.ceil(edges_out_reproject[idim].max() + 0.5)),
+                )
+                bounds.append((imin, imax))
+                if imax <= imin:
+                    skip_data = True
+                    break
+
+        if skip_data:
+            logger.info("Skipping reprojection as no predicted overlap with final mosaic header")
+            continue
+
+        slice_out = tuple([slice(imin, imax) for (imin, imax) in bounds[n_wcs_out_extra:]])
+
+        if isinstance(wcs_out, WCS):
+            wcs_out_indiv = wcs_out[slice_out]
+        else:
+            wcs_out_indiv = SlicedLowLevelWCS(wcs_out.low_level_wcs, slice_out)
+
+        shape_out_indiv = tuple([imax - imin for (imin, imax) in bounds])
+
+        global_block_size = block_sizes[idata]
+
+        # If the block size matches the output shape along the reprojected
+        # dimensions, we need to shrink those entries to match this cutout's
+        # size (keeping the broadcasted entries) so that the per-image
+        # reprojection parallelizes over the broadcasted dimensions.
+        if (
+            global_block_size
+            and not isinstance(global_block_size, str)
+            and tuple(global_block_size[-n_dim_reproject:]) == tuple(shape_out[-n_dim_reproject:])
+        ):
+            block_size = tuple(global_block_size[:n_broadcasted]) + tuple(
+                shape_out_indiv[n_broadcasted:]
+            )
+        else:
+            block_size = global_block_size
+
+        yield _InputCutout(
+            array_in=array_in,
+            wcs_in=wcs_in,
+            weights_in=weights_in,
+            weights_wcs=weights_wcs,
+            bounds=bounds,
+            wcs_out_indiv=wcs_out_indiv,
+            shape_out_indiv=shape_out_indiv,
+            block_size=block_size,
+        )
+
+
+def _coadd_dask(
+    cutouts,
+    *,
+    reproject_function,
+    combine_function,
+    shape_out,
+    target_chunks,
+    blank_pixel_value,
+    hdu_in,
+    reproject_kwargs,
+):
+    """
+    Deferred co-addition: reproject each cutout lazily, pad it onto the output
+    grid, and combine all the images along a stacking axis, matching the eager
+    path's _combine_array_into_output semantics exactly. The result is returned
+    uncomputed so the whole graph (reprojections and co-addition) is evaluated
+    in one deferred computation by the caller.
+    """
+    logger = getLogger(__name__)
+
+    dask_arrays = []
+    dask_footprints = []
+
+    for cutout in cutouts:
+        # Reproject this image (and its weights) lazily, mirroring the return_type='numpy'
+        # per-image handling: NaNs are masked out of the array and footprint,
+        # any weights are folded into the footprint, and both the array and
+        # footprint are padded back onto the full output grid (the uncovered
+        # region gets a zero footprint so it drops out of the combine). The
+        # footprint is kept so that the combine below can weight by it exactly
+        # as the return_type='numpy' path does. Nothing is computed here.
+        logger.info(
+            f"Calling {reproject_function.__name__} lazily with "
+            f"shape_out={cutout.shape_out_indiv} (return_type='dask')"
+        )
+        # A dask return requires the reprojection to run in blocks, so fall
+        # back to automatic block sizes if none was given for this image.
+        dask_block_size = cutout.block_size if cutout.block_size is not None else "auto"
+        array, footprint = reproject_function(
+            (cutout.array_in, cutout.wcs_in),
+            output_projection=cutout.wcs_out_indiv,
+            shape_out=cutout.shape_out_indiv,
+            hdu_in=hdu_in,
+            return_footprint=True,
+            return_type="dask",
+            block_size=dask_block_size,
+            **reproject_kwargs,
+        )
+
+        if cutout.weights_in is not None:
+            weights = reproject_function(
+                (cutout.weights_in, cutout.weights_wcs),
+                output_projection=cutout.wcs_out_indiv,
+                shape_out=cutout.shape_out_indiv,
+                hdu_in=hdu_in,
+                return_footprint=False,
+                return_type="dask",
+                block_size=dask_block_size,
+                **reproject_kwargs,
+            )
+        else:
+            weights = None
+
+        reset = da.isnan(array)
+        if weights is not None:
+            reset = reset | da.isnan(weights)
+        array = da.where(reset, 0.0, array)
+        footprint = da.where(reset, 0.0, footprint)
+        if weights is not None:
+            footprint = footprint * da.where(reset, 0.0, weights)
+
+        dask_arrays.append(pad_dask_array_to_grid(array, cutout.bounds, shape_out, target_chunks))
+        dask_footprints.append(
+            pad_dask_array_to_grid(footprint, cutout.bounds, shape_out, target_chunks)
+        )
+
+    if not dask_arrays:
+        # No image is predicted to overlap the output; return the same blank
+        # mosaic and zero footprint as the return_type='numpy' path, lazily.
+        output_array = da.full(tuple(shape_out), float(blank_pixel_value), chunks=target_chunks)
+        output_footprint = da.zeros(tuple(shape_out), chunks=target_chunks)
+        return output_array, output_footprint
+
+    # Each padded image has chunks aligned to the output chunking, with at most
+    # two extra chunk boundaries per dimension at the cutout edges. Rechunking to
+    # the common output chunking here therefore only merges those, and stacking
+    # identically-chunked arrays keeps the stack and reduction below small
+    # (stacking mismatched chunk grids would make dask unify them into an
+    # ever-finer grid, with the task count growing super-linearly with the
+    # number of images).
+    dask_arrays = [array.rechunk(target_chunks) for array in dask_arrays]
+    dask_footprints = [footprint.rechunk(target_chunks) for footprint in dask_footprints]
+    stacked_array = da.stack(dask_arrays)
+    stacked_footprint = da.stack(dask_footprints)
+
+    if combine_function in ("mean", "sum"):
+        # Footprint-weighted sum: output = sum(array * footprint), footprint =
+        # sum(footprint), and for the mean divide the two (as the
+        # return_type='numpy' path does, including contributions where the
+        # footprint is negative, which can happen when reprojecting weight maps
+        # with interpolation orders that overshoot). The numerator is zero
+        # wherever the footprint is zero, so for the mean divide by a footprint
+        # that has its zeros replaced by one to avoid a lazily-evaluated 0/0
+        # (which would warn at compute time).
+        output_array = (stacked_array * stacked_footprint).sum(axis=0)
+        output_footprint = stacked_footprint.sum(axis=0)
+        if combine_function == "mean":
+            output_array = output_array / da.where(output_footprint == 0, 1.0, output_footprint)
+    elif combine_function == "median":
+        covered = stacked_footprint > 0
+        # Unweighted median of the covered images. This is only available for the
+        # dask path (the return_type='numpy' path cannot compute a median on the fly).
+        masked = da.where(covered, stacked_array, np.nan)
+        # Pixels covered by no image at all would be all-NaN slices, which would
+        # make nanmedian warn at compute time; give them a value of zero since
+        # they are set to blank_pixel_value below anyway.
+        masked = da.where(covered.any(axis=0)[np.newaxis], masked, 0.0)
+        # The median needs the whole stacking axis at once, so collapse it to a
+        # single chunk and let dask re-split the other axes so that the total
+        # chunk size stays bounded instead of growing with the number of images.
+        masked = masked.rechunk({0: -1, **{iaxis: "auto" for iaxis in range(1, masked.ndim)}})
+        output_array = da.nanmedian(masked, axis=0).rechunk(target_chunks)
+        output_footprint = stacked_footprint.sum(axis=0)
+    else:
+        # first/last/min/max select one image per pixel; we find its index along
+        # the stacking axis and take both the value and the footprint from there.
+        covered = stacked_footprint > 0
+        n_images = stacked_array.shape[0]
+        axis_index = da.arange(n_images).reshape((n_images,) + (1,) * (stacked_array.ndim - 1))
+        if combine_function == "first":
+            selected = da.where(covered, axis_index, n_images).min(axis=0)
+        elif combine_function == "last":
+            selected = da.where(covered, axis_index, -1).max(axis=0)
+        elif combine_function == "min":
+            selected = da.where(covered, stacked_array, np.inf).argmin(axis=0)
+        elif combine_function == "max":
+            selected = da.where(covered, stacked_array, -np.inf).argmax(axis=0)
+        else:
+            raise ValueError(f"Unexpected combine_function: {combine_function}")
+        # Pick the value and footprint from the selected image with a one-hot
+        # mask along the stacking axis (dask has no take_along_axis). For pixels
+        # covered by no image, the selected index either matches no image
+        # (first/last) or picks an image whose footprint there is zero (min/max),
+        # so the sums give a zero footprint and the pixel is blanked below.
+        onehot = axis_index == selected[np.newaxis]
+        output_array = da.where(onehot, stacked_array, 0.0).sum(axis=0)
+        output_footprint = da.where(onehot, stacked_footprint, 0.0).sum(axis=0)
+
+    # Match the return_type='numpy' path's final step: set pixels with no coverage
+    # to the blank value (the return_type='numpy' loop does this at the end where
+    # output_footprint == 0, keeping pixels with a negative summed footprint).
+    output_array = da.where(output_footprint == 0, blank_pixel_value, output_array)
+    return output_array, output_footprint
+
+
+def _coadd_numpy(
+    cutouts,
+    *,
+    reproject_function,
+    combine_function,
+    match_background,
+    background_reference,
+    output_array,
+    output_footprint,
+    intermediate_memmap,
+    blank_pixel_value,
+    hdu_in,
+    reproject_kwargs,
+):
+    """
+    Eager co-addition: reproject each cutout and combine it into the output
+    arrays, either on the fly or, when the backgrounds need to be matched,
+    after all the images have been reprojected.
+    """
+    logger = getLogger(__name__)
+
+    # Define 'on-the-fly' mode: in the case where we don't need to match the
+    # backgrounds, we don't have to keep track of the intermediate arrays and
+    # can just modify the output array on-the-fly
+    on_the_fly = not match_background
+
+    on_the_fly_prefix = "Using" if on_the_fly else "Not using"
+    logger.info(
+        f"{on_the_fly_prefix} on-the-fly mode for adding individual reprojected images to output array"
+    )
+
+    if not on_the_fly:
+        arrays = []
+
+    if combine_function == "min":
+        output_array[...] = np.inf
+    elif combine_function == "max":
+        output_array[...] = -np.inf
+
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=IS_WIN) as local_tmp_dir:
+
+        for cutout in cutouts:
+
+            # TODO: optimize handling of weights by making reprojection functions
+            # able to handle weights, and make the footprint become the combined
+            # footprint + weight map
+
+            if intermediate_memmap:
+
+                array_path = os.path.join(local_tmp_dir, f"array_{uuid.uuid4()}.np")
+
+                logger.info(
+                    f"Creating memory-mapped array with shape {cutout.shape_out_indiv} at {array_path}"
+                )
+
+                array = np.memmap(
+                    array_path,
+                    shape=cutout.shape_out_indiv,
+                    mode="w+",
+                    dtype=cutout.array_in.dtype,
+                )
+
+                footprint_path = os.path.join(local_tmp_dir, f"footprint_{uuid.uuid4()}.np")
+
+                logger.info(
+                    f"Creating memory-mapped footprint with shape {cutout.shape_out_indiv} at {footprint_path}"
+                )
+
+                footprint = np.memmap(
+                    footprint_path,
+                    shape=cutout.shape_out_indiv,
+                    mode="w+",
+                    dtype=float,
+                )
+
+            else:
+
+                array = footprint = None
+
+            logger.info(
+                f"Calling {reproject_function.__name__} with shape_out={cutout.shape_out_indiv}"
+            )
+
+            array, footprint = reproject_function(
+                (cutout.array_in, cutout.wcs_in),
+                output_projection=cutout.wcs_out_indiv,
+                shape_out=cutout.shape_out_indiv,
+                hdu_in=hdu_in,
+                output_array=array,
+                output_footprint=footprint,
+                block_size=cutout.block_size,
+                **reproject_kwargs,
+            )
+
+            if cutout.weights_in is not None:
+
+                if intermediate_memmap:
+
+                    weights_path = os.path.join(local_tmp_dir, f"weights_{uuid.uuid4()}.np")
+
+                    logger.info(
+                        f"Creating memory-mapped weights with shape {cutout.shape_out_indiv} at {weights_path}"
+                    )
+
+                    weights = np.memmap(
+                        weights_path,
+                        shape=cutout.shape_out_indiv,
+                        mode="w+",
+                        dtype=float,
+                    )
+
+                else:
+
+                    weights = None
+
+                logger.info(
+                    f"Calling {reproject_function.__name__} with shape_out={cutout.shape_out_indiv} for weights"
+                )
+
+                weights = reproject_function(
+                    (cutout.weights_in, cutout.weights_wcs),
+                    output_projection=cutout.wcs_out_indiv,
+                    shape_out=cutout.shape_out_indiv,
+                    hdu_in=hdu_in,
+                    output_array=weights,
+                    return_footprint=False,
+                    **reproject_kwargs,
+                )
+
+            # For the purposes of mosaicking, we mask out NaN values from the array
+            # and set the footprint to 0 at these locations. We do this in chunks
+            # to avoid excessive memory usage.
+            for chunk in iterate_chunks(array.shape, max_chunk_size=DEFAULT_MAX_CHUNK_SIZE):
+
+                # Determine location of NaNs
+                reset = np.isnan(array[chunk])
+                if cutout.weights_in is not None:
+                    reset |= np.isnan(weights[chunk])
+
+                # Mask them in-place in the arrays
+                array[chunk][reset] = 0.0
+                footprint[chunk][reset] = 0.0
+
+                # Combine weights and footprint
+                if cutout.weights_in is not None:
+                    weights[chunk][reset] = 0.0
+                    footprint[chunk] *= weights[chunk]
+
+            if cutout.weights_in is not None and intermediate_memmap:
+                # Remove the reference to the memmap before trying to remove the file itself
+                logger.info("Removing memory-mapped weight array")
+                weights = None
+                _safe_remove(weights_path)
+
+            array = ReprojectedArraySubset(array, footprint, cutout.bounds)
+
+            if on_the_fly:
+                # Add this reprojected image to the output arrays one chunk at a
+                # time. This keeps peak memory usage set by the chunk size rather
+                # than by the (potentially large) size of each reprojected image,
+                # which matters in particular when there are many non-reprojected
+                # dimensions (e.g. spectral channels). Note that these are just
+                # chunks over Numpy arrays, not e.g. dask chunks.
+                logger.info("Adding reprojected array to final array in chunks")
+                _combine_array_into_output(combine_function, array, output_array, output_footprint)
+
+                if intermediate_memmap:
+                    logger.info("Removing memory-mapped array and footprint arrays")
+                    array = None
+                    footprint = None
+                    for path in (array_path, footprint_path):
+                        _safe_remove(path)
+
+            else:
+
+                logger.info("Adding reprojected array to list to combine later")
+                arrays.append(array)
+
+        # If requested, try and match the backgrounds.
+        if match_background and len(arrays) > 1:
+            logger.info("Match backgrounds")
+            offset_matrix = determine_offset_matrix(arrays)
+            corrections = solve_corrections_sgd(offset_matrix)
+            if background_reference:
+                corrections -= corrections[background_reference]
+            for array, correction in zip(arrays, corrections, strict=True):
+                array.array -= correction
+
+        if match_background:
+            logger.info(f"Combining reprojected arrays with function {combine_function}")
+            # if we're not matching the background, this part has already been done
+            for array in arrays:
+                _combine_array_into_output(combine_function, array, output_array, output_footprint)
+
+        if combine_function == "mean":
+            logger.info("Handle normalization of output array")
+            with np.errstate(invalid="ignore"):
+                output_array /= output_footprint
+
+        # Avoid keeping any references to the memory-mapped arrays so that the
+        # files get cleaned up once we exit the context manager.
+        if intermediate_memmap:
+            array = None
+            footprint = None
+            arrays = []
+
+    # We need to avoid potentially large memory allocation from output == 0 so
+    # we operate in chunks.
+    logger.info(f"Resetting invalid pixels to {blank_pixel_value}")
+    for chunk in iterate_chunks(output_array.shape, max_chunk_size=DEFAULT_MAX_CHUNK_SIZE):
+        output_array[chunk][output_footprint[chunk] == 0] = blank_pixel_value
+
+    return output_array, output_footprint
 
 
 def reproject_and_coadd(
@@ -297,8 +831,6 @@ def reproject_and_coadd(
             )
         if intermediate_memmap:
             raise ValueError("Cannot use return_type='dask' together with intermediate_memmap")
-        dask_arrays = []
-        dask_footprints = []
     else:
         if output_array is None:
             output_array = np.zeros(shape_out)
@@ -358,450 +890,42 @@ def reproject_and_coadd(
             chunk_spec = block_size
         target_chunks = da.core.normalize_chunks(chunk_spec, shape=tuple(shape_out), dtype=float)
 
-    # Define 'on-the-fly' mode: in the case where we don't need to match the
-    # backgrounds, we don't have to keep track of the intermediate arrays and
-    # can just modify the output array on-the-fly
-    on_the_fly = not match_background
-
-    on_the_fly_prefix = "Using" if on_the_fly else "Not using"
-    logger.info(
-        f"{on_the_fly_prefix} on-the-fly mode for adding individual reprojected images to output array"
+    cutouts = _iterate_input_cutouts(
+        input_data,
+        input_weights,
+        hdu_in,
+        hdu_weights,
+        wcs_out,
+        shape_out,
+        block_sizes,
+        n_broadcasted,
+        n_dim_reproject,
+        n_wcs_out_extra,
+        progress_bar,
     )
 
-    # Start off by reprojecting individual images to the final projection
-
-    if not on_the_fly:
-        arrays = []
-
-    if not coadd_with_dask:
-        if combine_function == "min":
-            output_array[...] = np.inf
-        elif combine_function == "max":
-            output_array[...] = -np.inf
-
-    with tempfile.TemporaryDirectory(ignore_cleanup_errors=IS_WIN) as local_tmp_dir:
-
-        for idata in progress_bar(range(len(input_data))):
-
-            logger.info(f"Processing input data {idata + 1} of {len(input_data)}")
-
-            # We need to pre-parse the data here since we need to figure out how to
-            # optimize/minimize the size of each output tile (see below).
-            array_in, wcs_in = parse_input_data(input_data[idata], hdu_in=hdu_in)
-
-            # We also get the weights map, if specified
-            if input_weights is None:
-                weights_in = None
-            else:
-                weights_in, weights_wcs = parse_input_weights(
-                    input_weights[idata], hdu_weights=hdu_weights
-                )
-                if weights_wcs is None:
-                    # if weights are passed as an array
-                    weights_wcs = wcs_in
-                else:
-                    try:
-                        _validate_wcs(weights_wcs, wcs_in, weights_in.shape, shape_out)
-                    except ValueError:
-                        # WCS is not valid (most likely, it is blank?)
-                        weights_wcs = wcs_in
-                if np.any(np.isnan(weights_in)):
-                    weights_in = np.nan_to_num(weights_in)
-
-            # Since we might be reprojecting small images into a large mosaic we
-            # want to make sure that for each image we reproject to an array with
-            # minimal footprint. We therefore find the pixel coordinates of the
-            # edges of the initial image and transform this to pixel coordinates in
-            # the final image to figure out the final WCS and shape to reproject to
-            # for each tile. We strike a balance between transforming only the
-            # input-image corners, which is fast but can cause clipping in cases of
-            # significant distortion (when the edges of the input image become
-            # convex in the output projection), and transforming every edge pixel,
-            # which provides a lot of redundant information.
-
-            try:
-                edges_out = sample_input_edges_in_output(array_in.shape, wcs_in, wcs_out)
-            except Exception as exc:
-                # If the edge coordinates cannot be transformed (for example if
-                # they fall outside the validity region of the WCS), fall back to
-                # assuming no predicted overlap so the full output is considered.
-                logger.info(
-                    f"Could not determine cutout bounds for input data {idata + 1} "
-                    f"({exc}), reprojecting to the full output instead"
-                )
-                edges_out = np.array([np.nan])
-
-            # Determine the cutout parameters
-
-            # In some cases, images might not have valid coordinates in the corners,
-            # such as all-sky images or full solar disk views. In this case we skip
-            # this step and just use the full output WCS for reprojection.
-
-            skip_data = False
-            if np.any(np.isnan(edges_out)):
-                bounds = list(zip([0] * ndim_out, shape_out, strict=False))
-            else:
-                bounds = []
-                if n_broadcasted > 0:
-                    for idim in range(n_broadcasted):
-                        bounds.append((0, shape_out[idim]))
-                # Only the reprojected (trailing) dimensions get a cutout; the
-                # corresponding edge coordinates are the trailing components of
-                # edges_out (which has one entry per input WCS pixel dimension).
-                edges_out_reproject = edges_out[-n_dim_reproject:]
-                for idim in range(len(edges_out_reproject)):
-                    imin = max(0, int(np.floor(edges_out_reproject[idim].min() + 0.5)))
-                    imax = min(
-                        shape_out[n_broadcasted + idim],
-                        int(np.ceil(edges_out_reproject[idim].max() + 0.5)),
-                    )
-                    bounds.append((imin, imax))
-                    if imax <= imin:
-                        skip_data = True
-                        break
-
-            if skip_data:
-                logger.info(
-                    "Skipping reprojection as no predicted overlap with final mosaic header"
-                )
-                continue
-
-            slice_out = tuple([slice(imin, imax) for (imin, imax) in bounds[n_wcs_out_extra:]])
-
-            if isinstance(wcs_out, WCS):
-                wcs_out_indiv = wcs_out[slice_out]
-            else:
-                wcs_out_indiv = SlicedLowLevelWCS(wcs_out.low_level_wcs, slice_out)
-
-            shape_out_indiv = tuple([imax - imin for (imin, imax) in bounds])
-
-            global_block_size = block_sizes[idata]
-
-            # If the block size matches the output shape along the reprojected
-            # dimensions, we need to shrink those entries to match this cutout's
-            # size (keeping the broadcasted entries) so that the per-image
-            # reprojection parallelizes over the broadcasted dimensions.
-            if (
-                global_block_size
-                and not isinstance(global_block_size, str)
-                and tuple(global_block_size[-n_dim_reproject:])
-                == tuple(shape_out[-n_dim_reproject:])
-            ):
-                block_size = tuple(global_block_size[:n_broadcasted]) + tuple(
-                    shape_out_indiv[n_broadcasted:]
-                )
-            else:
-                block_size = global_block_size
-
-            if coadd_with_dask:
-                # Reproject this image (and its weights) lazily, mirroring the return_type='numpy'
-                # per-image handling: NaNs are masked out of the array and footprint,
-                # any weights are folded into the footprint, and both the array and
-                # footprint are padded back onto the full output grid (the uncovered
-                # region gets a zero footprint so it drops out of the combine). The
-                # footprint is kept so that the combine below can weight by it exactly
-                # as the return_type='numpy' path does. Nothing is computed here.
-                logger.info(
-                    f"Calling {reproject_function.__name__} lazily with "
-                    f"shape_out={shape_out_indiv} (return_type='dask')"
-                )
-                # A dask return requires the reprojection to run in blocks, so fall
-                # back to automatic block sizes if none was given for this image.
-                dask_block_size = block_size if block_size is not None else "auto"
-                array, footprint = reproject_function(
-                    (array_in, wcs_in),
-                    output_projection=wcs_out_indiv,
-                    shape_out=shape_out_indiv,
-                    hdu_in=hdu_in,
-                    return_footprint=True,
-                    return_type="dask",
-                    block_size=dask_block_size,
-                    **kwargs,
-                )
-
-                if weights_in is not None:
-                    weights = reproject_function(
-                        (weights_in, weights_wcs),
-                        output_projection=wcs_out_indiv,
-                        shape_out=shape_out_indiv,
-                        hdu_in=hdu_in,
-                        return_footprint=False,
-                        return_type="dask",
-                        block_size=dask_block_size,
-                        **kwargs,
-                    )
-                else:
-                    weights = None
-
-                reset = da.isnan(array)
-                if weights is not None:
-                    reset = reset | da.isnan(weights)
-                array = da.where(reset, 0.0, array)
-                footprint = da.where(reset, 0.0, footprint)
-                if weights is not None:
-                    footprint = footprint * da.where(reset, 0.0, weights)
-
-                dask_arrays.append(pad_dask_array_to_grid(array, bounds, shape_out, target_chunks))
-                dask_footprints.append(
-                    pad_dask_array_to_grid(footprint, bounds, shape_out, target_chunks)
-                )
-                continue
-
-            # TODO: optimize handling of weights by making reprojection functions
-            # able to handle weights, and make the footprint become the combined
-            # footprint + weight map
-
-            if intermediate_memmap:
-
-                array_path = os.path.join(local_tmp_dir, f"array_{uuid.uuid4()}.np")
-
-                logger.info(
-                    f"Creating memory-mapped array with shape {shape_out_indiv} at {array_path}"
-                )
-
-                array = np.memmap(
-                    array_path,
-                    shape=shape_out_indiv,
-                    mode="w+",
-                    dtype=array_in.dtype,
-                )
-
-                footprint_path = os.path.join(local_tmp_dir, f"footprint_{uuid.uuid4()}.np")
-
-                logger.info(
-                    f"Creating memory-mapped footprint with shape {shape_out_indiv} at {footprint_path}"
-                )
-
-                footprint = np.memmap(
-                    footprint_path,
-                    shape=shape_out_indiv,
-                    mode="w+",
-                    dtype=float,
-                )
-
-            else:
-
-                array = footprint = None
-
-            logger.info(f"Calling {reproject_function.__name__} with shape_out={shape_out_indiv}")
-
-            array, footprint = reproject_function(
-                (array_in, wcs_in),
-                output_projection=wcs_out_indiv,
-                shape_out=shape_out_indiv,
-                hdu_in=hdu_in,
-                output_array=array,
-                output_footprint=footprint,
-                block_size=block_size,
-                **kwargs,
-            )
-
-            if weights_in is not None:
-
-                if intermediate_memmap:
-
-                    weights_path = os.path.join(local_tmp_dir, f"weights_{uuid.uuid4()}.np")
-
-                    logger.info(
-                        f"Creating memory-mapped weights with shape {shape_out_indiv} at {weights_path}"
-                    )
-
-                    weights = np.memmap(
-                        weights_path,
-                        shape=shape_out_indiv,
-                        mode="w+",
-                        dtype=float,
-                    )
-
-                else:
-
-                    weights = None
-
-                logger.info(
-                    f"Calling {reproject_function.__name__} with shape_out={shape_out_indiv} for weights"
-                )
-
-                weights = reproject_function(
-                    (weights_in, weights_wcs),
-                    output_projection=wcs_out_indiv,
-                    shape_out=shape_out_indiv,
-                    hdu_in=hdu_in,
-                    output_array=weights,
-                    return_footprint=False,
-                    **kwargs,
-                )
-
-            # For the purposes of mosaicking, we mask out NaN values from the array
-            # and set the footprint to 0 at these locations. We do this in chunks
-            # to avoid excessive memory usage.
-            for chunk in iterate_chunks(array.shape, max_chunk_size=DEFAULT_MAX_CHUNK_SIZE):
-
-                # Determine location of NaNs
-                reset = np.isnan(array[chunk])
-                if weights_in is not None:
-                    reset |= np.isnan(weights[chunk])
-
-                # Mask them in-place in the arrays
-                array[chunk][reset] = 0.0
-                footprint[chunk][reset] = 0.0
-
-                # Combine weights and footprint
-                if weights_in is not None:
-                    weights[chunk][reset] = 0.0
-                    footprint[chunk] *= weights[chunk]
-
-            if weights_in is not None and intermediate_memmap:
-                # Remove the reference to the memmap before trying to remove the file itself
-                logger.info("Removing memory-mapped weight array")
-                weights = None
-                _safe_remove(weights_path)
-
-            array = ReprojectedArraySubset(array, footprint, bounds)
-
-            if on_the_fly:
-                # Add this reprojected image to the output arrays one chunk at a
-                # time. This keeps peak memory usage set by the chunk size rather
-                # than by the (potentially large) size of each reprojected image,
-                # which matters in particular when there are many non-reprojected
-                # dimensions (e.g. spectral channels). Note that these are just
-                # chunks over Numpy arrays, not e.g. dask chunks.
-                logger.info("Adding reprojected array to final array in chunks")
-                _combine_array_into_output(combine_function, array, output_array, output_footprint)
-
-                if intermediate_memmap:
-                    logger.info("Removing memory-mapped array and footprint arrays")
-                    array = None
-                    footprint = None
-                    for path in (array_path, footprint_path):
-                        _safe_remove(path)
-
-            else:
-
-                logger.info("Adding reprojected array to list to combine later")
-                arrays.append(array)
-
-        # If requested, try and match the backgrounds.
-        if match_background and len(arrays) > 1:
-            logger.info("Match backgrounds")
-            offset_matrix = determine_offset_matrix(arrays)
-            corrections = solve_corrections_sgd(offset_matrix)
-            if background_reference:
-                corrections -= corrections[background_reference]
-            for array, correction in zip(arrays, corrections, strict=True):
-                array.array -= correction
-
-        if match_background:
-            logger.info(f"Combining reprojected arrays with function {combine_function}")
-            # if we're not matching the background, this part has already been done
-            for array in arrays:
-                _combine_array_into_output(combine_function, array, output_array, output_footprint)
-
-        if combine_function == "mean" and not coadd_with_dask:
-            logger.info("Handle normalization of output array")
-            with np.errstate(invalid="ignore"):
-                output_array /= output_footprint
-
-        # Avoid keeping any references to the memory-mapped arrays so that the
-        # files get cleaned up once we exit the context manager.
-        if intermediate_memmap:
-            array = None
-            footprint = None
-            arrays = []
-
     if coadd_with_dask:
-        # Combine all the lazily-reprojected images along the stacking axis, matching
-        # the return_type='numpy' _combine_array_into_output semantics exactly, and
-        # return the result uncomputed so the whole graph (reprojections and
-        # co-addition) is evaluated in one deferred computation by the caller.
-
-        if not dask_arrays:
-            # No image is predicted to overlap the output; return the same blank
-            # mosaic and zero footprint as the return_type='numpy' path, lazily.
-            output_array = da.full(
-                tuple(shape_out), float(blank_pixel_value), chunks=target_chunks
-            )
-            output_footprint = da.zeros(tuple(shape_out), chunks=target_chunks)
-            return output_array, output_footprint
-
-        # Each padded image has chunks aligned to the output chunking, with at most
-        # two extra chunk boundaries per dimension at the cutout edges. Rechunking to
-        # the common output chunking here therefore only merges those, and stacking
-        # identically-chunked arrays keeps the stack and reduction below small
-        # (stacking mismatched chunk grids would make dask unify them into an
-        # ever-finer grid, with the task count growing super-linearly with the
-        # number of images).
-        dask_arrays = [array.rechunk(target_chunks) for array in dask_arrays]
-        dask_footprints = [footprint.rechunk(target_chunks) for footprint in dask_footprints]
-        stacked_array = da.stack(dask_arrays)
-        stacked_footprint = da.stack(dask_footprints)
-
-        if combine_function in ("mean", "sum"):
-            # Footprint-weighted sum: output = sum(array * footprint), footprint =
-            # sum(footprint), and for the mean divide the two (as the
-            # return_type='numpy' path does, including contributions where the
-            # footprint is negative, which can happen when reprojecting weight maps
-            # with interpolation orders that overshoot). The numerator is zero
-            # wherever the footprint is zero, so for the mean divide by a footprint
-            # that has its zeros replaced by one to avoid a lazily-evaluated 0/0
-            # (which would warn at compute time).
-            output_array = (stacked_array * stacked_footprint).sum(axis=0)
-            output_footprint = stacked_footprint.sum(axis=0)
-            if combine_function == "mean":
-                output_array = output_array / da.where(
-                    output_footprint == 0, 1.0, output_footprint
-                )
-        elif combine_function == "median":
-            covered = stacked_footprint > 0
-            # Unweighted median of the covered images. This is only available for the
-            # dask path (the return_type='numpy' path cannot compute a median on the fly).
-            masked = da.where(covered, stacked_array, np.nan)
-            # Pixels covered by no image at all would be all-NaN slices, which would
-            # make nanmedian warn at compute time; give them a value of zero since
-            # they are set to blank_pixel_value below anyway.
-            masked = da.where(covered.any(axis=0)[np.newaxis], masked, 0.0)
-            # The median needs the whole stacking axis at once, so collapse it to a
-            # single chunk and let dask re-split the other axes so that the total
-            # chunk size stays bounded instead of growing with the number of images.
-            masked = masked.rechunk(
-                {0: -1, **{iaxis: "auto" for iaxis in range(1, masked.ndim)}}
-            )
-            output_array = da.nanmedian(masked, axis=0).rechunk(target_chunks)
-            output_footprint = stacked_footprint.sum(axis=0)
-        else:
-            # first/last/min/max select one image per pixel; we find its index along
-            # the stacking axis and take both the value and the footprint from there.
-            covered = stacked_footprint > 0
-            n_images = stacked_array.shape[0]
-            axis_index = da.arange(n_images).reshape((n_images,) + (1,) * (stacked_array.ndim - 1))
-            if combine_function == "first":
-                selected = da.where(covered, axis_index, n_images).min(axis=0)
-            elif combine_function == "last":
-                selected = da.where(covered, axis_index, -1).max(axis=0)
-            elif combine_function == "min":
-                selected = da.where(covered, stacked_array, np.inf).argmin(axis=0)
-            elif combine_function == "max":
-                selected = da.where(covered, stacked_array, -np.inf).argmax(axis=0)
-            else:
-                raise ValueError(f"Unexpected combine_function: {combine_function}")
-            # Pick the value and footprint from the selected image with a one-hot
-            # mask along the stacking axis (dask has no take_along_axis). For pixels
-            # covered by no image, the selected index either matches no image
-            # (first/last) or picks an image whose footprint there is zero (min/max),
-            # so the sums give a zero footprint and the pixel is blanked below.
-            onehot = axis_index == selected[np.newaxis]
-            output_array = da.where(onehot, stacked_array, 0.0).sum(axis=0)
-            output_footprint = da.where(onehot, stacked_footprint, 0.0).sum(axis=0)
-
-        # Match the return_type='numpy' path's final step: set pixels with no coverage
-        # to the blank value (the return_type='numpy' loop does this at the end where
-        # output_footprint == 0, keeping pixels with a negative summed footprint).
-        output_array = da.where(output_footprint == 0, blank_pixel_value, output_array)
-        return output_array, output_footprint
-
-    # We need to avoid potentially large memory allocation from output == 0 so
-    # we operate in chunks.
-    logger.info(f"Resetting invalid pixels to {blank_pixel_value}")
-    for chunk in iterate_chunks(output_array.shape, max_chunk_size=DEFAULT_MAX_CHUNK_SIZE):
-        output_array[chunk][output_footprint[chunk] == 0] = blank_pixel_value
-
-    return output_array, output_footprint
+        return _coadd_dask(
+            cutouts,
+            reproject_function=reproject_function,
+            combine_function=combine_function,
+            shape_out=shape_out,
+            target_chunks=target_chunks,
+            blank_pixel_value=blank_pixel_value,
+            hdu_in=hdu_in,
+            reproject_kwargs=kwargs,
+        )
+    else:
+        return _coadd_numpy(
+            cutouts,
+            reproject_function=reproject_function,
+            combine_function=combine_function,
+            match_background=match_background,
+            background_reference=background_reference,
+            output_array=output_array,
+            output_footprint=output_footprint,
+            intermediate_memmap=intermediate_memmap,
+            blank_pixel_value=blank_pixel_value,
+            hdu_in=hdu_in,
+            reproject_kwargs=kwargs,
+        )

--- a/reproject/mosaicking/_coadd.py
+++ b/reproject/mosaicking/_coadd.py
@@ -95,14 +95,13 @@ def _input_cutout_iterator(
     n_wcs_out_extra,
     progress_bar,
 ):
-    """
-    Parse each input dataset (and its weights map) and compute the minimal
-    cutout of the output grid that it covers, yielding everything that the
-    per-image reprojection needs. Datasets with no predicted overlap with the
-    output are skipped. This is shared between the return_type='numpy' and
-    return_type='dask' co-addition drivers so that the cutout logic exists
-    only once.
-    """
+    # Parse each input dataset (and its weights map) and compute the minimal
+    # cutout of the output grid that it covers, yielding everything that the
+    # per-image reprojection needs. Datasets with no predicted overlap with the
+    # output are skipped. This is shared between the return_type='numpy' and
+    # return_type='dask' co-addition drivers so that the cutout logic exists
+    # only once.
+
     logger = getLogger(__name__)
 
     ndim_out = len(shape_out)
@@ -240,14 +239,13 @@ def _coadd_dask(
     hdu_in,
     reproject_kwargs,
 ):
-    """
-    The return_type='dask' co-addition: reproject each cutout lazily, pad it
-    onto the output grid, and combine all the images along a stacking axis,
-    matching the return_type='numpy' path's _combine_array_into_output
-    semantics exactly. The result is returned uncomputed so the whole graph
-    (reprojections and co-addition) is evaluated in one computation by the
-    caller.
-    """
+    # The return_type='dask' co-addition: reproject each cutout lazily, pad it
+    # onto the output grid, and combine all the images along a stacking axis,
+    # matching the return_type='numpy' path's _combine_array_into_output
+    # semantics exactly. The result is returned uncomputed so the whole graph
+    # (reprojections and co-addition) is evaluated in one computation by the
+    # caller.
+
     logger = getLogger(__name__)
 
     dask_arrays = []
@@ -399,11 +397,10 @@ def _coadd_numpy(
     hdu_in,
     reproject_kwargs,
 ):
-    """
-    The return_type='numpy' co-addition: reproject each cutout and combine it
-    into the output arrays, either on the fly or, when the backgrounds need to
-    be matched, after all the images have been reprojected.
-    """
+    # The return_type='numpy' co-addition: reproject each cutout and combine it
+    # into the output arrays, either on the fly or, when the backgrounds need to
+    # be matched, after all the images have been reprojected.
+
     logger = getLogger(__name__)
 
     # Define 'on-the-fly' mode: in the case where we don't need to match the
@@ -857,8 +854,6 @@ def reproject_and_coadd(
             )
 
     logger.info(f"Output mosaic will have shape {shape_out}")
-
-    ndim_out = len(shape_out)
 
     # Determine how many leading dimensions are broadcasted (i.e. not
     # reprojected). If non_reprojected_dims is set these are given

--- a/reproject/mosaicking/_coadd.py
+++ b/reproject/mosaicking/_coadd.py
@@ -99,8 +99,9 @@ def _input_cutout_iterator(
     Parse each input dataset (and its weights map) and compute the minimal
     cutout of the output grid that it covers, yielding everything that the
     per-image reprojection needs. Datasets with no predicted overlap with the
-    output are skipped. This is shared between the eager (numpy) and deferred
-    (dask) co-addition drivers so that the cutout logic exists only once.
+    output are skipped. This is shared between the return_type='numpy' and
+    return_type='dask' co-addition drivers so that the cutout logic exists
+    only once.
     """
     logger = getLogger(__name__)
 
@@ -240,11 +241,12 @@ def _coadd_dask(
     reproject_kwargs,
 ):
     """
-    Deferred co-addition: reproject each cutout lazily, pad it onto the output
-    grid, and combine all the images along a stacking axis, matching the eager
-    path's _combine_array_into_output semantics exactly. The result is returned
-    uncomputed so the whole graph (reprojections and co-addition) is evaluated
-    in one deferred computation by the caller.
+    The return_type='dask' co-addition: reproject each cutout lazily, pad it
+    onto the output grid, and combine all the images along a stacking axis,
+    matching the return_type='numpy' path's _combine_array_into_output
+    semantics exactly. The result is returned uncomputed so the whole graph
+    (reprojections and co-addition) is evaluated in one computation by the
+    caller.
     """
     logger = getLogger(__name__)
 
@@ -398,9 +400,9 @@ def _coadd_numpy(
     reproject_kwargs,
 ):
     """
-    Eager co-addition: reproject each cutout and combine it into the output
-    arrays, either on the fly or, when the backgrounds need to be matched,
-    after all the images have been reprojected.
+    The return_type='numpy' co-addition: reproject each cutout and combine it
+    into the output arrays, either on the fly or, when the backgrounds need to
+    be matched, after all the images have been reprojected.
     """
     logger = getLogger(__name__)
 
@@ -668,14 +670,16 @@ def reproject_and_coadd(
         `~astropy.io.fits.HDUList` instance, specifies the HDU to use.
     reproject_function : callable
         The function to use for the reprojection.
-    combine_function : { 'mean', 'sum', 'first', 'last', 'min', 'max' }
+    combine_function : { 'mean', 'sum', 'first', 'last', 'min', 'max', 'median' }
         The type of function to use for combining the values into the final
         image. For 'first' and 'last', respectively, the reprojected images are
         simply overlaid on top of each other. With respect to the order of the
         input images in ``input_data``, either the first or the last image to
         cover a region of overlap determines the output data for that region.
+        'median' is only available with ``return_type='dask'``.
     match_background : bool
-        Whether to match the backgrounds of the images.
+        Whether to match the backgrounds of the images. Only supported with
+        ``return_type='numpy'``.
     background_reference : `None` or `int`
         If `None`, the background matching will make it so that the average of
         the corrections for all images is zero. If an integer, this specifies
@@ -684,14 +688,17 @@ def reproject_and_coadd(
         The final output array.  Specify this if you already have an
         appropriately-shaped array to store the data in.  Must match shape
         specified with ``shape_out`` or derived from the output
-        projection.
+        projection. Can only be specified with ``return_type='numpy'``.
     output_footprint : array or None
         The final output footprint array.  Specify this if you already have an
         appropriately-shaped array to store the data in.  Must match shape
         specified with ``shape_out`` or derived from the output projection.
+        Can only be specified with ``return_type='numpy'``.
     block_sizes : list of tuples or None
         The block size to use for each dataset.  Could also be a single tuple
-        if you want the same block size for all data sets.
+        if you want the same block size for all data sets. With
+        ``return_type='dask'``, a single common block size is also used as the
+        chunking of the returned dask arrays.
     non_reprojected_dims : tuple, optional
         Leading dimensions of the data that should not be reprojected but for
         which a one-to-one mapping between input and output pixels is assumed
@@ -707,33 +714,34 @@ def reproject_and_coadd(
         data.
     intermediate_memmap : bool, optional
         If `True`, use `numpy.memmap` to store intermediate output arrays for
-        reprojected data.
+        reprojected data. Only supported with ``return_type='numpy'``.
     return_type : {None, 'numpy', 'dask'}, optional
         If ``'dask'``, reproject each image lazily (using ``return_type='dask'``
         on the reprojection function), pad each onto the output grid, and combine
         them along a stacking axis, returning the resulting **uncomputed** dask
-        arrays so the whole co-addition is deferred into a single computation. The
-        combination matches the default ``return_type='numpy'`` path exactly
+        arrays so the whole co-addition is computed lazily in one go. The
+        combination matches the ``return_type='numpy'`` path exactly
         (footprint-weighted for 'mean' and 'sum', footprint-aware selection for
         'first', 'last', 'min' and 'max'), and ``input_weights`` are supported. A
         ``combine_function`` of 'median' is additionally available here (as an
         unweighted median), which the ``return_type='numpy'`` path cannot compute.
         ``match_background``, ``output_array``, ``output_footprint`` and
-        ``intermediate_memmap`` are not supported, since the result is a deferred
-        graph rather than arrays filled in place. The default (`None`, equivalent
-        to ``'numpy'``) uses the standard eager co-addition.
+        ``intermediate_memmap`` are not supported, since the result is an
+        uncomputed graph rather than arrays filled in place. The default (`None`)
+        is equivalent to ``'numpy'``.
 
     **kwargs
         Keyword arguments to be passed to the reprojection function.
 
     Returns
     -------
-    array : `~numpy.ndarray`
-        The co-added array.
-    footprint : `~numpy.ndarray`
+    array : `~numpy.ndarray` or `~dask.array.Array`
+        The co-added array. This is an uncomputed dask array when
+        ``return_type='dask'``.
+    footprint : `~numpy.ndarray` or `~dask.array.Array`
         Footprint of the co-added array. Values of 0 indicate no coverage or
         valid values in the input image, while values of 1 indicate valid
-        values.
+        values. This is an uncomputed dask array when ``return_type='dask'``.
     """
 
     # TODO: add support for saving intermediate files to disk to avoid blowing
@@ -745,7 +753,7 @@ def reproject_and_coadd(
     # Validate inputs
 
     # Validate return_type up front: a typo such as 'Dask' would otherwise
-    # silently select the eager numpy co-addition.
+    # silently select the return_type='numpy' co-addition.
     if return_type is None:
         return_type = "numpy"
     if return_type not in ("numpy", "dask"):

--- a/reproject/mosaicking/_coadd.py
+++ b/reproject/mosaicking/_coadd.py
@@ -656,23 +656,35 @@ def reproject_and_coadd(
 
     if coadd_with_dask:
         # Combine all the lazily-reprojected images along the stacking axis, matching
-        # the return_type='numpy' _combine_array_into_output semantics exactly, and return the
-        # result uncomputed so the whole graph (reprojections and co-addition) is
-        # evaluated in one deferred computation by the caller.
+        # the return_type='numpy' _combine_array_into_output semantics exactly, and
+        # return the result uncomputed so the whole graph (reprojections and
+        # co-addition) is evaluated in one deferred computation by the caller.
+        #
+        # Each image was padded to the full output grid, but with chunk boundaries
+        # that depend on where it landed. Stacking arrays with mismatched chunks makes
+        # dask unify them into an ever-finer grid, so the task count grows super-
+        # linearly with the number of images (the co-addition appears to hang). Rechunk
+        # every image to one common chunking first so the stack and reduction stay
+        # small and the memory per chunk stays bounded.
+        target_chunks = da.core.normalize_chunks("auto", shape=tuple(shape_out), dtype=float)
+        dask_arrays = [array.rechunk(target_chunks) for array in dask_arrays]
+        dask_footprints = [footprint.rechunk(target_chunks) for footprint in dask_footprints]
         stacked_array = da.stack(dask_arrays)
         stacked_footprint = da.stack(dask_footprints)
         covered = stacked_footprint > 0
 
         if combine_function in ("mean", "sum"):
             # Footprint-weighted sum: output = sum(array * footprint), footprint =
-            # sum(footprint), and for the mean divide the two (as the return_type='numpy' path does).
+            # sum(footprint), and for the mean divide the two (as the
+            # return_type='numpy' path does). The numerator is zero wherever the
+            # footprint is zero, so divide by a footprint that has its zeros replaced
+            # by one to avoid a lazily-evaluated 0/0 (which would warn at compute time).
             numerator = da.where(covered, stacked_array * stacked_footprint, 0.0).sum(axis=0)
             output_footprint = stacked_footprint.sum(axis=0)
             if combine_function == "sum":
                 output_array = numerator
             else:
-                with np.errstate(invalid="ignore"):
-                    output_array = numerator / output_footprint
+                output_array = numerator / da.where(output_footprint > 0, output_footprint, 1.0)
         elif combine_function == "median":
             # Unweighted median of the covered images. This is only available for the
             # dask path (the return_type='numpy' path cannot compute a median on the fly); the median

--- a/reproject/mosaicking/tests/test_coadd.py
+++ b/reproject/mosaicking/tests/test_coadd.py
@@ -241,6 +241,39 @@ class TestReprojectAndCoAdd:
         assert_allclose(footprint_dask, footprint_numpy, atol=ATOL)
         assert_allclose(array_dask, array_numpy, atol=ATOL)
 
+    def test_coadd_dask_duplicate_input_names(self):
+        # Dask identifies arrays by name, so two different input dask arrays
+        # sharing a name get silently deduplicated once the co-addition is
+        # combined into one graph, with one input's data used for both; the
+        # dask path must warn about this. Passing the same array object twice
+        # is legitimate and must stay silent.
+        views = [np.s_[0:200, :], np.s_[199:399, :]]
+        (array1, wcs1), (array2, wcs2) = self._get_tiles(views)
+        dup1 = da.from_array(array1, name="duplicate-name")
+        dup2 = da.from_array(array2, name="duplicate-name")
+
+        with pytest.warns(UserWarning, match="share the name"):
+            reproject_and_coadd(
+                [(dup1, wcs1), (dup2, wcs2)],
+                self.wcs,
+                shape_out=self.array.shape,
+                combine_function="mean",
+                reproject_function=reproject_interp,
+                return_type="dask",
+            )
+
+        with warnings.catch_warnings(record=True) as recorded:
+            warnings.simplefilter("always")
+            reproject_and_coadd(
+                [(dup1, wcs1), (dup1, wcs1)],
+                self.wcs,
+                shape_out=self.array.shape,
+                combine_function="mean",
+                reproject_function=reproject_interp,
+                return_type="dask",
+            )
+        assert not any("share the name" in str(w.message) for w in recorded)
+
     def test_coadd_dask_rejects_unsupported(self):
         # Options that fill arrays in place cannot apply to a deferred dask result
         # and must raise rather than being silently ignored.

--- a/reproject/mosaicking/tests/test_coadd.py
+++ b/reproject/mosaicking/tests/test_coadd.py
@@ -915,6 +915,94 @@ def test_coadd_non_reprojected_dims(combine_function, celestial_output):
     assert_allclose(footprint, reference_footprint, atol=ATOL)
 
 
+@pytest.mark.filterwarnings("ignore::erfa.ErfaWarning")
+@pytest.mark.parametrize("block_size", [(30, 30), (12, 12)])
+def test_coadd_non_reprojected_dims_reprojected_only_block_size(block_size):
+    # A block size covering only the reprojected dimensions (full-plane or
+    # sub-tiled) must give the same result as the full-length equivalent; the
+    # per-cutout shrinking used to prepend the wrong leading entries for such
+    # block sizes.
+
+    n_time = 3
+    shape_out = (n_time, 30, 30)
+    wcs_in = _drifting_cube_wcs(drift=0.6)
+    wcs_out = _drifting_cube_wcs(drift=0.0).celestial
+
+    rng = np.random.default_rng(12345)
+    data = rng.random((n_time, 30, 30))
+
+    reference, reference_footprint = reproject_and_coadd(
+        [(data, wcs_in)],
+        wcs_out,
+        shape_out=shape_out,
+        reproject_function=reproject_interp,
+        combine_function="mean",
+        non_reprojected_dims=(0,),
+        parallel=True,
+        block_size=(1,) + shape_out[1:],
+        roundtrip_coords=False,
+    )
+
+    array, footprint = reproject_and_coadd(
+        [(data, wcs_in)],
+        wcs_out,
+        shape_out=shape_out,
+        reproject_function=reproject_interp,
+        combine_function="mean",
+        non_reprojected_dims=(0,),
+        parallel=True,
+        block_size=block_size,
+        roundtrip_coords=False,
+    )
+
+    assert_allclose(array, reference, atol=ATOL)
+    assert_allclose(footprint, reference_footprint, atol=ATOL)
+
+
+@pytest.mark.filterwarnings("ignore::erfa.ErfaWarning")
+def test_coadd_non_reprojected_dims_with_weights():
+    # Weights combined with non_reprojected_dims used to raise
+    # NotImplementedError because the per-image weights reprojection did not
+    # pass the block size through. Uniform weights should give the same result
+    # as no weights.
+
+    n_time = 3
+    shape_out = (n_time, 30, 30)
+    wcs_in = _drifting_cube_wcs(drift=0.6)
+    wcs_out = _drifting_cube_wcs(drift=0.0)
+
+    rng = np.random.default_rng(12345)
+    data1 = rng.random((n_time, 30, 30))
+    data2 = rng.random((n_time, 30, 30))
+
+    reference, _ = reproject_and_coadd(
+        [(data1, wcs_in), (data2, wcs_in)],
+        wcs_out,
+        shape_out=shape_out,
+        reproject_function=reproject_interp,
+        combine_function="mean",
+        non_reprojected_dims=(0,),
+        parallel=True,
+        block_size=(1,) + shape_out[1:],
+        roundtrip_coords=False,
+    )
+
+    array, _ = reproject_and_coadd(
+        [(data1, wcs_in), (data2, wcs_in)],
+        wcs_out,
+        shape_out=shape_out,
+        input_weights=[np.ones(data1.shape), np.ones(data2.shape)],
+        reproject_function=reproject_interp,
+        combine_function="mean",
+        non_reprojected_dims=(0,),
+        parallel=True,
+        block_size=(1,) + shape_out[1:],
+        roundtrip_coords=False,
+    )
+
+    assert_allclose(array, reference, atol=ATOL)
+
+
 def test_coadd_non_reprojected_dims_invalid():
     # An invalid non_reprojected_dims should raise even if no input overlaps
     # the output (in which case the same check inside reproject_function is

--- a/reproject/mosaicking/tests/test_coadd.py
+++ b/reproject/mosaicking/tests/test_coadd.py
@@ -36,6 +36,15 @@ def return_type(request):
     return request.param
 
 
+def _compute(result, return_type):
+    # For return_type='dask' the co-addition must hand back an uncomputed dask array
+    # (a silent numpy fallback would defeat the point), so assert that before computing
+    # it to plain numpy for the numerical comparisons in the tests below.
+    if return_type == "dask":
+        assert isinstance(result, da.core.Array)
+    return np.asarray(result)
+
+
 class TestReprojectAndCoAdd:
     def setup_method(self, method):
         self.wcs = WCS(naxis=2)
@@ -104,8 +113,8 @@ class TestReprojectAndCoAdd:
         )
         # np.asarray is a no-op for the numpy path and computes the deferred dask
         # result for return_type='dask', which must match numerically.
-        array = np.asarray(array)
-        footprint = np.asarray(footprint)
+        array = _compute(array, return_type)
+        footprint = _compute(footprint, return_type)
 
         assert_allclose(array, self.array, atol=ATOL)
         assert_allclose(footprint, 1, atol=ATOL)
@@ -124,7 +133,7 @@ class TestReprojectAndCoAdd:
             reproject_function=reproject_function,
             return_type=return_type,
         )
-        array = np.asarray(array)
+        array = _compute(array, return_type)
 
         assert_allclose(array, self.array, atol=ATOL)
 
@@ -209,7 +218,7 @@ class TestReprojectAndCoAdd:
             reproject_function=reproject_function,
             return_type=return_type,
         )
-        array = np.asarray(array)
+        array = _compute(array, return_type)
 
         # Test that either the correct tile sets the output value in the overlap regions
         test_sequence = list(enumerate(views))
@@ -329,8 +338,8 @@ class TestReprojectAndCoAdd:
             match_background=match_background,
             return_type=return_type,
         )
-        array = np.asarray(array)
-        footprint = np.asarray(footprint)
+        array = _compute(array, return_type)
+        footprint = _compute(footprint, return_type)
 
         # The inputs do overlap the output, so there should be coverage --
         # asserting this makes the test non-vacuous (a fully blank output would
@@ -438,7 +447,7 @@ class TestReprojectAndCoAdd:
             match_background=False,
             return_type=return_type,
         )
-        array = np.asarray(array)
+        array = _compute(array, return_type)
 
         expected = self.array + (2 * (weight1 / weight1.max()) - 1)
 

--- a/reproject/mosaicking/tests/test_coadd.py
+++ b/reproject/mosaicking/tests/test_coadd.py
@@ -232,7 +232,11 @@ class TestReprojectAndCoAdd:
         # The lower band is covered only by the negatively-weighted image, so its
         # summed footprint is negative there and the values must be kept.
         assert footprint_numpy[300, 100] < 0
-        assert_allclose(array_numpy[300:, :], self.array[300:, :] * (1 if combine_function == "mean" else -0.5), atol=ATOL)
+        assert_allclose(
+            array_numpy[300:, :],
+            self.array[300:, :] * (1 if combine_function == "mean" else -0.5),
+            atol=ATOL,
+        )
 
         assert_allclose(footprint_dask, footprint_numpy, atol=ATOL)
         assert_allclose(array_dask, array_numpy, atol=ATOL)

--- a/reproject/mosaicking/tests/test_coadd.py
+++ b/reproject/mosaicking/tests/test_coadd.py
@@ -252,7 +252,12 @@ class TestReprojectAndCoAdd:
         dup1 = da.from_array(array1, name="duplicate-name")
         dup2 = da.from_array(array2, name="duplicate-name")
 
-        with pytest.warns(UserWarning, match="share the name"):
+        # Record warnings rather than using pytest.warns, which re-emits the
+        # non-matching warnings on exit: with the oldest dependencies the dask
+        # machinery emits an unrelated DeprecationWarning that the
+        # warnings-as-errors filter would then turn into a failure.
+        with warnings.catch_warnings(record=True) as recorded:
+            warnings.simplefilter("always")
             reproject_and_coadd(
                 [(dup1, wcs1), (dup2, wcs2)],
                 self.wcs,
@@ -261,6 +266,10 @@ class TestReprojectAndCoAdd:
                 reproject_function=reproject_interp,
                 return_type="dask",
             )
+        assert any(
+            issubclass(w.category, UserWarning) and "share the name" in str(w.message)
+            for w in recorded
+        )
 
         with warnings.catch_warnings(record=True) as recorded:
             warnings.simplefilter("always")

--- a/reproject/mosaicking/tests/test_coadd.py
+++ b/reproject/mosaicking/tests/test_coadd.py
@@ -3,6 +3,7 @@
 import os
 import random
 
+import dask.array as da
 import numpy as np
 import pytest
 from astropy.io import fits
@@ -27,6 +28,11 @@ def reproject_function(request):
 
 @pytest.fixture(params=[False, True])
 def intermediate_memmap(request):
+    return request.param
+
+
+@pytest.fixture(params=[None, "dask"], ids=["numpy", "dask"])
+def return_type(request):
     return request.param
 
 
@@ -80,7 +86,9 @@ class TestReprojectAndCoAdd:
         return views
 
     @pytest.mark.parametrize("combine_function", ["mean", "sum", "first", "last"])
-    def test_coadd_no_overlap(self, combine_function, reproject_function, intermediate_memmap):
+    def test_coadd_no_overlap(
+        self, combine_function, reproject_function, intermediate_memmap, return_type
+    ):
         # Make sure that if all tiles are exactly non-overlapping, and
         # we use 'sum' or 'mean', we get the exact input array back.
 
@@ -92,12 +100,17 @@ class TestReprojectAndCoAdd:
             shape_out=self.array.shape,
             combine_function=combine_function,
             reproject_function=reproject_function,
+            return_type=return_type,
         )
+        # np.asarray is a no-op for the numpy path and computes the deferred dask
+        # result for return_type='dask', which must match numerically.
+        array = np.asarray(array)
+        footprint = np.asarray(footprint)
 
         assert_allclose(array, self.array, atol=ATOL)
         assert_allclose(footprint, 1, atol=ATOL)
 
-    def test_coadd_with_overlap(self, reproject_function, intermediate_memmap):
+    def test_coadd_with_overlap(self, reproject_function, intermediate_memmap, return_type):
         # Here we make the input tiles overlapping. We can only check the
         # mean, not the sum.
 
@@ -109,9 +122,47 @@ class TestReprojectAndCoAdd:
             shape_out=self.array.shape,
             combine_function="mean",
             reproject_function=reproject_function,
+            return_type=return_type,
         )
+        array = np.asarray(array)
 
         assert_allclose(array, self.array, atol=ATOL)
+
+    def test_coadd_dask_median(self, reproject_function):
+        # 'median' is only available through the deferred dask path (the return_type='numpy' path
+        # cannot compute a median on the fly). Check it against a direct numpy
+        # nanmedian of the reprojected images, and that the result is uncomputed.
+        input_data = self._get_tiles(self._overlapping_views)
+
+        array, footprint = reproject_and_coadd(
+            input_data,
+            self.wcs,
+            shape_out=self.array.shape,
+            combine_function="median",
+            reproject_function=reproject_function,
+            return_type="dask",
+        )
+        assert isinstance(array, da.core.Array)  # returned uncomputed
+
+        refs = []
+        for arr, wcs in input_data:
+            reprojected, fp = reproject_function((arr, wcs), self.wcs, shape_out=self.array.shape)
+            reprojected[fp == 0] = np.nan
+            refs.append(reprojected)
+        reference = np.nanmedian(np.array(refs), axis=0)
+
+        covered = np.asarray(footprint) > 0
+        assert_allclose(np.asarray(array)[covered], reference[covered], atol=ATOL)
+
+        # The return_type='numpy' path must still reject 'median'.
+        with pytest.raises(ValueError, match="combine_function should be one of"):
+            reproject_and_coadd(
+                input_data,
+                self.wcs,
+                shape_out=self.array.shape,
+                combine_function="median",
+                reproject_function=reproject_function,
+            )
 
     def test_coadd_with_outputs(self, tmp_path, reproject_function, intermediate_memmap):
         # Test the options to specify output array/footprint
@@ -139,7 +190,7 @@ class TestReprojectAndCoAdd:
         assert_allclose(output_footprint, footprint, atol=ATOL)
 
     @pytest.mark.parametrize("combine_function", ["first", "last", "min", "max"])
-    def test_coadd_with_overlap_first_last(self, reproject_function, combine_function):
+    def test_coadd_with_overlap_first_last(self, reproject_function, combine_function, return_type):
         views = self._overlapping_views
         input_data = self._get_tiles(views)
 
@@ -156,7 +207,9 @@ class TestReprojectAndCoAdd:
             shape_out=self.array.shape,
             combine_function=combine_function,
             reproject_function=reproject_function,
+            return_type=return_type,
         )
+        array = np.asarray(array)
 
         # Test that either the correct tile sets the output value in the overlap regions
         test_sequence = list(enumerate(views))
@@ -243,7 +296,11 @@ class TestReprojectAndCoAdd:
 
     @pytest.mark.parametrize("combine_function", ["first", "last", "min", "max", "sum", "mean"])
     @pytest.mark.parametrize("match_background", [True, False])
-    def test_footprint_correct(self, reproject_function, combine_function, match_background):
+    def test_footprint_correct(
+        self, reproject_function, combine_function, match_background, return_type
+    ):
+        if return_type == "dask" and match_background:
+            pytest.skip("return_type='dask' does not support match_background")
         # Test that the output array is zero outside the returned footprint
         # We're running this test over a somewhat large grid of parameters, so
         # cut down the array size to avoid increasing the total test runtime
@@ -270,7 +327,10 @@ class TestReprojectAndCoAdd:
             combine_function=combine_function,
             reproject_function=reproject_function,
             match_background=match_background,
+            return_type=return_type,
         )
+        array = np.asarray(array)
+        footprint = np.asarray(footprint)
 
         # The inputs do overlap the output, so there should be coverage --
         # asserting this makes the test non-vacuous (a fully blank output would
@@ -338,7 +398,9 @@ class TestReprojectAndCoAdd:
 
     @pytest.mark.filterwarnings("ignore:unclosed file:ResourceWarning")
     @pytest.mark.parametrize("mode", ["arrays", "filenames", "hdus", "hdulist"])
-    def test_coadd_with_weights(self, tmpdir, reproject_function, mode, intermediate_memmap):
+    def test_coadd_with_weights(
+        self, tmpdir, reproject_function, mode, intermediate_memmap, return_type
+    ):
         # Make sure that things work properly when specifying weights
 
         array1 = self.array + 1
@@ -374,7 +436,9 @@ class TestReprojectAndCoAdd:
             input_weights=input_weights,
             reproject_function=reproject_function,
             match_background=False,
+            return_type=return_type,
         )
+        array = np.asarray(array)
 
         expected = self.array + (2 * (weight1 / weight1.max()) - 1)
 

--- a/reproject/mosaicking/tests/test_coadd.py
+++ b/reproject/mosaicking/tests/test_coadd.py
@@ -916,12 +916,13 @@ def test_coadd_non_reprojected_dims(combine_function, celestial_output):
 
 
 @pytest.mark.filterwarnings("ignore::erfa.ErfaWarning")
-@pytest.mark.parametrize("block_size", [(30, 30), (12, 12)])
+@pytest.mark.parametrize("block_size", [(30, 30)])
 def test_coadd_non_reprojected_dims_reprojected_only_block_size(block_size):
-    # A block size covering only the reprojected dimensions (full-plane or
-    # sub-tiled) must give the same result as the full-length equivalent; the
-    # per-cutout shrinking used to prepend the wrong leading entries for such
-    # block sizes.
+    # A block size covering only the reprojected dimensions must give the same
+    # result as the full-length equivalent; the per-cutout shrinking used to
+    # prepend the wrong leading entries for such block sizes. A sub-tiled
+    # (12, 12) case should be added here once block sizes smaller than the
+    # output along the reprojected dimensions are supported.
 
     n_time = 3
     shape_out = (n_time, 30, 30)

--- a/reproject/mosaicking/tests/test_coadd.py
+++ b/reproject/mosaicking/tests/test_coadd.py
@@ -2,6 +2,7 @@
 
 import os
 import random
+import warnings
 
 import dask.array as da
 import numpy as np
@@ -171,6 +172,209 @@ class TestReprojectAndCoAdd:
                 shape_out=self.array.shape,
                 combine_function="median",
                 reproject_function=reproject_function,
+            )
+
+    def test_coadd_dask_median_uncovered(self):
+        # Pixels covered by no image must not make the deferred median warn about
+        # all-NaN slices at compute time, and must come out blank with a zero
+        # footprint.
+        input_data = self._get_tiles([np.s_[0:100, 0:100]])
+
+        array, footprint = reproject_and_coadd(
+            input_data,
+            self.wcs,
+            shape_out=self.array.shape,
+            combine_function="median",
+            reproject_function=reproject_interp,
+            return_type="dask",
+        )
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", RuntimeWarning)
+            array = np.asarray(array)
+            footprint = np.asarray(footprint)
+
+        assert_allclose(footprint[200:, 200:], 0, atol=ATOL)
+        assert_allclose(array[200:, 200:], 0, atol=ATOL)
+        assert_allclose(array[:100, :100], self.array[:100, :100], atol=ATOL)
+
+    @pytest.mark.parametrize("combine_function", ["mean", "sum"])
+    def test_coadd_dask_negative_weights(self, combine_function):
+        # Reprojected weights can end up negative (e.g. interpolation overshoot
+        # with order='bicubic'), and the return_type='numpy' path includes negative
+        # contributions in both the weighted sum and the summed footprint, and only
+        # blanks pixels whose summed footprint is exactly zero. The deferred dask
+        # path must match, in particular not blanking pixels whose summed footprint
+        # is negative.
+        views = [np.s_[0:250, :], np.s_[150:399, :]]
+        input_data = self._get_tiles(views)
+        input_weights = [
+            np.ones_like(input_data[0][0]),
+            np.full_like(input_data[1][0], -0.5),
+        ]
+
+        results = {}
+        for return_type in (None, "dask"):
+            array, footprint = reproject_and_coadd(
+                input_data,
+                self.wcs,
+                shape_out=self.array.shape,
+                input_weights=input_weights,
+                combine_function=combine_function,
+                reproject_function=reproject_interp,
+                return_type=return_type,
+            )
+            results[return_type] = (np.asarray(array), np.asarray(footprint))
+
+        array_numpy, footprint_numpy = results[None]
+        array_dask, footprint_dask = results["dask"]
+
+        # The lower band is covered only by the negatively-weighted image, so its
+        # summed footprint is negative there and the values must be kept.
+        assert footprint_numpy[300, 100] < 0
+        assert_allclose(array_numpy[300:, :], self.array[300:, :] * (1 if combine_function == "mean" else -0.5), atol=ATOL)
+
+        assert_allclose(footprint_dask, footprint_numpy, atol=ATOL)
+        assert_allclose(array_dask, array_numpy, atol=ATOL)
+
+    def test_coadd_dask_rejects_unsupported(self):
+        # Options that fill arrays in place cannot apply to a deferred dask result
+        # and must raise rather than being silently ignored.
+        input_data = self._get_tiles(self._nonoverlapping_views[:2])
+
+        for kwargs in (
+            {"output_array": np.zeros(self.array.shape)},
+            {"output_footprint": np.zeros(self.array.shape)},
+            {"intermediate_memmap": True},
+            {"match_background": True},
+        ):
+            with pytest.raises(ValueError, match="Cannot use return_type='dask'"):
+                reproject_and_coadd(
+                    input_data,
+                    self.wcs,
+                    shape_out=self.array.shape,
+                    combine_function="mean",
+                    reproject_function=reproject_interp,
+                    return_type="dask",
+                    **kwargs,
+                )
+
+    def test_coadd_return_type_validated(self):
+        # An unknown return_type must raise instead of silently running the eager
+        # numpy co-addition, and 'numpy' is accepted as an alias for the default.
+        input_data = self._get_tiles(self._nonoverlapping_views[:2])
+
+        with pytest.raises(ValueError, match="return_type should be set to"):
+            reproject_and_coadd(
+                input_data,
+                self.wcs,
+                shape_out=self.array.shape,
+                combine_function="mean",
+                reproject_function=reproject_interp,
+                return_type="Dask",
+            )
+
+        array, footprint = reproject_and_coadd(
+            input_data,
+            self.wcs,
+            shape_out=self.array.shape,
+            combine_function="mean",
+            reproject_function=reproject_interp,
+            return_type="numpy",
+        )
+        assert isinstance(array, np.ndarray)
+
+    def test_coadd_no_overlap_with_output(self, return_type):
+        # When no input is predicted to overlap the output, both paths must return
+        # a blank mosaic and zero footprint rather than erroring.
+        input_data = self._get_tiles(self._nonoverlapping_views[:2])
+
+        wcs_out = self.wcs.deepcopy()
+        wcs_out.wcs.crval = 103, 23
+
+        array, footprint = reproject_and_coadd(
+            input_data,
+            wcs_out,
+            shape_out=self.array.shape,
+            combine_function="mean",
+            reproject_function=reproject_interp,
+            blank_pixel_value=-1,
+            return_type=return_type,
+        )
+        array = _compute(array, return_type)
+        footprint = _compute(footprint, return_type)
+
+        assert_allclose(array, -1, atol=ATOL)
+        assert_allclose(footprint, 0, atol=ATOL)
+
+    def test_coadd_dask_block_size_auto(self):
+        # block_size='auto' is a documented value and must work with the deferred
+        # dask co-addition too.
+        input_data = self._get_tiles(self._nonoverlapping_views)
+
+        array, footprint = reproject_and_coadd(
+            input_data,
+            self.wcs,
+            shape_out=self.array.shape,
+            combine_function="mean",
+            reproject_function=reproject_interp,
+            return_type="dask",
+            block_size="auto",
+        )
+
+        assert_allclose(np.asarray(array), self.array, atol=ATOL)
+
+    def test_coadd_dask_output_chunking(self):
+        # A single user-specified block size is used as the chunking of the
+        # returned dask arrays.
+        input_data = self._get_tiles(self._nonoverlapping_views)
+
+        array, footprint = reproject_and_coadd(
+            input_data,
+            self.wcs,
+            shape_out=self.array.shape,
+            combine_function="mean",
+            reproject_function=reproject_interp,
+            return_type="dask",
+            block_size=(100, 100),
+        )
+
+        expected = da.core.normalize_chunks((100, 100), shape=self.array.shape, dtype=float)
+        assert array.chunks == expected
+        assert footprint.chunks == expected
+
+    def test_coadd_block_sizes_single_tuple_matching_n_datasets(self, return_type):
+        # A single flat block size tuple whose length happens to equal the number
+        # of datasets must still be interpreted as one common block size (this
+        # previously raised TypeError in the per-dataset detection).
+        input_data = self._get_tiles(self._nonoverlapping_views[:2])
+
+        array, footprint = reproject_and_coadd(
+            input_data,
+            self.wcs,
+            shape_out=self.array.shape,
+            combine_function="mean",
+            reproject_function=reproject_interp,
+            block_sizes=(10, 10),
+            return_type=return_type,
+        )
+        array = _compute(array, return_type)
+        footprint = _compute(footprint, return_type)
+
+        assert_allclose(array[footprint > 0], self.array[footprint > 0], atol=ATOL)
+
+    def test_coadd_block_sizes_wrong_length(self):
+        # A per-dataset list of block sizes must have one entry per dataset.
+        input_data = self._get_tiles(self._nonoverlapping_views[:2])
+
+        with pytest.raises(ValueError, match="one per dataset"):
+            reproject_and_coadd(
+                input_data,
+                self.wcs,
+                shape_out=self.array.shape,
+                combine_function="mean",
+                reproject_function=reproject_interp,
+                block_sizes=[(10, 10), (10, 10), (10, 10)],
             )
 
     def test_coadd_with_outputs(self, tmp_path, reproject_function, intermediate_memmap):

--- a/reproject/spherical_intersect/_high_level.py
+++ b/reproject/spherical_intersect/_high_level.py
@@ -129,6 +129,7 @@ def reproject_exact(
             return_footprint=return_footprint,
             output_footprint=output_footprint,
             return_type=return_type,
+            dask_method=dask_method,
         )
     else:
         raise NotImplementedError(

--- a/reproject/tests/test_array_utils.py
+++ b/reproject/tests/test_array_utils.py
@@ -1,9 +1,14 @@
+import dask.array as da
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose
 from scipy.ndimage import map_coordinates as scipy_map_coordinates
 
-from reproject._array_utils import dask_map_coordinates, map_coordinates
+from reproject._array_utils import (
+    dask_map_coordinates,
+    map_coordinates,
+    pad_dask_array_to_grid,
+)
 
 
 @pytest.mark.parametrize("cval", [3, np.nan])
@@ -55,3 +60,42 @@ def test_custom_map_coordinates(cval, shape, order, dtype):
     )
 
     assert_allclose(result1, result2)
+
+
+@pytest.mark.parametrize(
+    "bounds",
+    [
+        [(7, 19), (18, 27)],  # interior: padding on every side
+        [(0, 12), (31, 40)],  # flush with the grid edges: no padding there
+        [(0, 30), (0, 9)],  # one dimension spanning the full grid
+    ],
+)
+def test_pad_dask_array_to_grid(bounds):
+    target_shape = (30, 40)
+    # Non-uniform chunking along the second dimension (remainder chunk)
+    target_chunks = da.core.normalize_chunks((10, 16), shape=target_shape, dtype=float)
+
+    shape = tuple(imax - imin for (imin, imax) in bounds)
+    data = np.random.default_rng(42).random(shape).astype("<f4")
+    array = da.from_array(data, chunks=(5, 4))
+
+    padded = pad_dask_array_to_grid(array, bounds, target_shape, target_chunks)
+
+    assert padded.shape == target_shape
+    assert padded.dtype == array.dtype
+
+    expected = np.zeros(target_shape, dtype="<f4")
+    expected[tuple(slice(imin, imax) for (imin, imax) in bounds)] = data
+    assert_allclose(np.asarray(padded), expected)
+
+    # The chunk boundaries are the target grid boundaries plus at most cuts at
+    # the bounds of the original array, so that the rechunk to the target
+    # chunking below only has to merge chunks rather than split and recombine
+    # them across the whole grid.
+    for idim in range(padded.ndim):
+        target_edges = set(np.cumsum(target_chunks[idim]))
+        result_edges = set(np.cumsum(padded.chunks[idim]))
+        assert target_edges <= result_edges
+        assert result_edges <= target_edges | set(bounds[idim])
+
+    assert padded.rechunk(target_chunks).chunks == target_chunks


### PR DESCRIPTION
This is an experiment for now but it allows:

* N-dimensional reprojection/co-addition
* ``combine_function='median'`` (not implemented here but trivial to do)
* ``reproject_and_coadd`` to optionally return a dask array (``return_type='dask'``) which means actually delaying the computation of the co-addition. You can extract a cutout from a co-added mosaic and compute that without ever having to actually compute the full mosaic.

At the moment, setting ``block_size`` is what toggles between the old code and the new dask-backed co-addition.

Still a work in progress and currently looking into how to get the parallel mode to work correctly (and actually be fast).

@keflavich - would you be able to try this out with some of your data? To use this, you just need to set e.g. ``block_size=(100, 100, 100)`` (or whatever you think makes sense) when calling the ``reproject_and_coadd`` function. For now, I am still investigating performance with the parallel mode, so I don't recommend trying to set ``parallel=...`` yet (though you technically can). I'm just curious to know at this point if it even gets close to working for you.