### PR TITLE
MNT: Use hash for Action workflow versions and update if needed

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
 
   tests:
-    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@924441154cf3053034c6513d5e06c69d262fb9a6  # v1.13.0
     with:
       envs: |
         - macos: py310-test-oldestdeps
@@ -35,7 +35,7 @@ jobs:
 
   publish:
     needs: tests
-    uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish.yml@v1
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish.yml@924441154cf3053034c6513d5e06c69d262fb9a6  # v1.13.0
     with:
       test_extras: test
       test_command: pytest -p no:warnings --pyargs reproject

--- a/.github/workflows/update-changelog.yaml
+++ b/.github/workflows/update-changelog.yaml
@@ -14,19 +14,19 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938  # v4.2.0
         with:
           ref: main
 
       - name: Update Changelog
-        uses: stefanzweifel/changelog-updater-action@v1
+        uses: stefanzweifel/changelog-updater-action@61ce794778aa787ea8d204d9fe2928543cb2fe40  # v1.11.0
         with:
           release-notes: ${{ github.event.release.body }}
           latest-version: ${{ github.event.release.name }}
           path-to-changelog: CHANGES.md
 
       - name: Commit updated CHANGELOG
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@8621497c8c39c72f3e2a999a26b4ca1b5058a842  # v5.0.1
         with:
           branch: main
           commit_message: Update CHANGELOG


### PR DESCRIPTION
As recommended by https://scientific-python.org/specs/spec-0008/#pin-github-actions-release-workflows-to-their-full-release-commit-shas , this PR changes your Actions workflow version pins to hashes, and updates to latest release hashes (at the time of writing) if needed.

This is an automated update made by the `batchpr` tool :robot: - feel free to close if it doesn't look good! You can report issues to @pllim.

[:ghost:](https://github.com/pllim/playpen/issues/60)