### PR TITLE
Give each thread its own copy of the WCS in the dask HiPS

### DIFF
--- a/reproject/hips/_dask_array.py
+++ b/reproject/hips/_dask_array.py
@@ -1,5 +1,7 @@
+import copy
 import functools
 import os
+import threading
 import urllib
 import uuid
 
@@ -140,6 +142,22 @@ class HiPSArray:
 
         self._blank = np.broadcast_to(np.nan, self.shape)
 
+        # astropy.wcs (wcslib) is not thread-safe, so when dask computes chunks
+        # in parallel each thread needs to use its own copy of the WCS.
+        self._local = threading.local()
+
+    @property
+    def _thread_wcs(self):
+        # Return a copy of the WCS that is unique to the calling thread.
+        wcs = getattr(self._local, "wcs", None)
+        if wcs is None:
+            if hasattr(self.wcs, "deepcopy"):
+                wcs = self.wcs.deepcopy()
+            else:
+                wcs = copy.deepcopy(self.wcs)
+            self._local.wcs = wcs
+        return wcs
+
     def __getitem__(self, item):
 
         for idx in range(self.ndim):
@@ -160,11 +178,14 @@ class HiPSArray:
 
         # Convert pixel coordinates to HEALPix indices
 
+        # astropy.wcs is not thread-safe, so use this thread's own WCS copy
+        wcs = self._thread_wcs
+
         if self.ndim == 2:
-            coord = self.wcs.pixel_to_world(jmid, imid)
+            coord = wcs.pixel_to_world(jmid, imid)
         else:
             kmid = 0.5 * (item[0].start + item[0].stop)
-            coord, spectral_coord = skycoord_first(self.wcs.pixel_to_world(jmid, imid, kmid))
+            coord, spectral_coord = skycoord_first(wcs.pixel_to_world(jmid, imid, kmid))
 
         if self._frame_str == "equatorial":
             lon, lat = coord.ra.deg, coord.dec.deg


### PR DESCRIPTION
We have to do this because astropy.wcs is not thread-safe for now (could be removed in future if we are ever confident about thread-safety)