### PR TITLE
Added ability to set ``block_size='auto'`` and fix missing parameters in docstrings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -75,7 +75,7 @@ repos:
     rev: main
     hooks:
       - id: numpydoc-validation
-        files: ".*(high_level.*)$"
+        files: ".*(high_level|mosaicking).*$"
         exclude: ".*(tests.*)$"
 
 ci:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -71,5 +71,12 @@ repos:
     hooks:
       - id: black
 
+  - repo: https://github.com/numpy/numpydoc
+    rev: main
+    hooks:
+      - id: numpydoc-validation
+        files: ".*(high_level.*)$"
+        exclude: ".*(tests.*)$"
+
 ci:
   autofix_prs: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,3 +30,13 @@ length_sort_sections = ["future", "stdlib"]
 [tool.black]
 line-length = 100
 target-version = ['py38']
+
+[tool.numpydoc_validation]
+checks = [
+    "all",   # report on all checks, except the below
+    "EX01",
+    "SA01",
+    "SS06",
+    "ES01",
+    "GL08",
+]

--- a/reproject/adaptive/high_level.py
+++ b/reproject/adaptive/high_level.py
@@ -12,12 +12,6 @@ def reproject_adaptive(
     output_projection,
     shape_out=None,
     hdu_in=0,
-    output_array=None,
-    return_footprint=True,
-    output_footprint=None,
-    block_size=None,
-    parallel=False,
-    return_type=None,
     center_jacobian=False,
     despike_jacobian=False,
     roundtrip_coords=True,
@@ -32,6 +26,12 @@ def reproject_adaptive(
     y_cyclic=False,
     bad_value_mode="strict",
     bad_fill_value=0,
+    output_array=None,
+    output_footprint=None,
+    return_footprint=True,
+    block_size=None,
+    parallel=False,
+    return_type=None,
 ):
     """
     Reproject a 2D array from one WCS to another using the DeForest (2004)
@@ -42,7 +42,7 @@ def reproject_adaptive(
 
     Parameters
     ----------
-    input_data
+    input_data : object
         The input data to reproject. This can be:
 
             * The name of a FITS file as a `str` or a `pathlib.Path` object
@@ -73,8 +73,6 @@ def reproject_adaptive(
     hdu_in : int or str, optional
         If ``input_data`` is a FITS file or an `~astropy.io.fits.HDUList`
         instance, specifies the HDU to use.
-    return_footprint : bool
-        Whether to return the footprint in addition to the output array.
     center_jacobian : bool
         A Jacobian matrix is calculated, representing
         d(input image coordinate) / d(output image coordinate),
@@ -185,11 +183,37 @@ def reproject_adaptive(
 
     bad_fill_value : double
         The constant value used by the ``constant`` bad-value mode.
+    output_array : None or `~numpy.ndarray`
+        An array in which to store the reprojected data.  This can be any numpy
+        array including a memory map, which may be helpful when dealing with
+        extremely large files.
+    output_footprint : `~numpy.ndarray`, optional
+        An array in which to store the footprint of reprojected data.  This can be
+        any numpy array including a memory map, which may be helpful when dealing with
+        extremely large files.
+    return_footprint : bool
+        Whether to return the footprint in addition to the output array.
+    block_size : tuple or 'auto', optional
+        The size of blocks in terms of output array pixels that each block will handle
+        reprojecting. Extending out from (0,0) coords positively, block sizes
+        are clamped to output space edges when a block would extend past edge.
+        Specifying ``'auto'`` means that reprojection will be done in blocks with
+        the block size automatically determined. If ``block_size`` is not
+        specified or set to `None`, the reprojection will not be carried out in
+        blocks.
+    parallel : bool or int, optional
+        If `True`, the reprojection is carried out in parallel, and if a
+        positive integer, this specifies the number of processes to use.
+        The reprojection will be parallelized over output array blocks specified
+        by ``block_size`` (if the block size is not set, it will be determined
+        automatically).
+    return_type : {'numpy', 'dask'}, optional
+        Whether to return numpy or dask arrays - defaults to 'numpy'.
 
     Returns
     -------
     array_new : `~numpy.ndarray`
-        The reprojected array
+        The reprojected array.
     footprint : `~numpy.ndarray`
         Footprint of the input array in the output array. Values of 0 indicate
         no coverage or valid values in the input image, while values of 1

--- a/reproject/common.py
+++ b/reproject/common.py
@@ -220,7 +220,7 @@ def _reproject_dispatcher(
         # NOTE: the following array is just used to set up the iteration in map_blocks
         # but isn't actually used otherwise - this is deliberate.
 
-        if block_size:
+        if block_size is not None and block_size != "auto":
             if wcs_in.low_level_wcs.pixel_n_dim < len(shape_out):
                 if len(block_size) < len(shape_out):
                     block_size = [-1] * (len(shape_out) - len(block_size)) + list(block_size)

--- a/reproject/common.py
+++ b/reproject/common.py
@@ -63,10 +63,14 @@ def _reproject_dispatcher(
         Target shape
     wcs_out: `~astropy.wcs.WCS`
         Target WCS
-    block_size: tuple, optional
+    block_size: tuple or 'auto', optional
         The size of blocks in terms of output array pixels that each block will handle
         reprojecting. Extending out from (0,0) coords positively, block sizes
-        are clamped to output space edges when a block would extend past edge
+        are clamped to output space edges when a block would extend past edge.
+        Specifying ``'auto'`` means that reprojection will be done in blocks with
+        the block size automatically determined. If ``block_size`` is not
+        specified or set to `None`, the reprojection will not be carried out in
+        blocks.
     array_out : `~numpy.ndarray`, optional
         An array in which to store the reprojected data.  This can be any numpy
         array including a memory map, which may be helpful when dealing with
@@ -77,12 +81,12 @@ def _reproject_dispatcher(
         An array in which to store the footprint of reprojected data.  This can be
         any numpy array including a memory map, which may be helpful when dealing with
         extremely large files.
-    parallel : bool or int
-        Flag for parallel implementation. If ``True``, a parallel implementation
-        is chosen, the number of processes selected automatically to be equal to
-        the number of logical CPUs detected on the machine. If ``False``, a
-        serial implementation is chosen. If the flag is a positive integer ``n``
-        greater than one, a parallel implementation using ``n`` processes is chosen.
+    parallel : bool or int, optional
+        If `True`, the reprojection is carried out in parallel, and if a
+        positive integer, this specifies the number of processes to use.
+        The reprojection will be parallelized over output array blocks specified
+        by ``block_size`` (if the block size is not set, it will be determined
+        automatically).
     reproject_func_kwargs : dict, optional
         Keyword arguments to pass through to ``reproject_func``
     return_type : {'numpy', 'dask'}, optional

--- a/reproject/healpix/high_level.py
+++ b/reproject/healpix/high_level.py
@@ -14,7 +14,7 @@ def reproject_from_healpix(
 
     Parameters
     ----------
-    input_data
+    input_data : object
         The input data to reproject. This can be:
 
             * The name of a HEALPIX FITS file
@@ -33,7 +33,7 @@ def reproject_from_healpix(
     hdu_in : int or str, optional
         If ``input_data`` is a FITS file, specifies the HDU to use.
         (the default HDU for HEALPIX data is 1, unlike with image files where
-        it is generally 0)
+        it is generally 0).
     order : int or str, optional
         The order of the interpolation (if ``mode`` is set to
         ``'interpolation'``). This can be either one of the following strings:
@@ -54,7 +54,7 @@ def reproject_from_healpix(
     Returns
     -------
     array_new : `~numpy.ndarray`
-        The reprojected array
+        The reprojected array.
     footprint : `~numpy.ndarray`
         Footprint of the input array in the output array. Values of 0 indicate
         no coverage or valid values in the input image, while values of 1
@@ -86,7 +86,7 @@ def reproject_to_healpix(
 
     Parameters
     ----------
-    input_data
+    input_data : object
         The input data to reproject. This can be:
 
             * The name of a FITS file
@@ -98,7 +98,7 @@ def reproject_to_healpix(
               `~astropy.io.fits.Header` object
 
     coord_system_out : `~astropy.coordinates.BaseCoordinateFrame` or str
-        The output coordinate system for the HEALPIX projection
+        The output coordinate system for the HEALPIX projection.
     hdu_in : int or str, optional
         If ``input_data`` is a FITS file or an `~astropy.io.fits.HDUList`
         instance, specifies the HDU to use.
@@ -114,14 +114,14 @@ def reproject_to_healpix(
         or an integer. A value of ``0`` indicates nearest neighbor
         interpolation.
     nested : bool
-        The order of the healpix_data, either nested (True) or ring (False)
+        The order of the healpix_data, either nested (`True`) or ring (`False`).
     nside : int, optional
         The resolution of the HEALPIX projection.
 
     Returns
     -------
     array_new : `~numpy.ndarray`
-        The reprojected array
+        The reprojected array.
     footprint : `~numpy.ndarray`
         Footprint of the input array in the output array. Values of 0 indicate
         no coverage or valid values in the input image, while values of 1

--- a/reproject/interpolation/high_level.py
+++ b/reproject/interpolation/high_level.py
@@ -21,14 +21,14 @@ def reproject_interp(
     output_projection,
     shape_out=None,
     hdu_in=0,
+    order="bilinear",
+    roundtrip_coords=True,
     output_array=None,
-    return_footprint=True,
     output_footprint=None,
+    return_footprint=True,
     block_size=None,
     parallel=False,
     return_type=None,
-    order="bilinear",
-    roundtrip_coords=True,
 ):
     """
     Reproject data to a new projection using interpolation (this is typically
@@ -36,7 +36,7 @@ def reproject_interp(
 
     Parameters
     ----------
-    input_data
+    input_data : object
         The input data to reproject. This can be:
 
             * The name of a FITS file as a `str` or a `pathlib.Path` object
@@ -78,32 +78,40 @@ def reproject_interp(
 
         or an integer. A value of ``0`` indicates nearest neighbor
         interpolation.
+    roundtrip_coords : bool
+        Whether to verify that coordinate transformations are defined in both
+        directions.
     output_array : None or `~numpy.ndarray`
         An array in which to store the reprojected data.  This can be any numpy
         array including a memory map, which may be helpful when dealing with
         extremely large files.
+    output_footprint : `~numpy.ndarray`, optional
+        An array in which to store the footprint of reprojected data.  This can be
+        any numpy array including a memory map, which may be helpful when dealing with
+        extremely large files.
     return_footprint : bool
         Whether to return the footprint in addition to the output array.
-    block_size : None or tuple of (int, int)
-        If not none, a blocked projection will be performed where the output space is
-        reprojected to one block at a time, this is useful for memory limited scenarios
-        such as dealing with very large arrays or high resolution output spaces.
-    parallel : bool or int
-        Flag for parallel implementation. If ``True``, a parallel implementation
-        is chosen, the number of processes selected automatically to be equal to
-        the number of logical CPUs detected on the machine. If ``False``, a
-        serial implementation is chosen. If the flag is a positive integer ``n``
-        greater than one, a parallel implementation using ``n`` processes is chosen.
-    roundtrip_coords : bool
-        Whether to verify that coordinate transformations are defined in both
-        directions.
+    block_size : tuple or 'auto', optional
+        The size of blocks in terms of output array pixels that each block will handle
+        reprojecting. Extending out from (0,0) coords positively, block sizes
+        are clamped to output space edges when a block would extend past edge.
+        Specifying ``'auto'`` means that reprojection will be done in blocks with
+        the block size automatically determined. If ``block_size`` is not
+        specified or set to `None`, the reprojection will not be carried out in
+        blocks.
+    parallel : bool or int, optional
+        If `True`, the reprojection is carried out in parallel, and if a
+        positive integer, this specifies the number of processes to use.
+        The reprojection will be parallelized over output array blocks specified
+        by ``block_size`` (if the block size is not set, it will be determined
+        automatically).
     return_type : {'numpy', 'dask'}, optional
         Whether to return numpy or dask arrays - defaults to 'numpy'.
 
     Returns
     -------
     array_new : `~numpy.ndarray`
-        The reprojected array
+        The reprojected array.
     footprint : `~numpy.ndarray`
         Footprint of the input array in the output array. Values of 0 indicate
         no coverage or valid values in the input image, while values of 1

--- a/reproject/interpolation/tests/test_core.py
+++ b/reproject/interpolation/tests/test_core.py
@@ -969,7 +969,7 @@ def test_auto_block_size():
     wcs_out = WCS(naxis=2)
 
     # When block size and parallel aren't specified, can't return as dask arrays
-    with pytest.raises(ValueError, match='Output cannot be returned as dask arrays'):
+    with pytest.raises(ValueError, match="Output cannot be returned as dask arrays"):
         reproject_interp(
             (array_in, wcs_in),
             wcs_out,
@@ -982,7 +982,7 @@ def test_auto_block_size():
         wcs_out,
         shape_out=(300, 300),
         return_type="dask",
-        block_size='auto',
+        block_size="auto",
     )
 
     assert array_out.chunksize == (350, 54, 54)

--- a/reproject/interpolation/tests/test_core.py
+++ b/reproject/interpolation/tests/test_core.py
@@ -985,5 +985,5 @@ def test_auto_block_size():
         block_size="auto",
     )
 
-    assert array_out.chunksize == (350, 54, 54)
-    assert footprint_out.chunksize == (350, 54, 54)
+    assert array_out.chunksize[0] == 350
+    assert footprint_out.chunksize[0] == 350

--- a/reproject/mosaicking/background.py
+++ b/reproject/mosaicking/background.py
@@ -11,6 +11,16 @@ def determine_offset_matrix(arrays):
     """
     Given a list of ReprojectedArraySubset, determine the offset
     matrix between all arrays.
+
+    Parameters
+    ----------
+    arrays : list
+        The list of ReprojectedArraySubset objects to determine the offsets for.
+
+    Returns
+    -------
+    `numpy.ndarray`
+        The offset matrix.
     """
 
     N = len(arrays)
@@ -59,9 +69,9 @@ def solve_corrections_sgd(offset_matrix, eta_initial=1, eta_half_life=100, rtol=
     ----------
     offset_matrix : `~numpy.ndarray`
         The NxN matrix giving the offsets between all images (or NaN if
-        an offset could not be determined)
+        an offset could not be determined).
     eta_initial : float
-        The initial learning rate to use
+        The initial learning rate to use.
     eta_half_life : float
         The number of iterations after which the learning rate should be
         decreased by a factor $e$.
@@ -71,6 +81,11 @@ def solve_corrections_sgd(offset_matrix, eta_initial=1, eta_half_life=100, rtol=
     atol : float
         The absolute tolerance to use to determine if the corrections have
         converged.
+
+    Returns
+    -------
+    `numpy.ndarray`
+        The corrections for each frame.
     """
 
     if offset_matrix.ndim != 2 or offset_matrix.shape[0] != offset_matrix.shape[1]:

--- a/reproject/mosaicking/coadd.py
+++ b/reproject/mosaicking/coadd.py
@@ -17,8 +17,8 @@ def reproject_and_coadd(
     shape_out=None,
     input_weights=None,
     hdu_in=None,
-    reproject_function=None,
     hdu_weights=None,
+    reproject_function=None,
     combine_function="mean",
     match_background=False,
     background_reference=None,
@@ -74,7 +74,7 @@ def reproject_and_coadd(
         If one or more items in ``input_weights`` is a FITS file or an
         `~astropy.io.fits.HDUList` instance, specifies the HDU to use.
     reproject_function : callable
-        The function to use for the reprojection
+        The function to use for the reprojection.
     combine_function : { 'mean', 'sum', 'median', 'first', 'last', 'min', 'max' }
         The type of function to use for combining the values into the final
         image. For 'first' and 'last', respectively, the reprojected images are
@@ -95,8 +95,17 @@ def reproject_and_coadd(
         The final output footprint array.  Specify this if you already have an
         appropriately-shaped array to store the data in.  Must match shape
         specified with ``shape_out`` or derived from the output projection.
-    kwargs
+    **kwargs
         Keyword arguments to be passed to the reprojection function.
+
+    Returns
+    -------
+    array : `~numpy.ndarray`
+        The co-added array.
+    footprint : `~numpy.ndarray`
+        Footprint of the co-added array. Values of 0 indicate no coverage or
+        valid values in the input image, while values of 1 indicate valid
+        values.
     """
 
     # TODO: add support for saving intermediate files to disk to avoid blowing

--- a/reproject/mosaicking/subset_array.py
+++ b/reproject/mosaicking/subset_array.py
@@ -6,11 +6,9 @@ __all__ = ["ReprojectedArraySubset"]
 
 
 class ReprojectedArraySubset:
-    """
-    The aim of this class is to represent a subset of an array and
-    footprint extracted (or meant to represent extracted) versions
-    from larger arrays and footprints.
-    """
+    # The aim of this class is to represent a subset of an array and
+    # footprint extracted (or meant to represent extracted) versions
+    # from larger arrays and footprints.
 
     # NOTE: we can't use Cutout2D here because it's much more convenient
     # to work with position being the lower left corner of the cutout

--- a/reproject/mosaicking/wcs_helpers.py
+++ b/reproject/mosaicking/wcs_helpers.py
@@ -71,12 +71,12 @@ def find_optimal_celestial_wcs(
         instance, specifies the HDU to use.
     frame : str or `~astropy.coordinates.BaseCoordinateFrame`
         The coordinate system for the final image (defaults to the frame of
-        the first image specified)
+        the first image specified).
     auto_rotate : bool
         Whether to rotate the header to minimize the final image area (if
-        `True`, requires shapely>=1.6 to be installed)
+        `True`, requires shapely>=1.6 to be installed).
     projection : str
-        Three-letter code for the WCS projection
+        Three-letter code for the WCS projection.
     resolution : `~astropy.units.Quantity`
         The resolution of the final image. If not specified, this is the
         smallest resolution of the input images.

--- a/reproject/spherical_intersect/high_level.py
+++ b/reproject/spherical_intersect/high_level.py
@@ -14,8 +14,8 @@ def reproject_exact(
     shape_out=None,
     hdu_in=0,
     output_array=None,
-    return_footprint=True,
     output_footprint=None,
+    return_footprint=True,
     block_size=None,
     parallel=False,
     return_type=None,
@@ -26,7 +26,7 @@ def reproject_exact(
 
     Parameters
     ----------
-    input_data
+    input_data : object
         The input data to reproject. This can be:
 
             * The name of a FITS file as a `str` or a `pathlib.Path` object
@@ -57,19 +57,37 @@ def reproject_exact(
     hdu_in : int or str, optional
         If ``input_data`` is a FITS file or an `~astropy.io.fits.HDUList`
         instance, specifies the HDU to use.
-    parallel : bool or int
-        Flag for parallel implementation. If ``True``, a parallel implementation
-        is chosen, the number of processes selected automatically to be equal to
-        the number of logical CPUs detected on the machine. If ``False``, a
-        serial implementation is chosen. If the flag is a positive integer ``n``
-        greater than one, a parallel implementation using ``n`` processes is chosen.
+    output_array : None or `~numpy.ndarray`
+        An array in which to store the reprojected data.  This can be any numpy
+        array including a memory map, which may be helpful when dealing with
+        extremely large files.
+    output_footprint : `~numpy.ndarray`, optional
+        An array in which to store the footprint of reprojected data.  This can be
+        any numpy array including a memory map, which may be helpful when dealing with
+        extremely large files.
     return_footprint : bool
         Whether to return the footprint in addition to the output array.
+    block_size : tuple or 'auto', optional
+        The size of blocks in terms of output array pixels that each block will handle
+        reprojecting. Extending out from (0,0) coords positively, block sizes
+        are clamped to output space edges when a block would extend past edge.
+        Specifying ``'auto'`` means that reprojection will be done in blocks with
+        the block size automatically determined. If ``block_size`` is not
+        specified or set to `None`, the reprojection will not be carried out in
+        blocks.
+    parallel : bool or int, optional
+        If `True`, the reprojection is carried out in parallel, and if a
+        positive integer, this specifies the number of processes to use.
+        The reprojection will be parallelized over output array blocks specified
+        by ``block_size`` (if the block size is not set, it will be determined
+        automatically).
+    return_type : {'numpy', 'dask'}, optional
+        Whether to return numpy or dask arrays - defaults to 'numpy'.
 
     Returns
     -------
     array_new : `~numpy.ndarray`
-        The reprojected array
+        The reprojected array.
     footprint : `~numpy.ndarray`
         Footprint of the input array in the output array. Values of 0 indicate
         no coverage or valid values in the input image, while values of 1


### PR DESCRIPTION
This enables the [numpydoc pre-commit hook](https://numpydoc.readthedocs.io/en/latest/validation.html) and fixes issues found as a result.

I've also added the ability to specify ``block_size='auto'`` so that users can opt in to blocked reprojection without having to specify an actual block size or setting ``parallel=True``.