### PR TITLE
Fix compatibility with Cython 3.0.2 and update version in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = ["setuptools",
             "wheel",
             "extension-helpers",
             "oldest-supported-numpy",
-            "cython==0.29.32"]
+            "cython==3.0.2"]
 build-backend = 'setuptools.build_meta'
 
 [tool.setuptools_scm]

--- a/reproject/adaptive/deforest.pyx
+++ b/reproject/adaptive/deforest.pyx
@@ -211,7 +211,7 @@ cdef void calculate_jacobian(double[:, :] Ji, int center_jacobian,
 @cython.wraparound(False)
 @cython.nonecheck(False)
 @cython.cdivision(True)
-cdef int cmp_func(const void* a, const void* b) nogil:
+cdef int cmp_func(const void* a, const void* b) noexcept nogil:
     cdef double a_v = (<double*>a)[0]
     cdef double b_v = (<double*>b)[0]
     if a_v < b_v:


### PR DESCRIPTION
This fixes an issue when compiling with Cython 3.0.2 and updates the pin.