### PR TITLE
Force little endian input for zarr

### DIFF
--- a/reproject/common.py
+++ b/reproject/common.py
@@ -300,7 +300,7 @@ def _reproject_dispatcher(
             reproject_single_block,
             array_out_dask,
             array_in_or_path,
-            dtype=float,
+            dtype="<f8",
             new_axis=0,
             chunks=(2,) + array_out_dask.chunksize,
         )

--- a/reproject/utils.py
+++ b/reproject/utils.py
@@ -34,7 +34,7 @@ def _dask_to_numpy_memmap(dask_array, tmp_dir):
     # Cast the dask array to regular float for two reasons - first, zarr 3.0.0
     # and later doesn't support big-endian arrays, and also we need to anyway
     # make a native float memory mapped array below.
-    dask_array = dask_array.astype(float, copy=False)
+    dask_array = dask_array.astype("<f8", copy=False)
 
     # NOTE: here we use a new TemporaryDirectory context manager for the zarr
     # array because we can remove the temporary directory straight away after


### PR DESCRIPTION
I think I found the cause for the failures in #491: One is what was already mentioned in https://github.com/astropy/reproject/pull/487#pullrequestreview-2675588760, and the other is similar in `reproject/common.py`. The reason why the patch shown in #491 didn't work was that the second patch in `reproject/utils.py` was actually wrong.

I applied this PR to the Debian package (merged with #487), and now [all tests pass on s390x](https://buildd.debian.org/status/fetch.php?pkg=reproject&arch=s390x&ver=0.14.1-3&stamp=1741727132&raw=0).

Disclaimer: This is a fix by a "poor stranger". I didn't dig into the structure of reproject for this but just fixed what could cause the failures. There may be other places with a similar issue, or side effects that are not covered by the CI tests. So, please carefully review whether this does what is intended, beside the CI.

Closes: #491