### PR TITLE
Ensure reproject_and_coadd handles bg-matching with one input image

### DIFF
--- a/reproject/mosaicking/coadd.py
+++ b/reproject/mosaicking/coadd.py
@@ -243,7 +243,7 @@ def reproject_and_coadd(
         arrays.append(array)
 
     # If requested, try and match the backgrounds.
-    if match_background:
+    if match_background and len(arrays) > 1:
         offset_matrix = determine_offset_matrix(arrays)
         corrections = solve_corrections_sgd(offset_matrix)
         if background_reference:

--- a/reproject/mosaicking/tests/test_coadd.py
+++ b/reproject/mosaicking/tests/test_coadd.py
@@ -210,6 +210,32 @@ class TestReprojectAndCoAdd:
 
         assert_allclose(array - np.mean(array), self.array - np.mean(self.array), atol=ATOL)
 
+    def test_coadd_background_matching_one_array(self, reproject_function):
+        # Test that background matching doesn't affect the output when there's
+        # only one input image.
+
+        input_data = [(self.array, self.wcs)]
+
+        array_matched, footprint_matched = reproject_and_coadd(
+            input_data,
+            self.wcs,
+            shape_out=self.array.shape,
+            combine_function="mean",
+            reproject_function=reproject_function,
+            match_background=True,
+        )
+
+        array, footprint = reproject_and_coadd(
+            input_data,
+            self.wcs,
+            shape_out=self.array.shape,
+            combine_function="mean",
+            reproject_function=reproject_function,
+            match_background=False,
+        )
+        np.testing.assert_allclose(array, array_matched)
+        np.testing.assert_allclose(footprint, footprint_matched)
+
     def test_coadd_background_matching_with_nan(self, reproject_function):
         # Test out the background matching when NaN values are present. We do
         # this by using three arrays with the same footprint but with different


### PR DESCRIPTION
I'm using `reproject_and_coadd` in a  loop---in some iterations, there's only one input image (while in others, there are multiple). When I set `match_background=True`, I get some warnings and the whole output image is `nan`. Maybe this indicates a deeper problem in the background-matching code, but as a workaround, we can just not do the bg-matching if there's only a single input image, to work around this bug and avoid some extra work.

```python
import numpy as np
import reproject
import reproject.mosaicking
import matplotlib.pyplot as plt
from astropy.wcs import WCS

data = np.ones((100, 100))
data[::5] = 2
wcs_in = WCS(naxis=2)
wcs_in.wcs.ctype = 'RA---TAN', 'DEC--TAN'
wcs_in.wcs.crpix = 50, 50
wcs_in.wcs.crval = 0, 0
wcs_in.wcs.cdelt = .1, .1

wcs_out = wcs_in.deepcopy()

reprojected, footprint = reproject.mosaicking.reproject_and_coadd(
    [(data, wcs_in)], wcs_out, data.shape,
    reproject_function=reproject.reproject_adaptive, match_background=True)
```

```python
/home/svankooten/.anaconda/envs/sunpy-dev/lib/python3.11/site-packages/numpy/core/fromnumeric.py:3464: RuntimeWarning: Mean of empty slice.
  return _methods._mean(a, axis=axis, dtype=dtype,
/home/svankooten/.anaconda/envs/sunpy-dev/lib/python3.11/site-packages/numpy/core/_methods.py:192: RuntimeWarning: invalid value encountered in scalar divide
  ret = ret.dtype.type(ret / rcount)
/home/svankooten/Documents/Research/reproject_dev/reproject/reproject/mosaicking/background.py:132: RuntimeWarning: Mean of empty slice
  corrections -= np.nanmean(corrections)
```

```python
np.all(np.isnan(reprojected)) # Output: True
```