### PR TITLE
Add brief example of north-aligning an image to quickstart

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -116,13 +116,13 @@ now in the same projection:
 
    fits.writeto('msx_on_2mass_header.fits', array, hdu1.header, overwrite=True)
 
-Separately, using the :func:`~reproject.reproject_interp` together with the 
-:func:`~reproject.mosaicking.find_optimal_celestial_wcs` function, we could rotate 
+Separately, using the :func:`~reproject.reproject_interp` together with the
+:func:`~reproject.mosaicking.find_optimal_celestial_wcs` function, we could rotate
 an image to align it such that North is up:
 
 .. plot::
    :include-source:
-   :nofigs:   
+   :nofigs:
    :context:
 
    from reproject.mosaicking import find_optimal_celestial_wcs


### PR DESCRIPTION
Adds a small example to the quickstart in the docs on using `reproject.mosaicking.find_optimal_celestial_wcs` and `reproject.reproject_interp` to north-align an image. A longer discussion of this capability is [here in the docs](https://reproject.readthedocs.io/en/stable/mosaicking.html#coordinate-system); this PR just tries to make that functionality more discoverable.

Closes #181 