### PR TITLE
Add testing on Python 3.12

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -18,16 +18,19 @@ jobs:
         - macos: py39-test
         - macos: py310-test
         - macos: py311-test
+        - macos: py312-test
         - linux: py38-test-oldestdeps
         - linux: py38-test
         - linux: py39-test
         - linux: py310-test
         - linux: py311-test
-        - linux: py311-test-devdeps
+        - linux: py312-test
+        - linux: py312-test-devdeps
         - windows: py38-test-oldestdeps
         - windows: py39-test
         - windows: py310-test
         - windows: py311-test
+        - windows: py312-test
       libraries: |
         apt:
           - libopenblas-dev

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = ["setuptools",
             "wheel",
             "extension-helpers",
             "oldest-supported-numpy",
-            "cython==3.0.2"]
+            "cython==3.0.4"]
 build-backend = 'setuptools.build_meta'
 
 [tool.setuptools_scm]

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,7 @@ setenv =
     MPLBACKEND = Agg
     PYTEST_COMMAND = pytest --arraydiff --arraydiff-default-format=fits --pyargs reproject --cov reproject --cov-config={toxinidir}/setup.cfg {toxinidir}/docs --remote-data
     devdeps: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/astropy/simple https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
+    py312: PIP_PRE=1
 changedir =
     .tmp/{envname}
 deps =
@@ -33,6 +34,7 @@ deps =
     devdeps: git+https://github.com/astropy/asdf-astropy.git
     devdeps: git+https://github.com/spacetelescope/gwcs.git#egg=gwcs
     #devdeps: git+https://github.com/sunpy/sunpy.git#egg=sunpy
+
 extras =
     test
     # Don't run the more complex tests on oldestdeps because it pulls in a nest

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{38,39,310,311}-{test}{-oldestdeps,-numpy121}
+    py{38,39,310,311,312}-{test}{-oldestdeps,-numpy121}
     build_docs
     codestyle
 isolated_build = True


### PR DESCRIPTION
Re-opened #399 

I added a commit to use pre-releases on Python 3.12 to pick up an aiohttp pre-release