### PR TITLE
Improve accuracy for high-resolution images in reproject_exact

### DIFF
--- a/reproject/spherical_intersect/core.py
+++ b/reproject/spherical_intersect/core.py
@@ -25,16 +25,16 @@ def _reproject_celestial(
     if output_footprint is None:
         output_footprint = np.empty(shape_out)
 
-    # There are precision issues below certain resolutions due to the
-    # TOLERANCE constant in the overlap area C code. For more details, see:
-    # https://github.com/astropy/reproject/issues/199
-    area_threshold = (1e-3 / 3600) ** 2
+    # There may be precision issues at extremely small resolutions due to
+    # floating-point limits in WCS coordinate transformations. For more
+    # details, see: https://github.com/astropy/reproject/issues/199
+    area_threshold = (1e-6 / 3600) ** 2
     if (isinstance(wcs_in, WCS) and proj_plane_pixel_area(wcs_in) < area_threshold) or (
         isinstance(wcs_out, WCS) and proj_plane_pixel_area(wcs_out) < area_threshold
     ):
         warnings.warn(
-            "The reproject_exact function currently has precision "
-            "issues with images that have resolutions below ~0.001 "
+            "The reproject_exact function may have precision "
+            "issues with images that have resolutions below ~1e-6 "
             "arcsec, so the results may not be accurate.",
             UserWarning,
             stacklevel=2,

--- a/reproject/spherical_intersect/core.py
+++ b/reproject/spherical_intersect/core.py
@@ -25,16 +25,16 @@ def _reproject_celestial(
     if output_footprint is None:
         output_footprint = np.empty(shape_out)
 
-    # There are currently precision issues below certain resolutions, so we
-    # emit a warning if this is the case. For more details, see:
+    # There are precision issues below certain resolutions due to the
+    # TOLERANCE constant in the overlap area C code. For more details, see:
     # https://github.com/astropy/reproject/issues/199
-    area_threshold = (0.05 / 3600) ** 2
+    area_threshold = (1e-3 / 3600) ** 2
     if (isinstance(wcs_in, WCS) and proj_plane_pixel_area(wcs_in) < area_threshold) or (
         isinstance(wcs_out, WCS) and proj_plane_pixel_area(wcs_out) < area_threshold
     ):
         warnings.warn(
             "The reproject_exact function currently has precision "
-            "issues with images that have resolutions below ~0.05 "
+            "issues with images that have resolutions below ~0.001 "
             "arcsec, so the results may not be accurate.",
             UserWarning,
             stacklevel=2,

--- a/reproject/spherical_intersect/overlapArea.c
+++ b/reproject/spherical_intersect/overlapArea.c
@@ -254,9 +254,10 @@ double computeOverlap(double *ilon, double *ilat, double *olon, double *olat,
     }
 
     // For unit vectors, |V - C|^2 = 2(1 - cos(theta)) ~ theta^2.
-    // Threshold of 1e-6 corresponds to theta ~ 1e-3 rad (~3.4 arcmin),
-    // where the planar approximation error is ~1e-6 relative.
-    if (max_dist_sq < 1e-6) {
+    // Threshold of 1e-8 corresponds to theta ~ 1e-4 rad (~20 arcsec),
+    // the crossover point where the planar approximation becomes more
+    // accurate than Girard's theorem in double precision.
+    if (max_dist_sq < 1e-8) {
       Vec east, north;
       double px[4], py[4], qx[4], qy[4];
       double ox[16], oy[16];
@@ -1126,7 +1127,7 @@ double Girard(int nv, Vec *V) {
     // For unit vectors, |V - C|^2 = 2(1 - cos(theta)) ~ theta^2 for small
     // theta. Threshold of 1e-6 corresponds to theta ~ 1e-3 rad (~3.4 arcmin),
     // where the planar approximation error is ~1e-6 relative.
-    if (max_dist_sq < 1e-6) {
+    if (max_dist_sq < 1e-8) {
       Vec east, north;
       double px[16], py[16];
 

--- a/reproject/spherical_intersect/overlapArea.c
+++ b/reproject/spherical_intersect/overlapArea.c
@@ -919,6 +919,77 @@ double Girard(int nv, Vec *V) {
   if (nv < 3)
     return 0;
 
+  // For very small polygons, Girard's theorem suffers from catastrophic
+  // cancellation: area = sum_of_angles - (N-2)*pi, and for tiny polygons
+  // the sum is extremely close to (N-2)*pi. Instead, project onto a local
+  // tangent plane and use the shoelace formula (planar approximation).
+
+  {
+    Vec centroid;
+    double max_dist_sq, dx, dy, dz, dist_sq;
+
+    centroid.x = centroid.y = centroid.z = 0;
+    for (i = 0; i < nv; ++i) {
+      centroid.x += V[i].x;
+      centroid.y += V[i].y;
+      centroid.z += V[i].z;
+    }
+    Normalize(&centroid);
+
+    max_dist_sq = 0;
+    for (i = 0; i < nv; ++i) {
+      dx = V[i].x - centroid.x;
+      dy = V[i].y - centroid.y;
+      dz = V[i].z - centroid.z;
+      dist_sq = dx * dx + dy * dy + dz * dz;
+      if (dist_sq > max_dist_sq)
+        max_dist_sq = dist_sq;
+    }
+
+    // For unit vectors, |V - C|^2 = 2(1 - cos(theta)) ~ theta^2 for small
+    // theta. Threshold of 1e-6 corresponds to theta ~ 1e-3 rad (~3.4 arcmin),
+    // where the planar approximation error is ~1e-6 relative.
+    if (max_dist_sq < 1e-6) {
+      Vec east, north;
+      double px[16], py[16];
+
+      // Build orthonormal basis on tangent plane at centroid
+      if (fabs(centroid.z) < 0.9) {
+        east.x = -centroid.y;
+        east.y = centroid.x;
+        east.z = 0.0;
+      } else {
+        east.x = 0.0;
+        east.y = centroid.z;
+        east.z = -centroid.y;
+      }
+      Normalize(&east);
+
+      Cross(&centroid, &east, &north);
+      Normalize(&north);
+
+      for (i = 0; i < nv; ++i) {
+        px[i] = Dot(&V[i], &east);
+        py[i] = Dot(&V[i], &north);
+      }
+
+      area = 0.0;
+      for (i = 0; i < nv; ++i) {
+        j = (i + 1) % nv;
+        area += px[i] * py[j] - px[j] * py[i];
+      }
+      area = fabs(area) / 2.0;
+
+      if (DEBUG >= 4) {
+        printf("\nGirard(): using planar approximation, area = %13.6e [%d]\n\n",
+               area, nv);
+        fflush(stdout);
+      }
+
+      return area;
+    }
+  }
+
   for (i = 0; i < nv; ++i) {
     Normalize(&side[i]);
   }

--- a/reproject/spherical_intersect/overlapArea.c
+++ b/reproject/spherical_intersect/overlapArea.c
@@ -110,6 +110,80 @@ static void ensureCCW2D(double *x, double *y, int n) {
 }
 
 /*
+ * Build an orthonormal tangent plane basis at a point on the unit sphere,
+ * then project vertices onto that plane.
+ *
+ * center: unit vector defining the tangent point
+ * V:      array of nv unit vectors to project
+ * nv:     number of vertices
+ * px, py: output arrays for the 2D projected coordinates (must have room for nv)
+ */
+static void projectToTangentPlane(Vec *center, Vec *V, int nv,
+                                  double *px, double *py) {
+  int i;
+  Vec east, north;
+
+  if (fabs(center->z) < 0.9) {
+    east.x = -center->y;
+    east.y = center->x;
+    east.z = 0.0;
+  } else {
+    east.x = 0.0;
+    east.y = center->z;
+    east.z = -center->y;
+  }
+  Normalize(&east);
+  Cross(center, &east, &north);
+  Normalize(&north);
+
+  for (i = 0; i < nv; ++i) {
+    px[i] = Dot(&V[i], &east);
+    py[i] = Dot(&V[i], &north);
+  }
+}
+
+/*
+ * Check if all vertices are close enough to use the planar approximation,
+ * and if so, compute the polygon area via tangent plane projection + shoelace.
+ * Returns 1 if the planar path was used (result stored in *area), 0 otherwise.
+ */
+static int planarArea(int nv, Vec *V, double *area) {
+  int i;
+  Vec centroid;
+  double max_dist_sq, dx, dy, dz, d2;
+  double px[16], py[16];
+
+  centroid.x = centroid.y = centroid.z = 0;
+  for (i = 0; i < nv; ++i) {
+    centroid.x += V[i].x;
+    centroid.y += V[i].y;
+    centroid.z += V[i].z;
+  }
+  Normalize(&centroid);
+
+  max_dist_sq = 0;
+  for (i = 0; i < nv; ++i) {
+    dx = V[i].x - centroid.x;
+    dy = V[i].y - centroid.y;
+    dz = V[i].z - centroid.z;
+    d2 = dx * dx + dy * dy + dz * dz;
+    if (d2 > max_dist_sq)
+      max_dist_sq = d2;
+  }
+
+  // For unit vectors, |V - C|^2 = 2(1 - cos(theta)) ~ theta^2.
+  // Threshold of 1e-8 corresponds to theta ~ 1e-4 rad (~20 arcsec),
+  // the crossover point where the planar approximation becomes more
+  // accurate than Girard's theorem in double precision.
+  if (max_dist_sq >= 1e-8)
+    return 0;
+
+  projectToTangentPlane(&centroid, V, nv, px, py);
+  *area = polyArea2D(px, py, nv);
+  return 1;
+}
+
+/*
  * Sutherland-Hodgman polygon clipping in 2D.
  * Clips subject polygon (sx, sy, sn) against clip polygon (cx, cy, cn).
  * Both must be convex and counter-clockwise.
@@ -226,62 +300,39 @@ double computeOverlap(double *ilon, double *ilat, double *olon, double *olat,
   // suffer from numerical precision loss. Instead, project onto a local
   // tangent plane and do the entire overlap computation in 2D.
   {
+    Vec all[8];
     Vec centroid;
     double max_dist_sq, dx, dy, dz, d2;
 
-    centroid.x = centroid.y = centroid.z = 0;
     for (i = 0; i < 4; ++i) {
-      centroid.x += P[i].x + Q[i].x;
-      centroid.y += P[i].y + Q[i].y;
-      centroid.z += P[i].z + Q[i].z;
+      all[i] = P[i];
+      all[i + 4] = Q[i];
+    }
+    centroid.x = centroid.y = centroid.z = 0;
+    for (i = 0; i < 8; ++i) {
+      centroid.x += all[i].x;
+      centroid.y += all[i].y;
+      centroid.z += all[i].z;
     }
     Normalize(&centroid);
 
     max_dist_sq = 0;
-    for (i = 0; i < 4; ++i) {
-      dx = P[i].x - centroid.x;
-      dy = P[i].y - centroid.y;
-      dz = P[i].z - centroid.z;
-      d2 = dx * dx + dy * dy + dz * dz;
-      if (d2 > max_dist_sq)
-        max_dist_sq = d2;
-      dx = Q[i].x - centroid.x;
-      dy = Q[i].y - centroid.y;
-      dz = Q[i].z - centroid.z;
+    for (i = 0; i < 8; ++i) {
+      dx = all[i].x - centroid.x;
+      dy = all[i].y - centroid.y;
+      dz = all[i].z - centroid.z;
       d2 = dx * dx + dy * dy + dz * dz;
       if (d2 > max_dist_sq)
         max_dist_sq = d2;
     }
 
-    // For unit vectors, |V - C|^2 = 2(1 - cos(theta)) ~ theta^2.
-    // Threshold of 1e-8 corresponds to theta ~ 1e-4 rad (~20 arcsec),
-    // the crossover point where the planar approximation becomes more
-    // accurate than Girard's theorem in double precision.
     if (max_dist_sq < 1e-8) {
-      Vec east, north;
       double px[4], py[4], qx[4], qy[4];
       double ox[16], oy[16];
       int noverlap;
 
-      if (fabs(centroid.z) < 0.9) {
-        east.x = -centroid.y;
-        east.y = centroid.x;
-        east.z = 0.0;
-      } else {
-        east.x = 0.0;
-        east.y = centroid.z;
-        east.z = -centroid.y;
-      }
-      Normalize(&east);
-      Cross(&centroid, &east, &north);
-      Normalize(&north);
-
-      for (i = 0; i < 4; ++i) {
-        px[i] = Dot(&P[i], &east);
-        py[i] = Dot(&P[i], &north);
-        qx[i] = Dot(&Q[i], &east);
-        qy[i] = Dot(&Q[i], &north);
-      }
+      projectToTangentPlane(&centroid, P, 4, px, py);
+      projectToTangentPlane(&centroid, Q, 4, qx, qy);
 
       ensureCCW2D(px, py, 4);
       ensureCCW2D(qx, qy, 4);
@@ -1102,71 +1153,13 @@ double Girard(int nv, Vec *V) {
   // the sum is extremely close to (N-2)*pi. Instead, project onto a local
   // tangent plane and use the shoelace formula (planar approximation).
 
-  {
-    Vec centroid;
-    double max_dist_sq, dx, dy, dz, dist_sq;
-
-    centroid.x = centroid.y = centroid.z = 0;
-    for (i = 0; i < nv; ++i) {
-      centroid.x += V[i].x;
-      centroid.y += V[i].y;
-      centroid.z += V[i].z;
+  if (planarArea(nv, V, &area)) {
+    if (DEBUG >= 4) {
+      printf("\nGirard(): using planar approximation, area = %13.6e [%d]\n\n",
+             area, nv);
+      fflush(stdout);
     }
-    Normalize(&centroid);
-
-    max_dist_sq = 0;
-    for (i = 0; i < nv; ++i) {
-      dx = V[i].x - centroid.x;
-      dy = V[i].y - centroid.y;
-      dz = V[i].z - centroid.z;
-      dist_sq = dx * dx + dy * dy + dz * dz;
-      if (dist_sq > max_dist_sq)
-        max_dist_sq = dist_sq;
-    }
-
-    // For unit vectors, |V - C|^2 = 2(1 - cos(theta)) ~ theta^2.
-    // Threshold of 1e-8 corresponds to theta ~ 1e-4 rad (~20 arcsec),
-    // the crossover point where the planar approximation becomes more
-    // accurate than Girard's theorem in double precision.
-    if (max_dist_sq < 1e-8) {
-      Vec east, north;
-      double px[16], py[16];
-
-      // Build orthonormal basis on tangent plane at centroid
-      if (fabs(centroid.z) < 0.9) {
-        east.x = -centroid.y;
-        east.y = centroid.x;
-        east.z = 0.0;
-      } else {
-        east.x = 0.0;
-        east.y = centroid.z;
-        east.z = -centroid.y;
-      }
-      Normalize(&east);
-
-      Cross(&centroid, &east, &north);
-      Normalize(&north);
-
-      for (i = 0; i < nv; ++i) {
-        px[i] = Dot(&V[i], &east);
-        py[i] = Dot(&V[i], &north);
-      }
-
-      area = 0.0;
-      for (i = 0; i < nv; ++i) {
-        j = (i + 1) % nv;
-        area += px[i] * py[j] - px[j] * py[i];
-      }
-      area = fabs(area) / 2.0;
-
-      if (DEBUG >= 4) {
-        printf("\nGirard(): using planar approximation, area = %13.6e [%d]\n\n",
-               area, nv);
-        fflush(stdout);
-      }
-
-      return area;
-    }
+    return area;
   }
 
   for (i = 0; i < nv; ++i) {

--- a/reproject/spherical_intersect/overlapArea.c
+++ b/reproject/spherical_intersect/overlapArea.c
@@ -75,6 +75,104 @@ void RemoveDups(int *nv, Vec *V);
 int printDir(char *point, char *vector, int dir);
 
 /*
+ * 2D polygon helpers for the planar approximation path.
+ */
+
+static double cross2d(double ax, double ay, double bx, double by) {
+  return ax * by - ay * bx;
+}
+
+static double polyArea2D(const double *x, const double *y, int n) {
+  int i, j;
+  double area = 0;
+  for (i = 0; i < n; ++i) {
+    j = (i + 1) % n;
+    area += x[i] * y[j] - x[j] * y[i];
+  }
+  return fabs(area) / 2.0;
+}
+
+static void ensureCCW2D(double *x, double *y, int n) {
+  int i, j;
+  double area = 0;
+  double tmp;
+  for (i = 0; i < n; ++i) {
+    j = (i + 1) % n;
+    area += x[i] * y[j] - x[j] * y[i];
+  }
+  if (area < 0) {
+    for (i = 0; i < n / 2; ++i) {
+      j = n - 1 - i;
+      tmp = x[i]; x[i] = x[j]; x[j] = tmp;
+      tmp = y[i]; y[i] = y[j]; y[j] = tmp;
+    }
+  }
+}
+
+/*
+ * Sutherland-Hodgman polygon clipping in 2D.
+ * Clips subject polygon (sx, sy, sn) against clip polygon (cx, cy, cn).
+ * Both must be convex and counter-clockwise.
+ * Returns the number of output vertices in (ox, oy).
+ */
+static int clipPolygon2D(
+    const double *sx, const double *sy, int sn,
+    const double *cx, const double *cy, int cn,
+    double *ox, double *oy) {
+  double tmpx[2][16], tmpy[2][16];
+  int cur = 0, nxt, n, nout, i, j, jnext, inext;
+  double ex, ey, s1, s2, t;
+
+  for (i = 0; i < sn; ++i) {
+    tmpx[0][i] = sx[i];
+    tmpy[0][i] = sy[i];
+  }
+  n = sn;
+
+  for (j = 0; j < cn; ++j) {
+    if (n == 0)
+      break;
+    jnext = (j + 1) % cn;
+    ex = cx[jnext] - cx[j];
+    ey = cy[jnext] - cy[j];
+    nxt = 1 - cur;
+    nout = 0;
+
+    for (i = 0; i < n; ++i) {
+      inext = (i + 1) % n;
+      s1 = cross2d(ex, ey, tmpx[cur][i] - cx[j], tmpy[cur][i] - cy[j]);
+      s2 = cross2d(ex, ey, tmpx[cur][inext] - cx[j], tmpy[cur][inext] - cy[j]);
+
+      if (s1 >= 0) {
+        tmpx[nxt][nout] = tmpx[cur][i];
+        tmpy[nxt][nout] = tmpy[cur][i];
+        ++nout;
+        if (s2 < 0) {
+          t = s1 / (s1 - s2);
+          tmpx[nxt][nout] = tmpx[cur][i] + t * (tmpx[cur][inext] - tmpx[cur][i]);
+          tmpy[nxt][nout] = tmpy[cur][i] + t * (tmpy[cur][inext] - tmpy[cur][i]);
+          ++nout;
+        }
+      } else if (s2 > 0) {
+        t = s1 / (s1 - s2);
+        tmpx[nxt][nout] = tmpx[cur][i] + t * (tmpx[cur][inext] - tmpx[cur][i]);
+        tmpy[nxt][nout] = tmpy[cur][i] + t * (tmpy[cur][inext] - tmpy[cur][i]);
+        ++nout;
+      }
+    }
+
+    cur = nxt;
+    n = nout;
+  }
+
+  for (i = 0; i < n; ++i) {
+    ox[i] = tmpx[cur][i];
+    oy[i] = tmpy[cur][i];
+  }
+  return n;
+}
+
+/*
  * Sets up the polygons, runs the overlap computation, and returns the area of overlap.
  */
 double computeOverlap(double *ilon, double *ilat, double *olon, double *olat,
@@ -122,6 +220,85 @@ double computeOverlap(double *ilon, double *ilat, double *olon, double *olat,
     Q[i].x = cos(olon[i]) * cos(olat[i]);
     Q[i].y = sin(olon[i]) * cos(olat[i]);
     Q[i].z = sin(olat[i]);
+  }
+
+  // For small pixels, the spherical intersection and Girard's theorem both
+  // suffer from numerical precision loss. Instead, project onto a local
+  // tangent plane and do the entire overlap computation in 2D.
+  {
+    Vec centroid;
+    double max_dist_sq, dx, dy, dz, d2;
+
+    centroid.x = centroid.y = centroid.z = 0;
+    for (i = 0; i < 4; ++i) {
+      centroid.x += P[i].x + Q[i].x;
+      centroid.y += P[i].y + Q[i].y;
+      centroid.z += P[i].z + Q[i].z;
+    }
+    Normalize(&centroid);
+
+    max_dist_sq = 0;
+    for (i = 0; i < 4; ++i) {
+      dx = P[i].x - centroid.x;
+      dy = P[i].y - centroid.y;
+      dz = P[i].z - centroid.z;
+      d2 = dx * dx + dy * dy + dz * dz;
+      if (d2 > max_dist_sq)
+        max_dist_sq = d2;
+      dx = Q[i].x - centroid.x;
+      dy = Q[i].y - centroid.y;
+      dz = Q[i].z - centroid.z;
+      d2 = dx * dx + dy * dy + dz * dz;
+      if (d2 > max_dist_sq)
+        max_dist_sq = d2;
+    }
+
+    // For unit vectors, |V - C|^2 = 2(1 - cos(theta)) ~ theta^2.
+    // Threshold of 1e-6 corresponds to theta ~ 1e-3 rad (~3.4 arcmin),
+    // where the planar approximation error is ~1e-6 relative.
+    if (max_dist_sq < 1e-6) {
+      Vec east, north;
+      double px[4], py[4], qx[4], qy[4];
+      double ox[16], oy[16];
+      int noverlap;
+
+      if (fabs(centroid.z) < 0.9) {
+        east.x = -centroid.y;
+        east.y = centroid.x;
+        east.z = 0.0;
+      } else {
+        east.x = 0.0;
+        east.y = centroid.z;
+        east.z = -centroid.y;
+      }
+      Normalize(&east);
+      Cross(&centroid, &east, &north);
+      Normalize(&north);
+
+      for (i = 0; i < 4; ++i) {
+        px[i] = Dot(&P[i], &east);
+        py[i] = Dot(&P[i], &north);
+        qx[i] = Dot(&Q[i], &east);
+        qy[i] = Dot(&Q[i], &north);
+      }
+
+      ensureCCW2D(px, py, 4);
+      ensureCCW2D(qx, qy, 4);
+
+      if (energyMode) {
+        *areaRatio = polyArea2D(px, py, 4) / refArea;
+      }
+
+      noverlap = clipPolygon2D(px, py, 4, qx, qy, 4, ox, oy);
+
+      if (DEBUG >= 4) {
+        printf("computeOverlap(): using planar approximation, "
+               "noverlap = %d\n", noverlap);
+        fflush(stdout);
+      }
+
+      return polyArea2D(ox, oy, noverlap);
+    }
   }
 
   EnsureCounterClockWise(P);

--- a/reproject/spherical_intersect/overlapArea.c
+++ b/reproject/spherical_intersect/overlapArea.c
@@ -1124,9 +1124,10 @@ double Girard(int nv, Vec *V) {
         max_dist_sq = dist_sq;
     }
 
-    // For unit vectors, |V - C|^2 = 2(1 - cos(theta)) ~ theta^2 for small
-    // theta. Threshold of 1e-6 corresponds to theta ~ 1e-3 rad (~3.4 arcmin),
-    // where the planar approximation error is ~1e-6 relative.
+    // For unit vectors, |V - C|^2 = 2(1 - cos(theta)) ~ theta^2.
+    // Threshold of 1e-8 corresponds to theta ~ 1e-4 rad (~20 arcsec),
+    // the crossover point where the planar approximation becomes more
+    // accurate than Girard's theorem in double precision.
     if (max_dist_sq < 1e-8) {
       Vec east, north;
       double px[16], py[16];

--- a/reproject/spherical_intersect/tests/test_high_level.py
+++ b/reproject/spherical_intersect/tests/test_high_level.py
@@ -75,7 +75,7 @@ def test_identity():
 
 
 def test_reproject_precision_warning():
-    for res in [0.1 / 3600, 0.01 / 3600, 1e-4 / 3600]:
+    for res in [0.1 / 3600, 0.01 / 3600, 1e-4 / 3600, 1e-7 / 3600]:
         wcs1 = WCS()
         wcs1.wcs.ctype = "RA---TAN", "DEC--TAN"
         wcs1.wcs.crval = 13, 80

--- a/reproject/spherical_intersect/tests/test_high_level.py
+++ b/reproject/spherical_intersect/tests/test_high_level.py
@@ -100,8 +100,11 @@ def test_reproject_precision_warning():
             assert len(w) == 0
 
 
-@pytest.mark.parametrize("res", [0.01, 0.001, 1e-4])
-def test_reproject_flux_conservation(res):
+@pytest.mark.parametrize(
+    "res,rtol",
+    [(0.01, 1e-6), (0.001, 1e-6), (1e-4, 1e-6), (1e-5, 1e-4)],
+)
+def test_reproject_flux_conservation(res, rtol):
     """Regression test for https://github.com/astropy/reproject/issues/199"""
     res = res / 3600  # convert to degrees
 
@@ -123,8 +126,9 @@ def test_reproject_flux_conservation(res):
     result, _ = reproject_exact((array, wcs1), wcs2, shape_out=(5, 5))
 
     # The output pixel area is 9x the input, so the ratio of sums
-    # should be 1/9.
-    assert_allclose(9 * np.nansum(result), np.nansum(array), rtol=1e-4)
+    # should be 1/9. Tolerance is looser at extreme resolutions due to
+    # floating-point limits in WCS coordinate transformations.
+    assert_allclose(9 * np.nansum(result), np.nansum(array), rtol=rtol)
 
 
 def _setup_for_broadcast_test():

--- a/reproject/spherical_intersect/tests/test_high_level.py
+++ b/reproject/spherical_intersect/tests/test_high_level.py
@@ -51,9 +51,9 @@ class TestReprojectExact:
             (self.array_in, self.header_in), self.header_out, parallel=4
         )
 
-        np.testing.assert_allclose(array1, array2, rtol=1.0e-5)
+        np.testing.assert_allclose(array1, array2, rtol=1.0e-10)
 
-        np.testing.assert_allclose(footprint1, footprint2, rtol=3.0e-5)
+        np.testing.assert_allclose(footprint1, footprint2, rtol=1.0e-10)
 
 
 def test_identity():
@@ -102,7 +102,7 @@ def test_reproject_precision_warning():
 
 @pytest.mark.parametrize(
     "res,rtol",
-    [(0.01, 1e-6), (0.001, 1e-6), (1e-4, 1e-6), (1e-5, 1e-4)],
+    [(0.01, 1e-7), (0.001, 1e-7), (1e-4, 1e-6), (1e-5, 5e-5)],
 )
 def test_reproject_flux_conservation(res, rtol):
     """Regression test for https://github.com/astropy/reproject/issues/199"""

--- a/reproject/spherical_intersect/tests/test_high_level.py
+++ b/reproject/spherical_intersect/tests/test_high_level.py
@@ -75,7 +75,7 @@ def test_identity():
 
 
 def test_reproject_precision_warning():
-    for res in [0.1 / 3600, 0.01 / 3600]:
+    for res in [0.1 / 3600, 0.01 / 3600, 1e-4 / 3600]:
         wcs1 = WCS()
         wcs1.wcs.ctype = "RA---TAN", "DEC--TAN"
         wcs1.wcs.crval = 13, 80
@@ -91,7 +91,7 @@ def test_reproject_precision_warning():
         array = np.zeros((19, 19))
         array[9, 9] = 1
 
-        if res < 0.05 / 3600:
+        if res < 1e-3 / 3600:
             with pytest.warns(
                 UserWarning, match="The reproject_exact function currently has precision"
             ):
@@ -100,6 +100,33 @@ def test_reproject_precision_warning():
             with warnings.catch_warnings(record=True) as w:
                 reproject_exact((array, wcs1), wcs2, shape_out=(5, 5))
             assert len(w) == 0
+
+
+@pytest.mark.parametrize("res", [0.01, 0.001])
+def test_reproject_flux_conservation(res):
+    """Regression test for https://github.com/astropy/reproject/issues/199"""
+    res = res / 3600  # convert to degrees
+
+    wcs1 = WCS(naxis=2)
+    wcs1.wcs.ctype = "RA---TAN", "DEC--TAN"
+    wcs1.wcs.crval = 13, 20
+    wcs1.wcs.crpix = 10.0, 10.0
+    wcs1.wcs.cdelt = res, res
+
+    wcs2 = WCS(naxis=2)
+    wcs2.wcs.ctype = "RA---TAN", "DEC--TAN"
+    wcs2.wcs.crval = 13, 20
+    wcs2.wcs.crpix = 3, 3
+    wcs2.wcs.cdelt = 3 * res, 3 * res
+
+    array = np.zeros((19, 19))
+    array[9, 9] = 1
+
+    result, _ = reproject_exact((array, wcs1), wcs2, shape_out=(5, 5))
+
+    # The output pixel area is 9x the input, so the ratio of sums
+    # should be 1/9.
+    assert_allclose(9 * np.nansum(result), np.nansum(array), rtol=1e-4)
 
 
 def _setup_for_broadcast_test():

--- a/reproject/spherical_intersect/tests/test_high_level.py
+++ b/reproject/spherical_intersect/tests/test_high_level.py
@@ -91,10 +91,8 @@ def test_reproject_precision_warning():
         array = np.zeros((19, 19))
         array[9, 9] = 1
 
-        if res < 1e-3 / 3600:
-            with pytest.warns(
-                UserWarning, match="The reproject_exact function currently has precision"
-            ):
+        if res < 1e-6 / 3600:
+            with pytest.warns(UserWarning, match="The reproject_exact function may have precision"):
                 reproject_exact((array, wcs1), wcs2, shape_out=(5, 5))
         else:
             with warnings.catch_warnings(record=True) as w:
@@ -102,7 +100,7 @@ def test_reproject_precision_warning():
             assert len(w) == 0
 
 
-@pytest.mark.parametrize("res", [0.01, 0.001])
+@pytest.mark.parametrize("res", [0.01, 0.001, 1e-4])
 def test_reproject_flux_conservation(res):
     """Regression test for https://github.com/astropy/reproject/issues/199"""
     res = res / 3600  # convert to degrees

--- a/reproject/spherical_intersect/tests/test_overlap.py
+++ b/reproject/spherical_intersect/tests/test_overlap.py
@@ -10,8 +10,8 @@ def test_full_overlap():
     EPS = np.radians(1e-2)
     lon, lat = np.array([[0, EPS, EPS, 0]]), np.array([[0, 0, EPS, EPS]])
     overlap, area_ratio = compute_overlap(lon, lat, lon, lat)
-    np.testing.assert_allclose(overlap, EPS**2, rtol=1e-6)
-    np.testing.assert_allclose(area_ratio, 1, rtol=1e-6)
+    np.testing.assert_allclose(overlap, EPS**2, rtol=1e-7)
+    np.testing.assert_allclose(area_ratio, 1, rtol=1e-7)
 
 
 def test_partial_overlap():
@@ -22,8 +22,8 @@ def test_partial_overlap():
     olat = np.array([[0, 0, EPS, EPS]])
 
     overlap, area_ratio = compute_overlap(ilon, ilat, olon, olat)
-    np.testing.assert_allclose(overlap, 0.5 * EPS**2, rtol=1e-6)
-    np.testing.assert_allclose(area_ratio, 1, rtol=1e-6)
+    np.testing.assert_allclose(overlap, 0.5 * EPS**2, rtol=1e-7)
+    np.testing.assert_allclose(area_ratio, 1, rtol=1e-7)
 
 
 @pytest.mark.parametrize(("clockwise1", "clockwise2"), product([False, True], [False, True]))
@@ -44,5 +44,5 @@ def test_overlap_direction(clockwise1, clockwise2):
         olon, olat = olon[:, ::-1], olat[:, ::-1]
 
     overlap, area_ratio = compute_overlap(ilon, ilat, olon, olat)
-    np.testing.assert_allclose(overlap, 0.5 * EPS**2, rtol=1e-6)
-    np.testing.assert_allclose(area_ratio, 1, rtol=1e-6)
+    np.testing.assert_allclose(overlap, 0.5 * EPS**2, rtol=1e-7)
+    np.testing.assert_allclose(area_ratio, 1, rtol=1e-7)

--- a/reproject/spherical_intersect/tests/test_reproject.py
+++ b/reproject/spherical_intersect/tests/test_reproject.py
@@ -104,8 +104,8 @@ def test_reproject_flipping():
     array3, footprint3 = _reproject_celestial(DATA, wcs_in, wcs_out_flipped, (4, 4))
     array3, footprint3 = array3[:, ::-1], footprint3[:, ::-1]
 
-    np.testing.assert_allclose(array1, array2, rtol=1.0e-5)
-    np.testing.assert_allclose(array1, array3, rtol=1.0e-5)
+    np.testing.assert_allclose(array1, array2, rtol=1.0e-10)
+    np.testing.assert_allclose(array1, array3, rtol=1.0e-10)
 
-    np.testing.assert_allclose(footprint1, footprint2, rtol=3.0e-5)
-    np.testing.assert_allclose(footprint1, footprint3, rtol=3.0e-5)
+    np.testing.assert_allclose(footprint1, footprint2, rtol=1.0e-10)
+    np.testing.assert_allclose(footprint1, footprint3, rtol=1.0e-10)


### PR DESCRIPTION
As described in #199, the reproject_exact function suffers from precision issues when reprojecting images with sub-arcsecond pixel scales, which is particularly problematic for instruments like JWST NIRCam (0.03" pixels). There are two reasons for this: 

* Girard's theorem computes spherical polygon areas as sum_of_angles - (N-2)*π, which loses precision catastrophically when the polygon is tiny and the sum is nearly equal to (N-2)*π.
* The spherical polygon intersection algorithm in the relies on a TOLERANCE constant (~9e-4 arcsec) that causes incorrect intersection results when pixel features are smaller than this threshold.

This PR fixes both issues by adding a planar approximation path in computeOverlap. When all vertices of both the input and output pixels are within ~3.4 arcmin of their centroid, the code projects them onto a local tangent plane and performs the entire overlap computation in 2D — using Sutherland-Hodgman polygon clipping and the shoelace formula instead of the spherical intersection and Girard's theorem. This avoids all sources of precision loss, since coordinate values in the tangent plane are proportional to the polygon size rather than being tiny perturbations on a unit sphere. The same planar approximation is also applied as a fallback within the Girard function itself, to handle the edge case of tiny sliver overlaps between large pixels. With these changes, flux conservation is accurate down to ~1e-5 arcsec, compared to the previous limit of ~0.07 arcsec.

Here's an updated plot of accuracy vs resolution based on this PR:

<img width="640" height="480" alt="ratios" src="https://github.com/user-attachments/assets/e6e5638d-0469-4040-b320-e7c0ce52cc1a" />

For comparison, the original plot looked like:



![](https://user-images.githubusercontent.com/314716/67883201-8edcfb80-fb3b-11e9-948e-8c93f3993960.png)

