### PR TITLE
Flag out NaN weights in coadd & allow for weights to have different WCS than data

### DIFF
--- a/reproject/mosaicking/coadd.py
+++ b/reproject/mosaicking/coadd.py
@@ -25,34 +25,6 @@ def _noop(iterable):
     return iterable
 
 
-def _byteordermatch(arr1, arr2):
-
-    # Match arr1's dtype to arr2
-
-    odt = arr2.dtype
-    idt = arr1.dtype
-    bo_resolver = {"=": "<" if sys.byteorder == "little" else ">", "<": "<", ">": ">"}
-    obo = bo_resolver[odt.byteorder]
-    ibo = bo_resolver[idt.byteorder]
-
-    if ibo != obo:
-        if hasattr(arr1, "byteswap"):
-            arr1 = arr1.byteswap(inplace=True).view(arr2.dtype)
-        else:
-            from dask.utils import M
-
-            try:
-                arr1 = arr1.map_blocks(M.byteswap, False).map_blocks(M.newbyteorder, "S")
-            except Exception:
-
-                def newbyteorder(arr, order):
-                    return arr.view(arr.dtype.newbyteorder(order))
-
-                arr1 = arr1.map_blocks(M.byteswap, False).map_blocks(newbyteorder, "S")
-
-    return arr1
-
-
 def reproject_and_coadd(
     input_data,
     output_projection,
@@ -234,7 +206,6 @@ def reproject_and_coadd(
             # We need to pre-parse the data here since we need to figure out how to
             # optimize/minimize the size of each output tile (see below).
             array_in, wcs_in = parse_input_data(input_data[idata], hdu_in=hdu_in)
-            array_in = _byteordermatch(array_in, output_array)
 
             # We also get the weights map, if specified
             if input_weights is None:

--- a/reproject/mosaicking/coadd.py
+++ b/reproject/mosaicking/coadd.py
@@ -358,7 +358,7 @@ def reproject_and_coadd(
 
             # For the purposes of mosaicking, we mask out NaN values from the array
             # and set the footprint to 0 at these locations.
-            reset = np.isnan(array)
+            reset = np.isnan(array) | np.isnan(weights)
             array[reset] = 0.0
             footprint[reset] = 0.0
 

--- a/reproject/mosaicking/coadd.py
+++ b/reproject/mosaicking/coadd.py
@@ -212,7 +212,7 @@ def reproject_and_coadd(
                 weights_in = None
             else:
                 weights_in, weights_wcs = parse_input_weights(input_weights[idata], hdu_weights=hdu_weights, return_wcs=True)
-                if weights_wcs is None:
+                if weights_wcs is None or not weights_wcs.has_celestial:
                     # if weights are passed as an array
                     weights_wcs = wcs_in
                 if np.any(np.isnan(weights_in)):

--- a/reproject/mosaicking/coadd.py
+++ b/reproject/mosaicking/coadd.py
@@ -32,22 +32,24 @@ def byteordermatch(arr1, arr2):
 
     odt = arr2.dtype
     idt = arr1.dtype
-    bo_resolver = {'=': '<' if sys.byteorder == 'little' else '>', '<': '<', '>': '>'}
+    bo_resolver = {"=": "<" if sys.byteorder == "little" else ">", "<": "<", ">": ">"}
     obo = bo_resolver[odt.byteorder]
     ibo = bo_resolver[idt.byteorder]
 
     if ibo != obo:
-        if hasattr(arr1, 'byteswap'):
+        if hasattr(arr1, "byteswap"):
             arr1 = arr1.byteswap(inplace=True).view(arr2.dtype)
         else:
             from dask.utils import M
 
-            #arr1 = arr1.map_blocks(np.ndarray.byteswap, True).map_blocks(np.ndarray.newbyteorder, "S")
+            # arr1 = arr1.map_blocks(np.ndarray.byteswap, True).map_blocks(np.ndarray.newbyteorder, "S")
             try:
                 arr1 = arr1.map_blocks(M.byteswap, False).map_blocks(M.newbyteorder, "S")
             except:
+
                 def newbyteorder(arr, order):
                     return arr.view(arr.dtype.newbyteorder(order))
+
                 arr1 = arr1.map_blocks(M.byteswap, False).map_blocks(newbyteorder, "S")
 
     return arr1
@@ -199,7 +201,6 @@ def reproject_and_coadd(
             f"the output shape {shape_out}"
         )
 
-
     if output_footprint is None:
         output_footprint = np.zeros(shape_out)
     elif output_footprint.shape != shape_out:
@@ -241,7 +242,9 @@ def reproject_and_coadd(
             if input_weights is None:
                 weights_in = None
             else:
-                weights_in, weights_wcs = parse_input_weights(input_weights[idata], hdu_weights=hdu_weights, return_wcs=True)
+                weights_in, weights_wcs = parse_input_weights(
+                    input_weights[idata], hdu_weights=hdu_weights, return_wcs=True
+                )
                 if weights_wcs is None or not weights_wcs.has_celestial:
                     # if weights are passed as an array
                     weights_wcs = wcs_in

--- a/reproject/mosaicking/coadd.py
+++ b/reproject/mosaicking/coadd.py
@@ -25,10 +25,9 @@ def _noop(iterable):
     return iterable
 
 
-def byteordermatch(arr1, arr2):
-    """
-    Match arr1's dtype to arr2
-    """
+def _byteordermatch(arr1, arr2):
+
+    # Match arr1's dtype to arr2
 
     odt = arr2.dtype
     idt = arr1.dtype
@@ -42,10 +41,9 @@ def byteordermatch(arr1, arr2):
         else:
             from dask.utils import M
 
-            # arr1 = arr1.map_blocks(np.ndarray.byteswap, True).map_blocks(np.ndarray.newbyteorder, "S")
             try:
                 arr1 = arr1.map_blocks(M.byteswap, False).map_blocks(M.newbyteorder, "S")
-            except:
+            except Exception:
 
                 def newbyteorder(arr, order):
                     return arr.view(arr.dtype.newbyteorder(order))
@@ -236,7 +234,7 @@ def reproject_and_coadd(
             # We need to pre-parse the data here since we need to figure out how to
             # optimize/minimize the size of each output tile (see below).
             array_in, wcs_in = parse_input_data(input_data[idata], hdu_in=hdu_in)
-            array_in = byteordermatch(array_in, output_array)
+            array_in = _byteordermatch(array_in, output_array)
 
             # We also get the weights map, if specified
             if input_weights is None:

--- a/reproject/mosaicking/coadd.py
+++ b/reproject/mosaicking/coadd.py
@@ -14,6 +14,7 @@ from ..array_utils import iterate_chunks, sample_array_edges
 from ..utils import parse_input_data, parse_input_weights, parse_output_projection
 from .background import determine_offset_matrix, solve_corrections_sgd
 from .subset_array import ReprojectedArraySubset
+from ..interpolation.core import _validate_wcs
 
 __all__ = ["reproject_and_coadd"]
 
@@ -217,6 +218,12 @@ def reproject_and_coadd(
                 if weights_wcs is None:
                     # if weights are passed as an array
                     weights_wcs = wcs_in
+                else:
+                    try:
+                        _validate_wcs(weights_wcs, wcs_in, weights_in.shape, shape_out)
+                    except ValueError:
+                        # WCS is not valid (most likely, it is blank?)
+                        weights_wcs = wcs_in
                 if np.any(np.isnan(weights_in)):
                     weights_in = np.nan_to_num(weights_in)
 

--- a/reproject/mosaicking/coadd.py
+++ b/reproject/mosaicking/coadd.py
@@ -355,10 +355,12 @@ def reproject_and_coadd(
                     return_footprint=False,
                     **kwargs,
                 )
+                reset = np.isnan(array) | np.isnan(weights)
+            else:
+                reset = np.isnan(array)
 
             # For the purposes of mosaicking, we mask out NaN values from the array
             # and set the footprint to 0 at these locations.
-            reset = np.isnan(array) | np.isnan(weights)
             array[reset] = 0.0
             footprint[reset] = 0.0
 

--- a/reproject/mosaicking/coadd.py
+++ b/reproject/mosaicking/coadd.py
@@ -212,9 +212,9 @@ def reproject_and_coadd(
                 weights_in = None
             else:
                 weights_in, weights_wcs = parse_input_weights(
-                    input_weights[idata], hdu_weights=hdu_weights, return_wcs=True
+                    input_weights[idata], hdu_weights=hdu_weights
                 )
-                if weights_wcs is None or not weights_wcs.has_celestial:
+                if weights_wcs is None:
                     # if weights are passed as an array
                     weights_wcs = wcs_in
                 if np.any(np.isnan(weights_in)):

--- a/reproject/mosaicking/coadd.py
+++ b/reproject/mosaicking/coadd.py
@@ -11,10 +11,10 @@ from astropy.wcs.utils import pixel_to_pixel
 from astropy.wcs.wcsapi import SlicedLowLevelWCS
 
 from ..array_utils import iterate_chunks, sample_array_edges
+from ..interpolation.core import _validate_wcs
 from ..utils import parse_input_data, parse_input_weights, parse_output_projection
 from .background import determine_offset_matrix, solve_corrections_sgd
 from .subset_array import ReprojectedArraySubset
-from ..interpolation.core import _validate_wcs
 
 __all__ = ["reproject_and_coadd"]
 

--- a/reproject/mosaicking/coadd.py
+++ b/reproject/mosaicking/coadd.py
@@ -212,6 +212,9 @@ def reproject_and_coadd(
                 weights_in = None
             else:
                 weights_in, weights_wcs = parse_input_weights(input_weights[idata], hdu_weights=hdu_weights, return_wcs=True)
+                if weights_wcs is None:
+                    # if weights are passed as an array
+                    weights_wcs = wcs_in
                 if np.any(np.isnan(weights_in)):
                     weights_in = np.nan_to_num(weights_in)
 

--- a/reproject/mosaicking/coadd.py
+++ b/reproject/mosaicking/coadd.py
@@ -211,7 +211,7 @@ def reproject_and_coadd(
             if input_weights is None:
                 weights_in = None
             else:
-                weights_in = parse_input_weights(input_weights[idata], hdu_weights=hdu_weights)
+                weights_in, weights_wcs = parse_input_weights(input_weights[idata], hdu_weights=hdu_weights, return_wcs=True)
                 if np.any(np.isnan(weights_in)):
                     weights_in = np.nan_to_num(weights_in)
 
@@ -347,7 +347,7 @@ def reproject_and_coadd(
                 )
 
                 weights = reproject_function(
-                    (weights_in, wcs_in),
+                    (weights_in, weights_wcs),
                     output_projection=wcs_out_indiv,
                     shape_out=shape_out_indiv,
                     hdu_in=hdu_in,

--- a/reproject/mosaicking/tests/test_coadd.py
+++ b/reproject/mosaicking/tests/test_coadd.py
@@ -304,7 +304,7 @@ class TestReprojectAndCoAdd:
         assert_allclose(array - np.mean(array), self.array - np.mean(self.array), atol=ATOL)
 
     @pytest.mark.filterwarnings("ignore:unclosed file:ResourceWarning")
-    @pytest.mark.parametrize("mode", ["arrays", "filenames", "hdus"])
+    @pytest.mark.parametrize("mode", ["arrays", "filenames", "hdus", "hdulist"])
     def test_coadd_with_weights(self, tmpdir, reproject_function, mode, intermediate_memmap):
         # Make sure that things work properly when specifying weights
 
@@ -327,6 +327,10 @@ class TestReprojectAndCoAdd:
         elif mode == "hdus":
             hdu1 = fits.ImageHDU(weight1)
             hdu2 = fits.ImageHDU(weight2)
+            input_weights = [hdu1, hdu2]
+        elif mode == "hdulist":
+            hdu1 = fits.HDUList([fits.ImageHDU(weight1, header=self.wcs.to_header())])
+            hdu2 = fits.HDUList([fits.ImageHDU(weight2, header=self.wcs.to_header())])
             input_weights = [hdu1, hdu2]
 
         array, footprint = reproject_and_coadd(

--- a/reproject/mosaicking/tests/test_coadd.py
+++ b/reproject/mosaicking/tests/test_coadd.py
@@ -347,7 +347,6 @@ class TestReprojectAndCoAdd:
 
         assert_allclose(array, expected, atol=ATOL)
 
-
     @pytest.mark.filterwarnings("ignore:unclosed file:ResourceWarning")
     def test_coadd_with_weights_with_wcs(self, tmpdir, reproject_function, intermediate_memmap):
         # Make sure that things work properly when specifying weights that have offset WCS
@@ -378,13 +377,21 @@ class TestReprojectAndCoAdd:
             match_background=False,
         )
 
-        weights1_reprojected = reproject_function(hdu1, self.wcs, shape_out=self.array.shape, return_footprint=False)
-        weights2_reprojected = reproject_function(hdu2, self.wcs, shape_out=self.array.shape, return_footprint=False)
-        array1_reprojected = reproject_function(input_data[0], self.wcs, shape_out=self.array.shape, return_footprint=False)
-        array2_reprojected = reproject_function(input_data[1], self.wcs, shape_out=self.array.shape, return_footprint=False)
-        expected = ((array1_reprojected * weights1_reprojected +
-                     array2_reprojected * weights2_reprojected) /
-                    (weights1_reprojected + weights2_reprojected))
+        weights1_reprojected = reproject_function(
+            hdu1, self.wcs, shape_out=self.array.shape, return_footprint=False
+        )
+        weights2_reprojected = reproject_function(
+            hdu2, self.wcs, shape_out=self.array.shape, return_footprint=False
+        )
+        array1_reprojected = reproject_function(
+            input_data[0], self.wcs, shape_out=self.array.shape, return_footprint=False
+        )
+        array2_reprojected = reproject_function(
+            input_data[1], self.wcs, shape_out=self.array.shape, return_footprint=False
+        )
+        expected = (
+            array1_reprojected * weights1_reprojected + array2_reprojected * weights2_reprojected
+        ) / (weights1_reprojected + weights2_reprojected)
 
         assert_allclose(array, expected, atol=ATOL)
 

--- a/reproject/utils.py
+++ b/reproject/utils.py
@@ -210,7 +210,7 @@ def parse_input_weights(input_weights, hdu_weights=None):
                 hdu_weights = 0
         return parse_input_data(input_weights[hdu_weights])
     elif isinstance(input_weights, PrimaryHDU | ImageHDU | CompImageHDU):
-        if 'CTYPE1' in input_weights.header:
+        if "CTYPE1" in input_weights.header:
             # all valid WCSes have CTYPE1 specified, at least
             ww = WCS(input_weights.header)
         else:

--- a/reproject/utils.py
+++ b/reproject/utils.py
@@ -212,7 +212,9 @@ def parse_input_weights(input_weights, hdu_weights=None, return_wcs=False):
         return parse_input_data(input_weights[hdu_weights])[slc]
     elif isinstance(input_weights, PrimaryHDU | ImageHDU | CompImageHDU):
         if return_wcs:
-            return input_weights.data, WCS(input_weights.header)
+            ww = WCS(input_weights.header)
+            ww = ww if ww.has_celestial else None
+            return input_weights.data, ww
         else:
             return input_weights.data
     elif isinstance(input_weights, np.ndarray):

--- a/reproject/utils.py
+++ b/reproject/utils.py
@@ -192,14 +192,13 @@ def parse_input_shape(input_shape, hdu_in=None):
         )
 
 
-def parse_input_weights(input_weights, hdu_weights=None, return_wcs=False):
+def parse_input_weights(input_weights, hdu_weights=None):
     """
     Parse input weights to return a Numpy array.
     """
-    slc = slice(None) if return_wcs else 0
 
     if isinstance(input_weights, str):
-        return parse_input_data(fits.open(input_weights), hdu_in=hdu_weights)[slc]
+        return parse_input_data(fits.open(input_weights), hdu_in=hdu_weights)
     elif isinstance(input_weights, HDUList):
         if hdu_weights is None:
             if len(input_weights) > 1:
@@ -209,19 +208,12 @@ def parse_input_weights(input_weights, hdu_weights=None, return_wcs=False):
                 )
             else:
                 hdu_weights = 0
-        return parse_input_data(input_weights[hdu_weights])[slc]
+        return parse_input_data(input_weights[hdu_weights])
     elif isinstance(input_weights, PrimaryHDU | ImageHDU | CompImageHDU):
-        if return_wcs:
-            ww = WCS(input_weights.header)
-            ww = ww if ww.has_celestial else None
-            return input_weights.data, ww
-        else:
-            return input_weights.data
+        ww = WCS(input_weights.header)
+        return input_weights.data, ww
     elif isinstance(input_weights, np.ndarray):
-        if return_wcs:
-            return input_weights, None
-        else:
-            return input_weights
+        return input_weights, None
     else:
         raise TypeError("input_weights should either be an HDU object or a Numpy array")
 

--- a/reproject/utils.py
+++ b/reproject/utils.py
@@ -192,10 +192,12 @@ def parse_input_shape(input_shape, hdu_in=None):
         )
 
 
-def parse_input_weights(input_weights, hdu_weights=None):
+def parse_input_weights(input_weights, hdu_weights=None, return_wcs=False):
     """
     Parse input weights to return a Numpy array.
     """
+    if return_wcs:
+        return parse_input_data(input_weights, hdu_in=hdu_weights)
 
     if isinstance(input_weights, str):
         return parse_input_data(fits.open(input_weights), hdu_in=hdu_weights)[0]

--- a/reproject/utils.py
+++ b/reproject/utils.py
@@ -196,11 +196,10 @@ def parse_input_weights(input_weights, hdu_weights=None, return_wcs=False):
     """
     Parse input weights to return a Numpy array.
     """
-    if return_wcs:
-        return parse_input_data(input_weights, hdu_in=hdu_weights)
+    slc = slice(None) if return_wcs else 0
 
     if isinstance(input_weights, str):
-        return parse_input_data(fits.open(input_weights), hdu_in=hdu_weights)[0]
+        return parse_input_data(fits.open(input_weights), hdu_in=hdu_weights)[slc]
     elif isinstance(input_weights, HDUList):
         if hdu_weights is None:
             if len(input_weights) > 1:
@@ -210,11 +209,17 @@ def parse_input_weights(input_weights, hdu_weights=None, return_wcs=False):
                 )
             else:
                 hdu_weights = 0
-        return parse_input_data(input_weights[hdu_weights])[0]
+        return parse_input_data(input_weights[hdu_weights])[slc]
     elif isinstance(input_weights, PrimaryHDU | ImageHDU | CompImageHDU):
-        return input_weights.data
+        if return_wcs:
+            return input_weights.data, WCS(input_weights.header)
+        else:
+            return input_weights.data
     elif isinstance(input_weights, np.ndarray):
-        return input_weights
+        if return_wcs:
+            return input_weights, None
+        else:
+            return input_weights
     else:
         raise TypeError("input_weights should either be an HDU object or a Numpy array")
 

--- a/reproject/utils.py
+++ b/reproject/utils.py
@@ -210,7 +210,11 @@ def parse_input_weights(input_weights, hdu_weights=None):
                 hdu_weights = 0
         return parse_input_data(input_weights[hdu_weights])
     elif isinstance(input_weights, PrimaryHDU | ImageHDU | CompImageHDU):
-        ww = WCS(input_weights.header)
+        if 'CTYPE1' in input_weights.header:
+            # all valid WCSes have CTYPE1 specified, at least
+            ww = WCS(input_weights.header)
+        else:
+            ww = None
         return input_weights.data, ww
     elif isinstance(input_weights, np.ndarray):
         return input_weights, None


### PR DESCRIPTION
I encountered a severe error case in which the weights array became NaN after reprojection.  Flagging out locations where weights is NaN solved the issue.

I cannot come up with an MWE; this occurs deep in the guts of a complicated mosaicking attempt, and it happened for only 1 field out of 270.  I think it might be the consequence of a numerical error that occurs only under unique conditions, but it also looks logically like this fix _should_ work.