### PR TITLE
WIP: Support for HiPS

### DIFF
--- a/reproject/hips/__init__.py
+++ b/reproject/hips/__init__.py
@@ -1,0 +1,1 @@
+from .high_level import *  # noqa

--- a/reproject/hips/core.py
+++ b/reproject/hips/core.py
@@ -1,0 +1,176 @@
+import os
+import uuid
+from datetime import datetime
+from logging import getLogger
+
+import numpy as np
+from astropy.coordinates import ICRS, BarycentricTrueEcliptic, Galactic
+from astropy.io import fits
+from astropy_healpix import HEALPix, level_to_nside
+
+from .utils import make_tile_folders, tile_filename, tile_header
+
+__all__ = ["image_to_hips"]
+
+
+VALID_COORD_SYSTEM = {
+    'equatorial': ICRS(),
+    'galactic': Galactic(),
+    'ecliptic': BarycentricTrueEcliptic(),
+}
+
+def image_to_hips(
+    array_in,
+    wcs_in,
+    coord_system_out,
+    *,
+    level,
+    reproject_function,
+    output_directory,
+    tile_size,
+    progress_bar=None,
+    **kwargs,
+):
+    """
+    Convert image in a normal WCS projection to HiPS tiles.
+
+    Parameters
+    ----------
+    data : `numpy.ndarray`
+        Input data array to reproject
+    wcs_in : `~astropy.wcs.WCS`
+        The WCS of the input array
+    coord_system_out : {'equatorial', 'galactic', 'ecliptic' }
+        The target coordinate system for the HEALPIX projection
+    level : int
+        The number of levels of FITS tiles.
+    reproject_function : callable
+        The function to use for the reprojection.
+    output_directory : str
+        The name of the output directory.
+    tile_size : int, optional
+        The size of each individual tile (defaults to 512).
+    progress_bar : callable, optional
+        If specified, use this as a progress_bar to track loop iterations over
+        data sets.
+    """
+
+    logger = getLogger(__name__)
+
+    # Check tile size is even
+    if tile_size % 2 != 0:
+        raise ValueError("tile_size should be even")
+
+    # Check coordinate system
+    if coord_system_out in VALID_COORD_SYSTEM:
+        frame = VALID_COORD_SYSTEM[coord_system_out]
+    else:
+        raise ValueError("coord_system_out should be one of " + "/".join(VALID_COORD_SYSTEM))
+
+    # Create output directory (and error if it already exists)
+    os.makedirs(output_directory, exist_ok=False)
+
+    # Determine center of image and radius to furthest corner, to determine
+    # which HiPS tiles need to be generated
+
+    ny, nx = array_in.shape
+
+    cen_x, cen_y = (nx - 1) / 2, (ny - 1) / 2
+
+    cor_x = np.array([-0.5, -0.5, nx - 0.5, nx - 0.5])
+    cor_y = np.array([-0.5, ny - 0.5, ny - 0.5, -0.5])
+
+    cen_world = wcs_in.pixel_to_world(cen_x, cen_y)
+    cor_world = wcs_in.pixel_to_world(cor_x, cor_y)
+
+    radius = cor_world.separation(cen_world).max()
+
+    # TODO: in future if astropy-healpix implements polygon searches, we could
+    # use that instead
+
+    # Determine all the indices at the highest level
+
+    nside = level_to_nside(level)
+    hp = HEALPix(nside=nside, order="nested", frame=frame)
+
+    indices = hp.cone_search_skycoord(cen_world, radius=radius)
+
+    logger.info(f"Found {len(indices)} tiles (at most) to generate at level {level}")
+
+    # PERF: the code above may be prohibitive for large numbers of tiles,
+    # so we may want to find a way to iterate over these in chunks.
+
+    # Make all the folders required for the tiles
+    make_tile_folders(level=level, indices=indices, output_directory=output_directory)
+
+    # Iterate over the tiles and generate them
+    generated_indices = []
+    for index in progress_bar(indices):
+        header = tile_header(level=level, index=index, frame=frame, tile_size=tile_size)
+        array_out, footprint = reproject_function((array_in, wcs_in), header, **kwargs)
+        array_out[np.isnan(array_out)] = 0.0
+        if np.all(footprint == 0):
+            continue
+        fits.writeto(tile_filename(level=level, index=index, output_directory=output_directory), array_out)
+        generated_indices.append(index)
+
+    indices = np.array(generated_indices)
+
+    # Iterate over higher levels and compute lower resolution tiles
+    for ilevel in range(level - 1, -1, -1):
+
+        # Find index of tiles to produce at lower-resolution levels
+        indices = np.sort(np.unique(indices // 4))
+
+        make_tile_folders(level=ilevel, indices=indices, output_directory=output_directory)
+
+        for index in indices:
+
+            header = tile_header(level=ilevel, index=index, frame=frame, tile_size=tile_size)
+
+            array = np.zeros((tile_size, tile_size))
+
+            for subindex in range(4):
+
+                current_index = 4 * index + subindex
+                subtile_filename = tile_filename(level=ilevel+1, index=current_index, output_directory=output_directory)
+
+                if os.path.exists(subtile_filename):
+
+                    data = fits.getdata(subtile_filename)[::2,::2]
+
+                    if subindex == 0:
+                        array[256:, :256] = data
+                    elif subindex == 2:
+                        array[256:, 256:] = data
+                    elif subindex == 1:
+                        array[:256, :256] = data
+                    elif subindex == 3:
+                        array[:256, 256:] = data
+
+            fits.writeto(tile_filename(level=ilevel, index=index, output_directory=output_directory), array, header)
+
+    # Generate properties file
+
+    cen_icrs = cen_world.icrs
+
+    properties = {
+        'creator_did': f'ivo://reproject/{str(uuid.uuid4())}',
+        'obs_title': 'Placeholder title',
+        'dataproduct_type': 'image',
+        'hips_version': '1.4',
+        'hips_release_date': datetime.now().isoformat(),
+        'hips_status': 'public master clonableOnce',
+        'hips_tile_format': 'fits',
+        'hips_tile_width': tile_size,
+        'hips_order': level,
+        'hips_frame': coord_system_out,
+        'hips_builder': 'astropy/reproject',
+        'hips_initial_ra': cen_icrs.ra.deg,
+        'hips_initial_dec': cen_icrs.dec.deg,
+        'hips_initial_fov': radius.deg,
+    }
+
+    with open(os.path.join(output_directory, 'properties'), 'w') as f:
+        for key, value in properties.items():
+            f.write(f'{key:20s} = {value}\n')

--- a/reproject/hips/high_level.py
+++ b/reproject/hips/high_level.py
@@ -1,0 +1,91 @@
+from ..utils import parse_input_data
+from ..wcs_utils import has_celestial
+from .core import image_to_hips
+
+__all__ = ["reproject_from_hips", "reproject_to_hips"]
+
+
+def reproject_from_hips():
+    raise NotImplementedError()
+
+
+def reproject_to_hips(
+    input_data,
+    *,
+    coord_system_out,
+    level,
+    reproject_function,
+    output_directory,
+    hdu_in=0,
+    tile_size=512,
+    progress_bar=None,
+):
+    """
+    Reproject data from a standard projection to a set of Hierarchical Progressive
+    Surveys (HiPS) tiles.
+
+    Parameters
+    ----------
+    input_data : object
+        The input data to reproject. This can be:
+
+            * The name of a FITS file as a `str` or a `pathlib.Path` object
+            * An `~astropy.io.fits.HDUList` object
+            * An image HDU object such as a `~astropy.io.fits.PrimaryHDU`,
+              `~astropy.io.fits.ImageHDU`, or `~astropy.io.fits.CompImageHDU`
+              instance
+            * A tuple where the first element is a `~numpy.ndarray` and the
+              second element is either a
+              `~astropy.wcs.wcsapi.BaseLowLevelWCS`,
+              `~astropy.wcs.wcsapi.BaseHighLevelWCS`, or a
+              `~astropy.io.fits.Header` object
+            * An `~astropy.nddata.NDData` object from which the ``.data`` and
+              ``.wcs`` attributes will be used as the input data.
+
+    coord_system_out : {'equatorial', 'galactic', 'ecliptic' }
+        The target coordinate system for the HEALPIX projection
+    level : int, optional
+        The number of levels of FITS tiles.
+    reproject_function : callable
+        The function to use for the reprojection.
+    output_directory : str
+        The name of the output directory - if this already exists, an error
+        will be raised.
+    hdu_in : int or str, optional
+        If ``input_data`` is a FITS file or an `~astropy.io.fits.HDUList`
+        instance, specifies the HDU to use.
+    tile_size : int, optional
+        The size of each individual tile (defaults to 512).
+    progress_bar : callable, optional
+        If specified, use this as a progress_bar to track loop iterations over
+        data sets.
+
+    **kwargs
+        Keyword arguments to be passed to the reprojection function.
+    """
+
+    array_in, wcs_in = parse_input_data(input_data, hdu_in=hdu_in)
+
+    if (
+        has_celestial(wcs_in)
+        and wcs_in.low_level_wcs.pixel_n_dim == 2
+        and wcs_in.low_level_wcs.world_n_dim == 2
+    ):
+        return image_to_hips(
+            array_in,
+            wcs_in,
+            coord_system_out,
+            level=level,
+            reproject_function=reproject_function,
+            output_directory=output_directory,
+            tile_size=tile_size,
+            progress_bar=progress_bar,
+        )
+    else:
+        raise NotImplementedError(
+            "Only data with a 2-d celestial WCS can be reprojected to HiPS tiles"
+        )
+
+
+def coadd_hips():
+    raise NotImplementedError()

--- a/reproject/hips/utils.py
+++ b/reproject/hips/utils.py
@@ -1,0 +1,68 @@
+import os
+
+import numpy as np
+from astropy.wcs.utils import celestial_frame_to_wcs
+from astropy_healpix import HEALPix, level_to_nside
+
+__all__ = ["tile_header", "tile_filename", "make_tile_folders"]
+
+
+def tile_header(*, level, index, frame, tile_size):
+    """
+    Return the WCS for a given HiPS tile
+    """
+
+    # PERF: we could optimize this by making it into a class, as very little
+    # changes from tile to tile so we could first create the base tile header
+    # and then just update values for each tile for performance.
+
+    nside = level_to_nside(level)
+    hp = HEALPix(nside=nside, order="nested", frame=frame)
+
+    print(level, index, nside)
+
+    tile_wcs = celestial_frame_to_wcs(frame, projection="HPX")
+
+    # Determine tile resolution
+    res = 45 / tile_size / 2**level  # degrees
+    tile_wcs.wcs.cd = [[-res, -res], [res, -res]]
+
+    # Set PV parameters to default values
+    tile_wcs.wcs.set_pv([(2, 1, 4), (2, 2, 3)])
+
+    # Determine CRPIX values by determining the position of the relevant corner
+    # relative to the origin of the projection.
+    offset_x, offset_y = tile_wcs.world_to_pixel(hp.healpix_to_skycoord(index, dx=1, dy=0))
+
+    tile_wcs.wcs.crpix[0] = -offset_x - 0.5
+    tile_wcs.wcs.crpix[1] = -offset_y - 0.5
+
+    # Construct header
+    header = tile_wcs.to_header()
+
+    header["NPIX"] = index
+    header["ORDER"] = level
+    header["NAXIS"] = 2
+    header["NAXIS1"] = tile_size
+    header["NAXIS2"] = tile_size
+
+    return header
+
+
+def _rounded_index(index):
+    return 10000 * (index // 10000)
+
+
+def tile_filename(*, level, index, output_directory):
+    return os.path.join(
+        output_directory, f"Norder{level}", f"Dir{_rounded_index(index)}", f"Npix{index}.fits",
+    )
+
+
+def make_tile_folders(*, level, indices, output_directory):
+
+    rounded_indices = np.unique(_rounded_index(indices))
+    for index in rounded_indices:
+        dirname = os.path.dirname(tile_filename(level=level, index=index, output_directory=output_directory))
+        if not os.path.exists(dirname):
+            os.makedirs(dirname)


### PR DESCRIPTION
This adds initial support for HiPS. Currently this only implements ``reproject_to_hips`` and only for 2D celestial images. We should be able to easily extend this to support cubes. The next step will then be to support going from HiPS to regular projections, which might end up being a wrapper around ``reproject_and_coadd``.