### PR TITLE
Performance improvements for interpolation with map_coordinates

### DIFF
--- a/reproject/array_utils.py
+++ b/reproject/array_utils.py
@@ -94,12 +94,13 @@ def memory_efficient_access(array, chunk):
     # If we access a number of chunks from a memory-mapped array, memory usage
     # will increase and could crash e.g. dask.distributed workers. We therefore
     # use a temporary memmap to load the data.
-    if isinstance(array, np.memmap):
+    if isinstance(array, np.memmap) and array.flags.c_contiguous:
         array_tmp = np.memmap(
             array.filename,
             mode="r",
             dtype=array.dtype,
             shape=array.shape,
+            offset=array.offset
         )
         return array_tmp[chunk]
     else:

--- a/reproject/array_utils.py
+++ b/reproject/array_utils.py
@@ -107,7 +107,9 @@ def memory_efficient_access(array, chunk):
         return array[chunk]
 
 
-def map_coordinates(image, coords, max_chunk_size=None, output=None, optimize_memory=False, **kwargs):
+def map_coordinates(
+    image, coords, max_chunk_size=None, output=None, optimize_memory=False, **kwargs
+):
     # In the built-in scipy map_coordinates, the values are defined at the
     # center of the pixels. This means that map_coordinates does not
     # correctly treat pixels that are in the outer half of the outer pixels.

--- a/reproject/array_utils.py
+++ b/reproject/array_utils.py
@@ -100,7 +100,7 @@ def memory_efficient_access(array, chunk):
             mode="r",
             dtype=array.dtype,
             shape=array.shape,
-            offset=array.offset
+            offset=array.offset,
         )
         return array_tmp[chunk]
     else:

--- a/reproject/array_utils.py
+++ b/reproject/array_utils.py
@@ -141,7 +141,7 @@ def map_coordinates(image, coords, max_chunk_size=None, output=None, **kwargs):
     # If the data type is native and we are not doing spline interpolation,
     # then scipy_map_coordinates deals properly with memory maps, so we can use
     # it without chunking. Otherwise, we need to iterate over data chunks.
-    if image.dtype.isnative and kwargs["order"] <= 1:
+    if image.dtype.isnative and "order" in kwargs and kwargs["order"] <= 1:
         values = scipy_map_coordinates(at_least_float32(image), coords, output=output, **kwargs)
     else:
         if output is None:
@@ -151,13 +151,12 @@ def map_coordinates(image, coords, max_chunk_size=None, output=None, **kwargs):
 
         include = np.ones(coords.shape[1], dtype=bool)
 
-        if kwargs["order"] <= 1:
+        if "order" in kwargs and kwargs["order"] <= 1:
             padding = 1
         else:
             padding = 10
 
         for chunk in iterate_chunks(image.shape, max_chunk_size=max_chunk_size):
-            include = np.ones(coords.shape[1], dtype=bool)
 
             include[...] = True
             for idim, slc in enumerate(chunk):


### PR DESCRIPTION
Split out from #447, this is needed to make workers not use up too much memory when using dask.distributed, but doesn't quite work yet as the memmap copying doesn't seem to always work (some tests failing)