### PR TITLE
Fix 426: add blank_pixel_value keyword

### DIFF
--- a/reproject/mosaicking/coadd.py
+++ b/reproject/mosaicking/coadd.py
@@ -24,6 +24,7 @@ def reproject_and_coadd(
     background_reference=None,
     output_array=None,
     output_footprint=None,
+    blank_pixel_value=np.nan,
     **kwargs,
 ):
     """
@@ -276,7 +277,7 @@ def reproject_and_coadd(
         if combine_function == "mean":
             with np.errstate(invalid="ignore"):
                 output_array /= output_footprint
-                output_array[output_footprint == 0] = 0
+                output_array[output_footprint == 0] = blank_pixel_value
 
     elif combine_function in ("first", "last", "min", "max"):
         for array in arrays:
@@ -306,7 +307,6 @@ def reproject_and_coadd(
 
         raise NotImplementedError("combine_function='median' is not yet implemented")
 
-    if combine_function in ("min", "max"):
-        output_array[output_footprint == 0] = 0.0
+    output_array[output_footprint == 0] = blank_pixel_value
 
     return output_array, output_footprint


### PR DESCRIPTION
This adds a `blank_pixel_value` keyword that defaults to `nan` and applies to all combination modes in the coadd/mosaicking step.