### PR TITLE
Fix threads=True option in reproject.hips

### DIFF
--- a/reproject/hips/high_level.py
+++ b/reproject/hips/high_level.py
@@ -269,7 +269,7 @@ def reproject_to_hips(
 
     if threads:
         generated_indices = []
-        with ThreadPoolExecutor(max_workers=threads) as executor:
+        with ThreadPoolExecutor(max_workers=None if threads is True else threads) as executor:
             futures = [executor.submit(process, index) for index in indices]
             for future in progress_bar(futures):
                 result = future.result()


### PR DESCRIPTION
Previously ``threads=True`` meant ``threads=1``

Fixes https://github.com/astropy/reproject/issues/525