### PR TITLE
Improve performance for large datasets and switch to multi-threading by default

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -138,6 +138,7 @@ that you want to reproject.
    footprints
    mosaicking
    performance
+   performance_mosaicking
 
 Reference/API
 =============

--- a/docs/performance_mosaicking.rst
+++ b/docs/performance_mosaicking.rst
@@ -1,0 +1,50 @@
+*************************************
+Optimizing performance for mosaicking
+*************************************
+
+Using memory-mapped output arrays
+=================================
+
+If you are producing a large mosaic, you may be want to write the mosaic and
+footprint to an array of your choice, such as for example a memory-mapped array.
+For example:
+
+.. doctest-skip::
+
+    >>> output_array = np.memmap(filename='array.np', mode='w+',
+    ...                          shape=shape_out, dtype='float32')
+    >>> output_footprint = np.memmap(filename='footprint.np', mode='w+',
+    ...                              shape=shape_out, dtype='float32')
+    >>> reproject_and_coadd(...,
+                            output_array=output_array,
+                            output_footprint=output_footprint)
+
+Using memory-mapped intermediate arrays
+=======================================
+
+During the mosaicking process, each cube is reprojected to the minimal subset of
+the final header that it covers. In some cases, this can result in arrays that
+may not fit in memory. In this case, you can use the ``intermediate_memmap``
+option to indicate that all intermediate arrays in the mosaicking process should
+use memory-mapped arrays rather than in-memory arrays:
+
+    >>> reproject_and_coadd(...,
+                            intermediate_memmap=True)
+
+Combined with the above option to specify the output array and footprint for the
+final mosaic, it is possible to make sure that no large arrays are ever loaded
+into memory. Note however that you will need to make sure you have sufficient disk
+space in your temporary directory. If your default system temporary directory does
+not have sufficient space, you can set the ``TMPDIR`` environment variable to point
+at another directory:
+
+    >>> import os
+    >>> os.environ['TMPDIR'] = '/home/lancelot/tmp'
+
+Multi-threading
+===============
+
+Similarly to single-image reprojection (see :ref:`multithreading`), it is possible
+to make use of multi-threading during the mosaicking process by setting the
+``parallel=`` option to True or to an integer value to indicate the number of
+threads to use.

--- a/docs/performance_mosaicking.rst
+++ b/docs/performance_mosaicking.rst
@@ -16,8 +16,8 @@ For example:
     >>> output_footprint = np.memmap(filename='footprint.np', mode='w+',
     ...                              shape=shape_out, dtype='float32')
     >>> reproject_and_coadd(...,
-                            output_array=output_array,
-                            output_footprint=output_footprint)
+    ...                     output_array=output_array,
+    ...                     output_footprint=output_footprint)
 
 Using memory-mapped intermediate arrays
 =======================================
@@ -28,8 +28,10 @@ may not fit in memory. In this case, you can use the ``intermediate_memmap``
 option to indicate that all intermediate arrays in the mosaicking process should
 use memory-mapped arrays rather than in-memory arrays:
 
+.. doctest-skip::
+
     >>> reproject_and_coadd(...,
-                            intermediate_memmap=True)
+    ...                     intermediate_memmap=True)
 
 Combined with the above option to specify the output array and footprint for the
 final mosaic, it is possible to make sure that no large arrays are ever loaded

--- a/reproject/array_utils.py
+++ b/reproject/array_utils.py
@@ -3,7 +3,90 @@ import numpy as np
 __all__ = ["map_coordinates", "sample_array_edges"]
 
 
-def map_coordinates(image, coords, **kwargs):
+def find_chunk_shape(shape, max_chunk_size=None):
+    """
+    Given the shape of an n-dimensional array, and the maximum number of
+    elements in a chunk, return the largest chunk shape to use for iteration.
+
+    This currently assumes the optimal chunk shape to return is for C-contiguous
+    arrays.
+
+    Parameters
+    ----------
+    shape : iterable
+        The shape of the n-dimensional array.
+    max_chunk_size : int, optional
+        The maximum number of elements per chunk.
+    """
+
+    if max_chunk_size is None:
+        return tuple(shape)
+
+    block_shape = []
+
+    max_repeat_remaining = max_chunk_size
+
+    for size in shape[::-1]:
+
+        if max_repeat_remaining > size:
+            block_shape.append(size)
+            max_repeat_remaining = max_repeat_remaining // size
+        else:
+            block_shape.append(max_repeat_remaining)
+            max_repeat_remaining = 1
+
+    return tuple(block_shape[::-1])
+
+
+def iterate_chunks(shape, max_chunk_size):
+    """
+    Given a data shape and a chunk shape (or maximum chunk size), iteratively
+    return slice objects that can be used to slice the array.
+
+    Parameters
+    ----------
+    shape : iterable
+        The shape of the n-dimensional array.
+    max_chunk_size : int
+        The maximum number of elements per chunk.
+    """
+
+    if np.prod(shape) == 0:
+        return
+
+    chunk_shape = find_chunk_shape(shape, max_chunk_size)
+
+    ndim = len(chunk_shape)
+    start_index = [0] * ndim
+
+    shape = list(shape)
+
+    while start_index <= shape:
+
+        end_index = [min(start_index[i] + chunk_shape[i], shape[i]) for i in range(ndim)]
+
+        slices = tuple([slice(start_index[i], end_index[i]) for i in range(ndim)])
+
+        yield slices
+
+        # Update chunk index. What we do is to increment the
+        # counter for the first dimension, and then if it
+        # exceeds the number of elements in that direction,
+        # cycle back to zero and advance in the next dimension,
+        # and so on.
+        start_index[0] += chunk_shape[0]
+        for i in range(ndim - 1):
+            if start_index[i] >= shape[i]:
+                start_index[i] = 0
+                start_index[i + 1] += chunk_shape[i + 1]
+
+        # We can now check whether the iteration is finished
+        if start_index[-1] >= shape[-1]:
+            break
+
+
+def map_coordinates(image, coords, max_chunk_size=None, output=None, **kwargs):
+
     # In the built-in scipy map_coordinates, the values are defined at the
     # center of the pixels. This means that map_coordinates does not
     # correctly treat pixels that are in the outer half of the outer pixels.
@@ -12,11 +95,21 @@ def map_coordinates(image, coords, **kwargs):
     # instead pad the array but this was not memory efficient as it ended up
     # producing a copy of the output array.
 
+    # In addition, map_coordinates is not efficient when given big-endian Numpy
+    # arrays as it will then make a copy, which is an issue when dealing with
+    # memory-mapped FITS files that might be larger than memory. Therefore, for
+    # big-endian arrays, we operate in chunks with a size smaller or equal to
+    # max_chunk_size.
+
+    # TODO: check how this should behave on a big-endian system.
+
     from scipy.ndimage import map_coordinates as scipy_map_coordinates
 
     original_shape = image.shape
 
-    # We copy the coordinates array as we then modify it in-place below
+    # We copy the coordinates array as we then modify it in-place below to clip
+    # to the edges of the array.
+
     coords = coords.copy()
     for i in range(coords.shape[0]):
         coords[i][(coords[i] < 0) & (coords[i] >= -0.5)] = 0
@@ -24,7 +117,42 @@ def map_coordinates(image, coords, **kwargs):
             original_shape[i] - 1
         )
 
-    values = scipy_map_coordinates(image, coords, **kwargs)
+    if image.dtype.isnative:
+
+        values = scipy_map_coordinates(image, coords, prefilter=False, output=output, **kwargs)
+
+    else:
+
+        if output is None:
+            output = np.repeat(np.nan, coords.shape[1])
+
+        values = output
+
+        for chunk in iterate_chunks(image.shape, max_chunk_size):
+
+            include = np.ones(coords.shape[1], dtype=bool)
+
+            for idim, slc in enumerate(chunk):
+                include[(coords[idim] < slc.start) | (coords[idim] >= slc.stop)] = False
+
+            if not np.any(include):
+                continue
+
+            chunk = list(chunk)
+
+            # Adjust chunks to add padding
+            for idim, slc in enumerate(chunk):
+                start = max(0, slc.start - 10)
+                stop = min(original_shape[i], slc.stop + 10)
+                chunk[idim] = slice(start, stop)
+
+            chunk = tuple(chunk)
+
+            coords_subset = coords[:, include].copy()
+            for idim, slc in enumerate(chunk):
+                coords_subset[idim, :] -= slc.start
+
+            output[include] = scipy_map_coordinates(image[chunk], coords_subset, **kwargs)
 
     reset = np.zeros(coords.shape[1], dtype=bool)
 

--- a/reproject/array_utils.py
+++ b/reproject/array_utils.py
@@ -27,7 +27,6 @@ def find_chunk_shape(shape, max_chunk_size=None):
     max_repeat_remaining = max_chunk_size
 
     for size in shape[::-1]:
-
         if max_repeat_remaining > size:
             block_shape.append(size)
             max_repeat_remaining = max_repeat_remaining // size
@@ -38,7 +37,7 @@ def find_chunk_shape(shape, max_chunk_size=None):
     return tuple(block_shape[::-1])
 
 
-def iterate_chunks(shape, max_chunk_size):
+def iterate_chunks(shape, *, max_chunk_size):
     """
     Given a data shape and a chunk shape (or maximum chunk size), iteratively
     return slice objects that can be used to slice the array.
@@ -62,7 +61,6 @@ def iterate_chunks(shape, max_chunk_size):
     shape = list(shape)
 
     while start_index <= shape:
-
         end_index = [min(start_index[i] + chunk_shape[i], shape[i]) for i in range(ndim)]
 
         slices = tuple([slice(start_index[i], end_index[i]) for i in range(ndim)])
@@ -86,7 +84,6 @@ def iterate_chunks(shape, max_chunk_size):
 
 
 def map_coordinates(image, coords, max_chunk_size=None, output=None, **kwargs):
-
     # In the built-in scipy map_coordinates, the values are defined at the
     # center of the pixels. This means that map_coordinates does not
     # correctly treat pixels that are in the outer half of the outer pixels.
@@ -118,18 +115,15 @@ def map_coordinates(image, coords, max_chunk_size=None, output=None, **kwargs):
         )
 
     if image.dtype.isnative:
-
         values = scipy_map_coordinates(image, coords, prefilter=False, output=output, **kwargs)
 
     else:
-
         if output is None:
             output = np.repeat(np.nan, coords.shape[1])
 
         values = output
 
-        for chunk in iterate_chunks(image.shape, max_chunk_size):
-
+        for chunk in iterate_chunks(image.shape, max_chunk_size=max_chunk_size):
             include = np.ones(coords.shape[1], dtype=bool)
 
             for idim, slc in enumerate(chunk):

--- a/reproject/array_utils.py
+++ b/reproject/array_utils.py
@@ -121,11 +121,11 @@ def map_coordinates(image, coords, max_chunk_size=None, output=None, **kwargs):
             original_shape[i] - 1
         )
 
-    if image.dtype.isnative:
-        values = scipy_map_coordinates(
-            at_least_float32(image), coords, prefilter=False, output=output, **kwargs
-        )
-
+    # If the data type is native and we are not doing spline interpolation,
+    # then scipy_map_coordinates deals properly with memory maps, so we can use
+    # it without chunking. Otherwise, we need to iterate over data chunks.
+    if image.dtype.isnative and kwargs["order"] <= 1:
+        values = scipy_map_coordinates(at_least_float32(image), coords, output=output, **kwargs)
     else:
         if output is None:
             output = np.repeat(np.nan, coords.shape[1])

--- a/reproject/array_utils.py
+++ b/reproject/array_utils.py
@@ -146,7 +146,7 @@ def map_coordinates(image, coords, max_chunk_size=None, output=None, **kwargs):
             # Adjust chunks to add padding
             for idim, slc in enumerate(chunk):
                 start = max(0, slc.start - 10)
-                stop = min(original_shape[i], slc.stop + 10)
+                stop = min(original_shape[idim], slc.stop + 10)
                 chunk[idim] = slice(start, stop)
 
             chunk = tuple(chunk)

--- a/reproject/array_utils.py
+++ b/reproject/array_utils.py
@@ -83,6 +83,13 @@ def iterate_chunks(shape, *, max_chunk_size):
             break
 
 
+def at_least_float32(array):
+    if array.dtype.kind == "f" and array.dtype.itemsize >= 4:
+        return array
+    else:
+        return array.astype(np.float32)
+
+
 def map_coordinates(image, coords, max_chunk_size=None, output=None, **kwargs):
     # In the built-in scipy map_coordinates, the values are defined at the
     # center of the pixels. This means that map_coordinates does not
@@ -115,7 +122,9 @@ def map_coordinates(image, coords, max_chunk_size=None, output=None, **kwargs):
         )
 
     if image.dtype.isnative:
-        values = scipy_map_coordinates(image, coords, prefilter=False, output=output, **kwargs)
+        values = scipy_map_coordinates(
+            at_least_float32(image), coords, prefilter=False, output=output, **kwargs
+        )
 
     else:
         if output is None:
@@ -146,7 +155,9 @@ def map_coordinates(image, coords, max_chunk_size=None, output=None, **kwargs):
             for idim, slc in enumerate(chunk):
                 coords_subset[idim, :] -= slc.start
 
-            output[include] = scipy_map_coordinates(image[chunk], coords_subset, **kwargs)
+            output[include] = scipy_map_coordinates(
+                at_least_float32(image[chunk]), coords_subset, **kwargs
+            )
 
     reset = np.zeros(coords.shape[1], dtype=bool)
 

--- a/reproject/common.py
+++ b/reproject/common.py
@@ -251,7 +251,7 @@ def _reproject_dispatcher(
             else:
                 rechunk_kwargs = {}
             array_out_dask = da.empty(shape_out)
-            array_out_dask = array_out_dask.rechunk(block_size_limit=8 * 1024**2, **rechunk_kwargs)
+            array_out_dask = array_out_dask.rechunk(block_size_limit=64 * 1024**2, **rechunk_kwargs)
 
         result = da.map_blocks(
             reproject_single_block,

--- a/reproject/interpolation/core.py
+++ b/reproject/interpolation/core.py
@@ -71,8 +71,7 @@ def _reproject_full(
     the same coordinate information. The transformation is computed once and
     "broadcast" across those images.
     """
-    # Make sure image is floating point
-    array = np.asarray(array, dtype=float)
+
     # shape_out must be exactly a tuple type
     shape_out = tuple(shape_out)
     _validate_wcs(wcs_in, wcs_out, array.shape, shape_out)

--- a/reproject/interpolation/core.py
+++ b/reproject/interpolation/core.py
@@ -125,6 +125,7 @@ def _reproject_full(
             cval=np.nan,
             mode="constant",
             output=array_out_loopable[i].ravel(),
+            max_chunk_size=256 * 1024**2,
         )
 
     # n.b. We write the reprojected data into array_out_loopable, but array_out

--- a/reproject/mosaicking/coadd.py
+++ b/reproject/mosaicking/coadd.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 from astropy.wcs import WCS
+from astropy.wcs.utils import pixel_to_pixel
 from astropy.wcs.wcsapi import SlicedLowLevelWCS
 
 from ..array_utils import sample_array_edges
@@ -200,7 +201,7 @@ def reproject_and_coadd(
         # which provides a lot of redundant information.
 
         edges = sample_array_edges(array_in.shape, n_samples=11)[::-1]
-        edges_out = wcs_out.world_to_pixel(wcs_in.pixel_to_world(*edges))[::-1]
+        edges_out = pixel_to_pixel(wcs_in, wcs_out, *edges)[::-1]
 
         # Determine the cutout parameters
 
@@ -312,7 +313,6 @@ def reproject_and_coadd(
         if combine_function == "mean":
             with np.errstate(invalid="ignore"):
                 output_array /= output_footprint
-                output_array[output_footprint == 0] = blank_pixel_value
 
     elif combine_function in ("first", "last", "min", "max"):
         if combine_function == "min":

--- a/reproject/spherical_intersect/core.py
+++ b/reproject/spherical_intersect/core.py
@@ -148,7 +148,6 @@ def _reproject_celestial(
             array_new /= weights
 
         if broadcasting:
-            print(array_out.shape, array_new.shape)
             array_out[i] = array_new
             if return_footprint:
                 output_footprint[i] = weights

--- a/reproject/tests/test_array_utils.py
+++ b/reproject/tests/test_array_utils.py
@@ -36,7 +36,4 @@ def test_custom_map_coordinates():
         mode="constant",
     )
 
-    for i in range(coords.shape[1]):
-        print(coords[:, i], expected[i], result[i])
-
     assert_allclose(result, expected)

--- a/reproject/tests/test_utils.py
+++ b/reproject/tests/test_utils.py
@@ -7,7 +7,7 @@ from astropy.wcs import WCS
 from reproject.conftest import set_wcs_array_shape
 from reproject.tests.helpers import assert_wcs_allclose
 from reproject.utils import (
-    hdu_to_vanilla_memmap,
+    hdu_to_numpy_memmap,
     parse_input_data,
     parse_input_shape,
     parse_output_projection,
@@ -144,6 +144,6 @@ class TestHDUToMemmap:
         hdu = fits.CompImageHDU(data=np.random.random((128, 128)))
         hdu.writeto(tmp_path / "test.fits")
 
-        mmap = hdu_to_vanilla_memmap(hdu)
+        mmap = hdu_to_numpy_memmap(hdu)
 
         np.testing.assert_allclose(hdu.data, mmap)

--- a/reproject/tests/test_utils.py
+++ b/reproject/tests/test_utils.py
@@ -6,7 +6,12 @@ from astropy.wcs import WCS
 
 from reproject.conftest import set_wcs_array_shape
 from reproject.tests.helpers import assert_wcs_allclose
-from reproject.utils import parse_input_data, parse_input_shape, parse_output_projection
+from reproject.utils import (
+    hdu_to_vanilla_memmap,
+    parse_input_data,
+    parse_input_shape,
+    parse_output_projection,
+)
 from reproject.wcs_utils import has_celestial
 
 
@@ -130,3 +135,15 @@ def test_has_celestial():
 
     wwh2 = HighLevelWCSWrapper(SlicedLowLevelWCS(ww, [slice(0, 1), slice(0, 1)]))
     assert has_celestial(wwh2)
+
+
+class TestHDUToMemmap:
+
+    def test_compressed(self, tmp_path):
+
+        hdu = fits.CompImageHDU(data=np.random.random((128, 128)))
+        hdu.writeto(tmp_path / "test.fits")
+
+        mmap = hdu_to_vanilla_memmap(hdu)
+
+        np.testing.assert_allclose(hdu.data, mmap)

--- a/reproject/utils.py
+++ b/reproject/utils.py
@@ -68,7 +68,7 @@ def _dask_to_numpy_memmap(dask_array, tmp_dir):
     return memmap_path, memmapped_array
 
 
-def hdu_to_vanilla_memmap(hdu):
+def hdu_to_numpy_memmap(hdu):
     """
     Given an HDU object, return a regular Numpy memmap rather than a Numpy
     array backed by a memmapped buffer as returned by astropy.
@@ -111,7 +111,7 @@ def parse_input_data(input_data, hdu_in=None):
                 hdu_in = 0
         return parse_input_data(input_data[hdu_in])
     elif isinstance(input_data, PrimaryHDU | ImageHDU | CompImageHDU):
-        return hdu_to_vanilla_memmap(input_data), WCS(input_data.header)
+        return hdu_to_numpy_memmap(input_data), WCS(input_data.header)
     elif isinstance(input_data, tuple) and isinstance(input_data[0], np.ndarray | da.core.Array):
         if isinstance(input_data[1], Header):
             return input_data[0], WCS(input_data[1])

--- a/reproject/utils.py
+++ b/reproject/utils.py
@@ -74,13 +74,19 @@ def hdu_to_vanilla_memmap(hdu):
     array backed by a memmapped buffer as returned by astropy.
     """
 
-    if hdu.fileinfo() is None:
+    if (
+        "BSCALE" in hdu.header
+        or "BZERO" in hdu.header
+        or hdu.fileinfo() is None
+        or hdu._data_replaced
+        or hdu.fileinfo()["file"].compression is not None
+    ):
         return hdu.data
 
     return np.memmap(
         hdu.fileinfo()["file"].name,
         mode="r",
-        dtype=hdu.data.dtype,
+        dtype=hdu.data.dtype.newbyteorder(">"),
         shape=hdu.data.shape,
         offset=hdu.fileinfo()["datLoc"],
     )

--- a/reproject/utils.py
+++ b/reproject/utils.py
@@ -68,6 +68,20 @@ def _dask_to_numpy_memmap(dask_array, tmp_dir):
     return memmap_path, memmapped_array
 
 
+def hdu_to_vanilla_memmap(hdu):
+    """
+    Given an HDU object, return a regular Numpy memmap rather than a Numpy
+    array backed by a memmapped buffer as returned by astropy.
+    """
+    return np.memmap(
+        hdu.fileinfo()["file"].name,
+        mode="r",
+        dtype=hdu.data.dtype,
+        shape=hdu.data.shape,
+        offset=hdu.fileinfo()["datLoc"],
+    )
+
+
 def parse_input_data(input_data, hdu_in=None):
     """
     Parse input data to return a Numpy array and WCS object.
@@ -87,7 +101,7 @@ def parse_input_data(input_data, hdu_in=None):
                 hdu_in = 0
         return parse_input_data(input_data[hdu_in])
     elif isinstance(input_data, PrimaryHDU | ImageHDU | CompImageHDU):
-        return input_data.data, WCS(input_data.header)
+        return hdu_to_vanilla_memmap(input_data), WCS(input_data.header)
     elif isinstance(input_data, tuple) and isinstance(input_data[0], np.ndarray | da.core.Array):
         if isinstance(input_data[1], Header):
             return input_data[0], WCS(input_data[1])

--- a/reproject/utils.py
+++ b/reproject/utils.py
@@ -73,6 +73,10 @@ def hdu_to_vanilla_memmap(hdu):
     Given an HDU object, return a regular Numpy memmap rather than a Numpy
     array backed by a memmapped buffer as returned by astropy.
     """
+
+    if hdu.fileinfo() is None:
+        return hdu.data
+
     return np.memmap(
         hdu.fileinfo()["file"].name,
         mode="r",


### PR DESCRIPTION
This is a work in progress to address serious performance issues when reprojecting large datasets, mainly with ``reproject_interp``.

To do:

* [x] Add more robust checks for ``hdu_to_vanilla_memmap`` to make sure we handle the case where it might fail (e.g. for an in-memory HDU)
* [x] Document TMPDIR and ``intermediate_memmap``
* [ ] Write up recommendations for if someone wants to run using dask distributed with multi-processing

Fixes #393 
Fixes #394 
