### PR TITLE
Enable limited API builds only when building wheels for publishing

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -51,6 +51,8 @@ jobs:
         - cp*-macosx_x86_64
         - cp*-macosx_arm64
         - cp*-win_amd64
+      env: |
+        EXTENSION_HELPERS_PY_LIMITED_API: 'cp311'
 
       # Developer wheels
       upload_to_anaconda: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -203,6 +203,3 @@ lint.select = [
 
 [tool.ruff.lint.extend-per-file-ignores]
 "docs/conf.py" = ["F405"]  # Sphinx injects variables into namespace
-
-[tool.distutils.bdist_wheel]
-py-limited-api = "cp311"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ dev = [
 [build-system]
 requires = ["setuptools",
             "setuptools_scm",
-            "extension-helpers>=1.3,<2",
+            "extension-helpers>=1.4,<2",
             "numpy>=2",
             "cython>=3.1"]
 build-backend = 'setuptools.build_meta'
@@ -154,6 +154,7 @@ write_to = "reproject/version.py"
 [tool.cibuildwheel]
 skip = "cp36-* pp* *-musllinux* cp31?t-*"
 test-skip = "*-manylinux_aarch64"
+environment-pass = ["EXTENSION_HELPERS_PY_LIMITED_API"]
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
This should fix https://github.com/astropy/reproject/issues/596 and allow local free-threaded builds