### PR TITLE
Clean up RGB code and API

### DIFF
--- a/reproject/adaptive/high_level.py
+++ b/reproject/adaptive/high_level.py
@@ -211,11 +211,8 @@ def reproject_adaptive(
         by ``block_size`` (if the block size is not set, it will be determined
         automatically). To use the currently active dask scheduler (e.g.
         dask.distributed), set this to ``'current-scheduler'``.
-    return_type : {'numpy', 'dask', 'pil_image'}, optional
-        Whether to return numpy, dask arrays, or RGB images - defaults to 'numpy'.
-        If this is set to 'pil_image', a PIL ``Image`` object is returned. The
-        'pil_image' option can only be used if the input was RGB images or if
-        the input data has shape (3, ny, nx) and contains values between 0 and 255.
+    return_type : {'numpy', 'dask'}, optional
+        Whether to return numpy or dask arrays.
 
     Returns
     -------

--- a/reproject/conftest.py
+++ b/reproject/conftest.py
@@ -15,7 +15,7 @@ from astropy.wcs import WCS
 from astropy.wcs.wcsapi import HighLevelWCSMixin, SlicedLowLevelWCS
 from pyavm import AVM
 
-from .utils import as_rgb_images
+from .utils import as_transparent_rgb
 
 try:
     from pytest_astropy_header.display import PYTEST_HEADER_MODULES, TESTED_VERSIONS
@@ -160,7 +160,9 @@ def valid_celestial_input(tmp_path, request, wcs):
         array = np.broadcast_to(array[None], (channels,) + array.shape).copy()
         if channels == 4:
             array[3] = 1
-        image = as_rgb_images(array)
+        image = as_transparent_rgb(array)
+        if 'transparent' not in request.param:
+            image = image.convert('RGB')
         original_rgb = tmp_path / f"original.{extension}"
         image.save(original_rgb)
         input_value = tmp_path / f"tagged.{extension}"

--- a/reproject/conftest.py
+++ b/reproject/conftest.py
@@ -161,8 +161,8 @@ def valid_celestial_input(tmp_path, request, wcs):
         if channels == 4:
             array[3] = 1
         image = as_transparent_rgb(array)
-        if 'transparent' not in request.param:
-            image = image.convert('RGB')
+        if "transparent" not in request.param:
+            image = image.convert("RGB")
         original_rgb = tmp_path / f"original.{extension}"
         image.save(original_rgb)
         input_value = tmp_path / f"tagged.{extension}"

--- a/reproject/hips/high_level.py
+++ b/reproject/hips/high_level.py
@@ -255,7 +255,7 @@ def reproject_to_hips(
             if tile_format == "png":
                 image = as_transparent_rgb(array_out, alpha=footprint[0])
             else:
-                image = as_transparent_rgb(array_out).convert('RGB')
+                image = as_transparent_rgb(array_out).convert("RGB")
             image.save(
                 tile_filename(
                     level=level,
@@ -345,7 +345,7 @@ def reproject_to_hips(
             else:
                 image = as_transparent_rgb(array.transpose(2, 0, 1))
                 if tile_format == "jpeg":
-                    image = image.convert('RGB')
+                    image = image.convert("RGB")
                 image.save(
                     tile_filename(
                         level=ilevel,

--- a/reproject/hips/high_level.py
+++ b/reproject/hips/high_level.py
@@ -17,7 +17,7 @@ from astropy_healpix import (
 )
 from PIL import Image
 
-from ..utils import as_rgb_images, as_transparent_rgb, is_jpeg, is_png, parse_input_data
+from ..utils import as_transparent_rgb, is_jpeg, is_png, parse_input_data
 from ..wcs_utils import has_celestial
 from .utils import (
     determine_healpix_level,
@@ -253,9 +253,9 @@ def reproject_to_hips(
             )
         else:
             if tile_format == "png":
-                image = as_transparent_rgb(array_out, footprint=footprint)
+                image = as_transparent_rgb(array_out, alpha=footprint[0])
             else:
-                image = as_rgb_images(array_out)
+                image = as_transparent_rgb(array_out).convert('RGB')
             image.save(
                 tile_filename(
                     level=level,
@@ -343,10 +343,9 @@ def reproject_to_hips(
                     header,
                 )
             else:
-                if tile_format == "png":
-                    image = Image.fromarray(array[::-1])
-                else:
-                    image = as_rgb_images(array.transpose(2, 0, 1))
+                image = as_transparent_rgb(array.transpose(2, 0, 1))
+                if tile_format == "jpeg":
+                    image = image.convert('RGB')
                 image.save(
                     tile_filename(
                         level=ilevel,

--- a/reproject/interpolation/high_level.py
+++ b/reproject/interpolation/high_level.py
@@ -107,11 +107,8 @@ def reproject_interp(
         by ``block_size`` (if the block size is not set, it will be determined
         automatically). To use the currently active dask scheduler (e.g.
         dask.distributed), set this to ``'current-scheduler'``.
-    return_type : {'numpy', 'dask', 'pil_image'}, optional
-        Whether to return numpy, dask arrays, or RGB images - defaults to 'numpy'.
-        If this is set to 'pil_image', a PIL ``Image`` object is returned. The
-        'pil_image' option can only be used if the input was RGB images or if
-        the input data has shape (3, ny, nx) and contains values between 0 and 255.
+    return_type : {'numpy', 'dask'}, optional
+        Whether to return numpy or dask arrays.
 
     Returns
     -------

--- a/reproject/interpolation/tests/test_core.py
+++ b/reproject/interpolation/tests/test_core.py
@@ -2,7 +2,6 @@
 
 import itertools
 
-from PIL import Image
 import dask.array as da
 import numpy as np
 import pytest

--- a/reproject/interpolation/tests/test_core.py
+++ b/reproject/interpolation/tests/test_core.py
@@ -2,6 +2,7 @@
 
 import itertools
 
+from PIL import Image
 import dask.array as da
 import numpy as np
 import pytest

--- a/reproject/spherical_intersect/high_level.py
+++ b/reproject/spherical_intersect/high_level.py
@@ -85,11 +85,8 @@ def reproject_exact(
         by ``block_size`` (if the block size is not set, it will be determined
         automatically). To use the currently active dask scheduler (e.g.
         dask.distributed), set this to ``'current-scheduler'``.
-    return_type : {'numpy', 'dask', 'pil_image'}, optional
-        Whether to return numpy, dask arrays, or RGB images - defaults to 'numpy'.
-        If this is set to 'pil_image', a PIL ``Image`` object is returned. The
-        'pil_image' option can only be used if the input was RGB images or if
-        the input data has shape (3, ny, nx) and contains values between 0 and 255.
+    return_type : {'numpy', 'dask'}, optional
+        Whether to return numpy or dask arrays
 
     Returns
     -------

--- a/reproject/utils.py
+++ b/reproject/utils.py
@@ -338,7 +338,9 @@ def as_transparent_rgb(data, alpha=None):
             raise ValueError("alpha needs to be two-dimensional")
 
         if alpha.shape != data.shape[1:]:
-            raise ValueError("alpha layer shape {alpha.shape} does not match data spatial shape {data.shape[1:]}")
+            raise ValueError(
+                "alpha layer shape {alpha.shape} does not match data spatial shape {data.shape[1:]}"
+            )
 
         alpha = alpha.copy()
 

--- a/reproject/utils.py
+++ b/reproject/utils.py
@@ -20,7 +20,6 @@ __all__ = [
     "parse_input_weights",
     "parse_output_projection",
     "as_transparent_rgb",
-    "as_rgb_images",
 ]
 
 
@@ -304,38 +303,47 @@ def is_jpeg(filename):
         return f.read(4) == b"\xff\xd8\xff\xe0"
 
 
-def as_rgb_images(data, footprint=None):
+def as_transparent_rgb(data, alpha=None):
+    """
+    Convert a 3D Numpy array to a PIL object.
 
-    for image in [data, footprint]:
-        if image is not None:
-            if image.ndim != 3:
-                raise ValueError("Data needs to be three-dimensional to return RGB image")
-            if image.shape[0] not in (3, 4):
-                raise ValueError("Data should have shape (3, ny, nx) or (4, ny, nx)")
+    This takes care of swapping the order of the axes, and can apply an additional
+    transparency layer. This also converts any NaNs to transparency.
 
-    rgb_images = []
-    rgb_images.append(Image.fromarray(data.astype(np.uint8).transpose(1, 2, 0)[::-1]))
-    if footprint is not None:
-        rgb_images.append(Image.fromarray(footprint[0].transpose(1, 2, 0)[::-1]))
+    Parameters
+    ----------
+    data : `numpy.ndarray`
+        Input array with shape ``(3, ny, nx)`` or ``(4, ny, nx)``
+    alpha : `numpy.ndarray`
+        Alpha layer to apply to the image in addition to any pre-existing alpha
+        layer and transparency originating from NaN values. This should have
+        a shape ``(ny, nx)``
+    """
 
-    if footprint is None:
-        return rgb_images[0]
-    else:
-        return tuple(rgb_images)
+    if data.ndim != 3:
+        raise ValueError("Data needs to be three-dimensional to return RGB image")
 
-
-def as_transparent_rgb(data, footprint=None):
-
-    for image in [data, footprint]:
-        if image is not None:
-            if image.ndim != 3:
-                raise ValueError("Data needs to be three-dimensional to return RGB image")
-            if image.shape[0] not in (3, 4):
-                raise ValueError("Data should have shape (3, ny, nx) or (4, ny, nx)")
+    if data.shape[0] not in (3, 4):
+        raise ValueError("Data should have shape (3, ny, nx) or (4, ny, nx)")
 
     array = np.zeros((4,) + data.shape[1:], dtype=np.uint8)
 
-    footprint[np.isnan(data)] = 0
+    if alpha is None:
+
+        alpha = np.ones(data.shape[1:])
+
+    else:
+
+        if alpha.ndim != 2:
+            raise ValueError("alpha needs to be two-dimensional")
+
+        if alpha.shape != data.shape[1:]:
+            raise ValueError("alpha layer shape {alpha.shape} does not match data spatial shape {data.shape[1:]}")
+
+        alpha = alpha.copy()
+
+    alpha[np.any(np.isnan(data), axis=0)] = 0
+
     data = np.nan_to_num(data)
 
     if data.shape[0] == 3:
@@ -344,7 +352,6 @@ def as_transparent_rgb(data, footprint=None):
     else:
         array[...] = data
 
-    valid = (footprint > 0).max(axis=0)
-    array[3, ~valid] = 0
+    array[3] = array[3] * alpha
 
     return Image.fromarray(array.transpose(1, 2, 0)[::-1])


### PR DESCRIPTION
This removed the short-lived ``return_type='pil_image'`` (never released) because it's a bit ambiguous how we should handle the footprint, and it would make more sense for users to decide how they want to construct an RGB image with the output. We can still use RGB images with AVM as input though. I've also removed ``as_rgb_images`` which is not needed anymore.

Closes https://github.com/astropy/reproject/issues/523