### PR TITLE
Add testing on Python 3.12

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -18,16 +18,19 @@ jobs:
         - macos: py39-test
         - macos: py310-test
         - macos: py311-test
+        - macos: py312-test
         - linux: py38-test-oldestdeps
         - linux: py38-test
         - linux: py39-test
         - linux: py310-test
         - linux: py311-test
-        - linux: py311-test-devdeps
+        - linux: py312-test
+        - linux: py312-test-devdeps
         - windows: py38-test-oldestdeps
         - windows: py39-test
         - windows: py310-test
         - windows: py311-test
+        - windows: py312-test
       libraries: |
         apt:
           - libopenblas-dev

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = ["setuptools",
             "wheel",
             "extension-helpers",
             "oldest-supported-numpy",
-            "cython==3.0.2"]
+            "cython==3.0.4"]
 build-backend = 'setuptools.build_meta'
 
 [tool.setuptools_scm]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{38,39,310,311}-{test}{-oldestdeps,-numpy121}
+    py{38,39,310,311,312}-{test}{-oldestdeps,-numpy121}
     build_docs
     codestyle
 isolated_build = True


### PR DESCRIPTION
I can get this building locally fine on Python 3.12 (using `python -m build`), but can reproduce the tox failure. so I think the issue must be somehow `tox` is installing a different and older version of `Cython` when trying to build `reproject`. I'm a bit lost on how to debug that though...

Update: if I remove `aiohttp` from the deps (that is also trying and failing to build a wheel due to Cython issues) this works fine. So I guess there's some dogy Cython version interaction going on somewhere... I think the answer here is to wait for `aiohttp` to get a new version out with 3.12 support and hopefully this will Just Work ™️ after that.