### PR TITLE
Support readonly arrays in adaptive

### DIFF
--- a/reproject/adaptive/deforest.pyx
+++ b/reproject/adaptive/deforest.pyx
@@ -155,7 +155,7 @@ cdef double clip(double x, double vmin, double vmax, int cyclic,
 @cython.wraparound(False)
 @cython.nonecheck(False)
 @cython.cdivision(True)
-cdef bint sample_array(double[:,:,:] source, double[:] dest,
+cdef bint sample_array(const double[:,:,:] source, double[:] dest,
         double x, double y, int x_cyclic, int y_cyclic,
         bint out_of_range_nearest) noexcept nogil:
     x = clip(x, 0, source.shape[2] - 1, x_cyclic, out_of_range_nearest)
@@ -352,7 +352,7 @@ BAD_VALUE_MODES['ignore'] = 3
 @cython.wraparound(False)
 @cython.nonecheck(False)
 @cython.cdivision(True)
-def map_coordinates(double[:,:,:] source, double[:,:,:] target, Ci, int max_samples_width=-1,
+def map_coordinates(const double[:,:,:] source, double[:,:,:] target, Ci, int max_samples_width=-1,
                     int conserve_flux=False, int progress=False, int singularities_nan=False,
                     int x_cyclic=False, int y_cyclic=False, int out_of_range_nan=False,
                     bint center_jacobian=False, bint despiked_jacobian=False,

--- a/reproject/adaptive/tests/test_core.py
+++ b/reproject/adaptive/tests/test_core.py
@@ -1006,3 +1006,16 @@ def test_adaptive_input_output_types(
 
     assert_allclose(output_ref, output_test)
     assert_allclose(footprint_ref, footprint_test)
+
+
+def test_readonly_array():
+    wcs1 = WCS(naxis=2)
+    wcs2 = WCS(naxis=2)
+    wcs2.wcs.crpix = [2, 2]
+
+    array = np.random.random((128, 128))
+    array.flags.writeable = False
+
+    # This should work
+    reproject_adaptive((array, wcs1), wcs2, shape_out=(128, 128))
+


### PR DESCRIPTION
@astrofrog This is what I found for readonly arrays in Cython: https://github.com/cython/cython/pull/1869

Just need to add `const` to the types of the input arrays

Closes #449 ?