### PR TITLE
Fix devdeps CI

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -31,10 +31,11 @@ deps =
     devdeps: scipy>=0.0.dev0
     devdeps: astropy>=0.0.dev0
     devdeps: astropy-healpix>=0.0.dev0
-    devdeps: git+https://github.com/asdf-format/asdf.git#egg=asdf
-    devdeps: git+https://github.com/astropy/asdf-astropy.git
-    devdeps: git+https://github.com/spacetelescope/gwcs.git#egg=gwcs
-    #devdeps: git+https://github.com/sunpy/sunpy.git#egg=sunpy
+    devdeps: asdf @ git+https://github.com/asdf-format/asdf.git
+    devdeps: asdf-astropy @ git+https://github.com/astropy/asdf-astropy.git
+    devdeps: gwcs @ git+https://github.com/spacetelescope/gwcs.git
+    devdeps: sunpy[map] @ git+https://github.com/sunpy/sunpy.git
+    devdeps: zarr<3
 
 extras =
     test

--- a/tox.ini
+++ b/tox.ini
@@ -31,8 +31,9 @@ deps =
     devdeps: scipy>=0.0.dev0
     devdeps: astropy>=0.0.dev0
     devdeps: astropy-healpix>=0.0.dev0
-    devdeps: asdf @ git+https://github.com/asdf-format/asdf.git
-    devdeps: asdf-astropy @ git+https://github.com/astropy/asdf-astropy.git
+    # For now we don't test with asdf dev due to this issue: https://github.com/asdf-format/asdf/issues/1811
+    #devdeps: asdf @ git+https://github.com/asdf-format/asdf.git
+    #devdeps: asdf-astropy @ git+https://github.com/astropy/asdf-astropy.git
     devdeps: gwcs @ git+https://github.com/spacetelescope/gwcs.git
     devdeps: sunpy[map] @ git+https://github.com/sunpy/sunpy.git
     devdeps: zarr<3


### PR DESCRIPTION
This pins zarr as the zarr 3.0 pre-release is very incompatible with dask. At the same time, I added back sunpy dev.