### PR TITLE
Upgrade PyPI CI publishing to use Trusted Publishing

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -36,7 +36,7 @@ jobs:
           - libopenblas-dev
       coverage: 'codecov'
 
-  publish:
+  build:
     needs: tests
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish.yml@2835f0cacddf3f8de198db9afdb5354a5cebe0ef  # v2.6.3
     with:
@@ -77,7 +77,7 @@ jobs:
       }}
     name: Upload release to PyPI
     runs-on: ubuntu-latest
-    needs: [publish]
+    needs: [build]
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -40,6 +40,8 @@ jobs:
     needs: tests
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish.yml@2835f0cacddf3f8de198db9afdb5354a5cebe0ef  # v2.6.3
     with:
+      upload_to_pypi: false
+      save_artifacts: true
       test_extras: test
       test_command: pytest -p no:warnings --pyargs reproject --log-cli-level=INFO
       targets: |
@@ -57,5 +59,31 @@ jobs:
       anaconda_keep_n_latest: 10
 
     secrets:
-      pypi_token: ${{ secrets.pypi_token }}
       anaconda_token: ${{ secrets.anaconda_token }}
+
+  upload:
+    permissions:
+      id-token: write
+    environment:
+      name: pypi
+      url: https://pypi.org/project/reproject
+    if: >-
+      ${{ startsWith(github.ref, 'refs/tags/v') &&
+          !endsWith(github.ref, '.dev') &&
+          (
+            github.event_name == 'push' ||
+            github.event_name == 'workflow_dispatch'
+          )
+      }}
+    name: Upload release to PyPI
+    runs-on: ubuntu-latest
+    needs: [publish]
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          merge-multiple: true
+          pattern: dist-*
+          path: dist
+      - name: Upload to PyPI
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0


### PR DESCRIPTION
- Background: https://github.com/astropy/specutils/issues/1323

Migrates PyPI publishing from a long-lived API token to [Trusted Publishing](https://docs.pypi.org/trusted-publishers/) (OIDC), motivated by recent supply chain attacks ([litellm](https://blog.pypi.org/posts/2026-04-02-incident-report-litellm-telnyx-supply-chain-attack/), [lightning](https://cybersecuritynews.com/python-package-lightning-hacked/)).

The publishing step uses [a reusable workflow](https://github.com/OpenAstronomy/github-actions-workflows/blob/v2.6.3/.github/workflows/publish.yml) from the OpenAstronomy org, and since you can't pass OIDC tokens across orgs, the workaround (documented [here](https://github-actions-workflows.openastronomy.org/en/latest/trusted_publishing.html)) is to instead set `upload_to_pypi: false` and `save_artifacts: true` then publish the stored artifact with the `pypa/gh-action-pypi` action.

- Adapted from similar PR in regions repo: https://github.com/astropy/regions/pull/661 which followed [this example](https://github.com/astropy/astropy/blob/80447a4334ba617c04d5918b66d80793f202c52e/.github/workflows/publish.yml#L77-L94) from the astropy package repo.
- :bulb: I made this repo's package build step condition consistent with the one in that repo, which was more defensive
  - It means "publish all tags starting with `v` that don't end in `.dev`, if sent via push or manual dispatch"
- :warning: note the sibling repos (regions, photutils, astropy-healpix) call this workflow `publish.yml`, only this one calls it `ci_workflows.yml`, I'd consider renaming it but have left it as-is.

```yaml
    if: >-
      ${{ startsWith(github.ref, 'refs/tags/v') &&
          !endsWith(github.ref, '.dev') &&
          (
            github.event_name == 'push' ||
            github.event_name == 'workflow_dispatch'
          )
      }}
```

The code changes here require some further (trivial) setup on the PyPI-side. Specifically, the PyPI admin (@astrofrog) needs to register the TP on PyPI at https://pypi.org/manage/project/reproject/settings/publishing/

- Owner: `astropy`
- Repo: `reproject`
- Workflow: `ci_workflows.yml`
- Environment: `pypi`

The `pypi_token` secret should be deleted from the repo secrets and can be invalidated on PyPI too.