### PR TITLE
Don't use --pre on Python 3.12

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,6 @@ setenv =
     MPLBACKEND = Agg
     PYTEST_COMMAND = pytest --arraydiff --arraydiff-default-format=fits --pyargs reproject --cov reproject --cov-config={toxinidir}/pyproject.toml {toxinidir}/docs --remote-data
     devdeps: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/liberfa/simple https://pypi.anaconda.org/astropy/simple https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
-    py312: PIP_PRE=1
 changedir =
     .tmp/{envname}
 deps =


### PR DESCRIPTION
Currently this was resulting in zarr 3.0.0a1 being pulled in which is broken (https://github.com/zarr-developers/zarr-python/issues/1965)