### PR TITLE
Fix caplog-related failures in test_reproject_parallel_broadcasting

### DIFF
--- a/reproject/interpolation/tests/test_core.py
+++ b/reproject/interpolation/tests/test_core.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import itertools
+import logging
 
 import dask.array as da
 import numpy as np
@@ -1001,6 +1002,10 @@ def test_reproject_parallel_broadcasting(caplog, dask_method):
 
     # Unit test for reprojecting using parallelization along broadcasted
     # dimensions
+
+    # Ensure caplog captures INFO regardless of the global pytest log
+    # configuration, since this test relies on it.
+    caplog.set_level(logging.INFO, logger="reproject._common")
 
     array_in = np.ones((350, 250, 150))
     wcs_in = WCS(naxis=2)


### PR DESCRIPTION
When running ``test_reproject_parallel_broadcasting`` from outside the repo, the test failed because it was relying on:

```
log_cli_level = "INFO"
log_level = "INFO"
```

in the ``pyproject.toml`` file. This PR fixes it so that we no longer depend on the global configuration.