### PR TITLE
Add a new keyword argument ``negative_lon_cdelt`` to `find_optimal_celestial_wcs`

### DIFF
--- a/reproject/mosaicking/tests/test_wcs_helpers.py
+++ b/reproject/mosaicking/tests/test_wcs_helpers.py
@@ -322,6 +322,8 @@ def test_solar_wcs():
 
     pytest.importorskip("sunpy", minversion="6.0.1")
 
+    # The following registers the WCS <-> frame for solar coordinates
+
     # Make sure the WCS <-> frame functions are registered
 
     wcs_ref = WCS(fits.Header.fromstring(SOLAR_HEADER, sep="\n"))
@@ -338,5 +340,8 @@ def test_solar_wcs():
     assert wcs.wcs.ctype[1] == wcs_ref.wcs.ctype[1]
     assert wcs.wcs.cunit[0] == wcs_ref.wcs.cunit[0]
     assert wcs.wcs.cunit[1] == wcs_ref.wcs.cunit[1]
+
+    # Make sure cdelt[0] and cdelt[1] are both positive
+    assert np.all(wcs.wcs.cdelt > 0)
 
     assert shape == (4281, 8237)

--- a/reproject/mosaicking/tests/test_wcs_helpers.py
+++ b/reproject/mosaicking/tests/test_wcs_helpers.py
@@ -324,6 +324,8 @@ def test_solar_wcs():
 
     # The following registers the WCS <-> frame for solar coordinates
 
+    import sunpy.coordinates  # noqa
+
     # Make sure the WCS <-> frame functions are registered
 
     wcs_ref = WCS(fits.Header.fromstring(SOLAR_HEADER, sep="\n"))
@@ -332,7 +334,9 @@ def test_solar_wcs():
     wcs2 = wcs_ref.deepcopy()
     wcs2.wcs.crpix[0] -= 4096
 
-    wcs, shape = find_optimal_celestial_wcs([((4096, 4096), wcs1), ((4096, 4096), wcs2)])
+    wcs, shape = find_optimal_celestial_wcs(
+        [((4096, 4096), wcs1), ((4096, 4096), wcs2)], negative_lon_cdelt="auto"
+    )
 
     wcs.wcs.set()
 
@@ -345,3 +349,36 @@ def test_solar_wcs():
     assert np.all(wcs.wcs.cdelt > 0)
 
     assert shape == (4281, 8237)
+
+
+@pytest.mark.filterwarnings("ignore::astropy.wcs.wcs.FITSFixedWarning")
+def test_negative_lon_cdelt():
+    # Regression test for issues that occurred when trying to find
+    # the optimal WCS for a set of solar WCSes
+
+    pytest.importorskip("sunpy", minversion="6.0.1")
+
+    # The following registers the WCS <-> frame for solar coordinates
+
+    import sunpy.coordinates  # noqa
+
+    # Make sure the WCS <-> frame functions are registered
+
+    wcs_ref = WCS(fits.Header.fromstring(SOLAR_HEADER, sep="\n"))
+
+    with pytest.warns(DeprecationWarning, match="negative_lon_cdelt is not set"):
+        wcs_out, _ = find_optimal_celestial_wcs(((10, 10), wcs_ref))
+
+    assert wcs_out.wcs.cdelt[0] < 0 and wcs_out.wcs.cdelt[1] > 0
+
+    wcs_out, _ = find_optimal_celestial_wcs(((10, 10), wcs_ref), negative_lon_cdelt=True)
+
+    assert wcs_out.wcs.cdelt[0] < 0 and wcs_out.wcs.cdelt[1] > 0
+
+    wcs_out, _ = find_optimal_celestial_wcs(((10, 10), wcs_ref), negative_lon_cdelt=False)
+
+    assert np.all(wcs_out.wcs.cdelt > 0)
+
+    wcs_out, _ = find_optimal_celestial_wcs(((10, 10), wcs_ref), negative_lon_cdelt="auto")
+
+    assert np.all(wcs_out.wcs.cdelt > 0)

--- a/reproject/mosaicking/wcs_helpers.py
+++ b/reproject/mosaicking/wcs_helpers.py
@@ -19,6 +19,7 @@ from ..utils import parse_input_shape
 __all__ = ["find_optimal_celestial_wcs"]
 
 
+# Note that if this is modified, the docstring should be updated
 NEGATIVE_CDELT_CTYPES = ["RA--", "GLON", "ELON", "HLON", "SLON"]
 
 
@@ -91,7 +92,10 @@ def find_optimal_celestial_wcs(
         (`True`) or positive (`False`). For astronomical observations of the
         sky this is usually the case, while for coordinate systems used in
         solar physics this is usually positive. If this is not specified, the
-        value will be guessed based on the coordinate frame.
+        value will be `True` if the first four characters for CTYPE for the
+        longitude is ``RA--``, ``GLON``, ``ELON``, ``HLON``, or ``SLON``, and
+        `False` otherwise.
+
 
     Returns
     -------

--- a/reproject/mosaicking/wcs_helpers.py
+++ b/reproject/mosaicking/wcs_helpers.py
@@ -96,7 +96,6 @@ def find_optimal_celestial_wcs(
         longitude is ``RA--``, ``GLON``, ``ELON``, ``HLON``, or ``SLON``, and
         `False` otherwise.
 
-
     Returns
     -------
     wcs : :class:`~astropy.wcs.WCS`


### PR DESCRIPTION
This defaults to ``None`` which means auto. This is a break in API compared to before since for solar WCS for example, cdelt will now be positive. I'm not sure how to change the default via a deprecation phase though, so maybe we have to just bite the bullet?

Fixes https://github.com/astropy/reproject/issues/431

@svank @Cadair - any opinions?