### PR TITLE
Fix a bug that caused big-endian dask arrays to not be reprojected correctly

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "scipy>=1.9",
     "dask[array]>=2021.8",
     "cloudpickle",
-    "zarr",
+    "zarr<3",
     "fsspec",
 ]
 dynamic = ["version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "scipy>=1.9",
     "dask[array]>=2021.8",
     "cloudpickle",
-    "zarr<3",
+    "zarr",
     "fsspec",
 ]
 dynamic = ["version"]

--- a/reproject/interpolation/tests/test_core.py
+++ b/reproject/interpolation/tests/test_core.py
@@ -956,13 +956,14 @@ def test_auto_block_size():
     assert footprint_out.chunksize[0] == 350
 
 
-def test_bigendian_dask():
+@pytest.mark.parametrize('itemsize', (4, 8))
+def test_bigendian_dask(itemsize):
 
     # Regression test for an endianness issue that occurred when the input was
     # passed in as (dask_array, wcs) and the dask array was big endian.
 
-    array_in_le = da.ones((350, 250, 150), dtype=">f8")
-    array_in_be = da.ones((350, 250, 150), dtype="<f8")
+    array_in_le = da.ones((350, 250, 150), dtype=f">f{itemsize}")
+    array_in_be = da.ones((350, 250, 150), dtype=f"<f{itemsize}")
     wcs_in = WCS(naxis=2)
     wcs_out = WCS(naxis=2)
 

--- a/reproject/interpolation/tests/test_core.py
+++ b/reproject/interpolation/tests/test_core.py
@@ -956,7 +956,7 @@ def test_auto_block_size():
     assert footprint_out.chunksize[0] == 350
 
 
-@pytest.mark.parametrize('itemsize', (4, 8))
+@pytest.mark.parametrize("itemsize", (4, 8))
 def test_bigendian_dask(itemsize):
 
     # Regression test for an endianness issue that occurred when the input was

--- a/reproject/interpolation/tests/test_core.py
+++ b/reproject/interpolation/tests/test_core.py
@@ -954,3 +954,30 @@ def test_auto_block_size():
 
     assert array_out.chunksize[0] == 350
     assert footprint_out.chunksize[0] == 350
+
+
+def test_bigendian_dask():
+
+    # Regression test for an endianness issue that occurred when the input was
+    # passed in as (dask_array, wcs) and the dask array was big endian.
+
+    array_in_le = da.ones((350, 250, 150), dtype=">f8")
+    array_in_be = da.ones((350, 250, 150), dtype="<f8")
+    wcs_in = WCS(naxis=2)
+    wcs_out = WCS(naxis=2)
+
+    array_out_be, _ = reproject_interp(
+        (array_in_be, wcs_in),
+        wcs_out,
+        shape_out=(300, 300),
+        block_size=(100, 100),
+    )
+
+    array_out_le, _ = reproject_interp(
+        (array_in_le, wcs_in),
+        wcs_out,
+        shape_out=(300, 300),
+        block_size=(100, 100),
+    )
+
+    assert_allclose(array_out_be, array_out_le)

--- a/reproject/utils.py
+++ b/reproject/utils.py
@@ -53,7 +53,7 @@ def _dask_to_numpy_memmap(dask_array, tmp_dir):
 
         memmapped_array = np.memmap(
             memmap_path,
-            dtype=zarr_array.dtype,
+            dtype=float,
             shape=zarr_array.shape,
             mode="w+",
         )

--- a/reproject/utils.py
+++ b/reproject/utils.py
@@ -31,6 +31,11 @@ def _dask_to_numpy_memmap(dask_array, tmp_dir):
     if isinstance(dask_array.ravel()[0].compute(), da.Array):
         dask_array = dask_array.compute()
 
+    # Cast the dask array to regular float for two reasons - first, zarr 3.0.0
+    # and later doesn't support big-endian arrays, and also we need to anyway
+    # make a native float memory mapped array below.
+    dask_array = dask_array.astype(float, copy=False)
+
     # NOTE: here we use a new TemporaryDirectory context manager for the zarr
     # array because we can remove the temporary directory straight away after
     # converting the input to a Numpy memory mapped array.

--- a/tox.ini
+++ b/tox.ini
@@ -36,7 +36,6 @@ deps =
     #devdeps: asdf-astropy @ git+https://github.com/astropy/asdf-astropy.git
     devdeps: gwcs @ git+https://github.com/spacetelescope/gwcs.git
     devdeps: sunpy[map] @ git+https://github.com/sunpy/sunpy.git
-    devdeps: zarr<3
 
 extras =
     test


### PR DESCRIPTION
I'm surprised I didn't run into this sooner, but this should fix the endianness issue @keflavich - can you confirm?