### PR TITLE
Build against Numpy 2.0.0rc1 or later

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -46,14 +46,11 @@ jobs:
         - cp*-macosx_arm64
         - cp*-win_amd64
 
-      # Developer wheels (use Numpy dev to build)
+      # Developer wheels
       upload_to_anaconda: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}
       anaconda_user: astropy
       anaconda_package: reproject
       anaconda_keep_n_latest: 10
-      env: |
-        CIBW_BEFORE_BUILD: '${{ ((github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request') && 'pip install --pre --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple setuptools setuptools_scm numpy>=0.0dev0 extension-helpers cython') || '' }}'
-        CIBW_BUILD_FRONTEND: '${{ ((github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request') && 'pip; args: --no-build-isolation') || 'build' }}'
 
     secrets:
       pypi_token: ${{ secrets.pypi_token }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ docs = [
 requires = ["setuptools",
             "setuptools_scm",
             "extension-helpers==1.*",
-            "numpy>=1.25",
+            "numpy>=2.0.0rc1",
             "cython>=3.0,<3.1"]
 build-backend = 'setuptools.build_meta'
 


### PR DESCRIPTION
We need to release new wheels of reproject compiled against Numpy 2.0.0rc1 ahead of the final Numpy 2.0.0 release, so this PR updates the build-time dependencies and also simplifies the nightly wheels configuration.