### PR TITLE
Fix multi-threaded reprojection when using Astropy WCS

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,9 +32,7 @@ test = [
 ]
 testall = [
     "shapely>=2.0.2",  # 2.0.2 fixed a bug that causes changes in test results
-    # Once a release of reproject is done for Python 3.12,
-    # can remove python_version specifier here
-    'sunpy[map]>=2.1;python_version<"3.12" and platform_machine!="i686"',
+    "sunpy[map]>=2.1",
     "asdf",
     "gwcs",
     "pyvo",

--- a/reproject/common.py
+++ b/reproject/common.py
@@ -1,11 +1,11 @@
 import os
 import tempfile
 import uuid
-from copy import deepcopy
 
 import dask
 import dask.array as da
 import numpy as np
+from astropy.wcs import WCS
 from astropy.wcs.wcsapi import BaseHighLevelWCS, SlicedLowLevelWCS
 from astropy.wcs.wcsapi.high_level_wcs_wrapper import HighLevelWCSWrapper
 from dask import delayed
@@ -194,12 +194,11 @@ def _reproject_dispatcher(
             # https://github.com/astropy/astropy/issues/16245
             # To work around these issues, we make sure we do a deep copy of
             # the WCS object in here when using FITS WCS. This is a very fast
-            # operation (<1ms) so should not be a concern in terms of
-            # performance. For safety, we do this for all WCS objects even if
-            # they are not FITS WCS.
+            # operation (<0.1ms) so should not be a concern in terms of
+            # performance. We only need to do this for FITS WCS.
 
-            wcs_in_cp = deepcopy(wcs_in)
-            wcs_out_cp = deepcopy(wcs_out)
+            wcs_in_cp = wcs_in.deepcopy() if isinstance(wcs_in, WCS) else wcs_in
+            wcs_out_cp = wcs_out.deepcopy() if isinstance(wcs_out, WCS) else wcs_out
 
             slices = [
                 slice(*x) for x in block_info[None]["array-location"][-wcs_out_cp.pixel_n_dim :]

--- a/reproject/common.py
+++ b/reproject/common.py
@@ -187,12 +187,16 @@ def _reproject_dispatcher(
         def reproject_single_block(a, array_or_path, block_info=None):
             if a.ndim == 0 or block_info is None or block_info == []:
                 return np.array([a, a])
-            slices = [slice(*x) for x in block_info[None]["array-location"][-wcs_out.pixel_n_dim :]]
+
+            wcs_in_cp = wcs_in.deepcopy()
+            wcs_out_cp = wcs_out.deepcopy()
+
+            slices = [slice(*x) for x in block_info[None]["array-location"][-wcs_out_cp.pixel_n_dim :]]
 
             if isinstance(wcs_out, BaseHighLevelWCS):
-                low_level_wcs = SlicedLowLevelWCS(wcs_out.low_level_wcs, slices=slices)
+                low_level_wcs = SlicedLowLevelWCS(wcs_out_cp.low_level_wcs, slices=slices)
             else:
-                low_level_wcs = SlicedLowLevelWCS(wcs_out, slices=slices)
+                low_level_wcs = SlicedLowLevelWCS(wcs_out_cp, slices=slices)
 
             wcs_out_sub = HighLevelWCSWrapper(low_level_wcs)
 
@@ -208,7 +212,7 @@ def _reproject_dispatcher(
 
             array, footprint = reproject_func(
                 array_in,
-                wcs_in,
+                wcs_in_cp,
                 wcs_out_sub,
                 shape_out=shape_out,
                 array_out=np.zeros(shape_out),

--- a/reproject/common.py
+++ b/reproject/common.py
@@ -1,6 +1,7 @@
 import os
 import tempfile
 import uuid
+from copy import deepcopy
 
 import dask
 import dask.array as da
@@ -193,12 +194,12 @@ def _reproject_dispatcher(
             # https://github.com/astropy/astropy/issues/16245
             # To work around these issues, we make sure we do a deep copy of
             # the WCS object in here when using FITS WCS. This is a very fast
-            # operation (<0.1ms) so should not be a concern in terms of
-            # performance. However we don't deep copy *all* WCSes because
-            # the APE-14 API does not mandate the existence of the .deepcopy()
-            # method, and because it should not be necessary for all WCSes.
-            wcs_in_cp = wcs_in.deepcopy() if isinstance(wcs_in, WCS) else wcs_in
-            wcs_out_cp = wcs_out.deepcopy() if isinstance(wcs_out, WCS) else wcs_out
+            # operation (<1ms) so should not be a concern in terms of
+            # performance. For safety, we do this for all WCS objects even if
+            # they are not FITS WCS.
+
+            wcs_in_cp = deepcopy(wcs_in)
+            wcs_out_cp = deepcopy(wcs_out)
 
             slices = [
                 slice(*x) for x in block_info[None]["array-location"][-wcs_out_cp.pixel_n_dim :]

--- a/reproject/tests/test_high_level.py
+++ b/reproject/tests/test_high_level.py
@@ -279,6 +279,7 @@ def test_dask_schedulers(reproject_function, scheduler, wcs_type):
         wcs_out = WCS(hdu_out.header)
         shape_out = hdu_out.data.shape
     elif wcs_type == "gwcs":
+        pytest.importorskip("sunpy", minversion="2.1.0")
         asdf = pytest.importorskip("asdf")
         if reproject_function == reproject_exact:
             pytest.skip()

--- a/reproject/tests/test_high_level.py
+++ b/reproject/tests/test_high_level.py
@@ -270,7 +270,9 @@ def test_dask_schedulers(reproject_function, scheduler):
 
     array1 = reproject_function(hdu1, hdu2.header, return_footprint=False)
 
-    array2 = reproject_function(hdu1, hdu2.header, return_footprint=False, return_type="dask", block_size=(100, 100))
+    array2 = reproject_function(
+        hdu1, hdu2.header, return_footprint=False, return_type="dask", block_size=(100, 100)
+    )
     array2 = array2.compute(scheduler=scheduler)
 
     np.testing.assert_allclose(array1, array2, equal_nan=True)


### PR DESCRIPTION
To run just the relevant test:

```
tox -e test -- -k "test_dask_scheduler"
```

This currently shows three test failures:

```
FAILED ../../.tox/test/lib/python3.11/site-packages/reproject/tests/test_high_level.py::test_dask_schedulers[threads-reproject_interp] - AssertionError: 
FAILED ../../.tox/test/lib/python3.11/site-packages/reproject/tests/test_high_level.py::test_dask_schedulers[threads-reproject_adaptive] - AssertionError: 
FAILED ../../.tox/test/lib/python3.11/site-packages/reproject/tests/test_high_level.py::test_dask_schedulers[threads-reproject_exact] - AssertionError: 
```

To run just one of the parameter combinations of the test, one can do e.g.:

```
tox -e test -- -k "test_dask_sched and interp and threads"
```
