### PR TITLE
Fix formatting of authors and add @Cadair and @svank

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,11 @@
 [project]
 name = "reproject"
 authors = [
-    {name = "Thomas Robitaille", email = "thomas.robitaille@gmail.com"},
+    {name = "Thomas Robitaille"},
     {name = "Christoph Deil"},
     {name = "Adam Ginsburg"},
+    {name = "Stuart Mumford"},
+    {name = "Sam Van Kooten"}
 ]
 license = {text = "BSD 3-Clause"}
 description = "Reproject astronomical images"


### PR DESCRIPTION
For some reason the version with email was getting transformed to:

```
Author: Christoph Deil, Adam Ginsburg
Author-email: Thomas Robitaille <thomas.robitaille@gmail.com>
```

who knows :shrug: