### PR TITLE
Guard against NaN and division by zero in the exact overlap computation

### DIFF
--- a/reproject/spherical_intersect/overlapArea.c
+++ b/reproject/spherical_intersect/overlapArea.c
@@ -349,7 +349,12 @@ double computeOverlap(double *ilon, double *ilat, double *olon, double *olat,
         fflush(stdout);
       }
 
-      return polyArea2D(ox, oy, noverlap);
+      {
+        double parea = polyArea2D(ox, oy, noverlap);
+        if (mNaN(parea) || parea < 0.)
+          parea = 0.;
+        return parea;
+      }
     }
   }
 
@@ -1154,6 +1159,8 @@ double Girard(int nv, Vec *V) {
   // tangent plane and use the shoelace formula (planar approximation).
 
   if (planarArea(nv, V, &area)) {
+    if (mNaN(area) || area < 0.)
+      area = 0.;
     if (DEBUG >= 4) {
       printf("\nGirard(): using planar approximation, area = %13.6e [%d]\n\n",
              area, nv);

--- a/reproject/spherical_intersect/reproject_slice_c.c
+++ b/reproject/spherical_intersect/reproject_slice_c.c
@@ -1,5 +1,6 @@
 #include "overlapArea.h"
 #include "reproject_slice_c.h"
+#include "mNaN.h"
 
 #if defined(_MSC_VER)
   #define INLINE _inline
@@ -114,11 +115,15 @@ void _reproject_slice_c(int startx, int endx, int starty, int endy, int nx_out, 
                     _compute_overlap(&overlap,&area_ratio,ilon,ilat,olon,olat);
                     _compute_overlap(&original,&area_ratio,olon,olat,olon,olat);
 
-                    // Write into array_new and weights.
-                    *GETPTR2(array_new,col_new,jj,ii) += *GETPTR2(array,col_array,j,i) *
-                                                                     (overlap / original);
-
-                    *GETPTR2(weights,col_new,jj,ii) += (overlap / original);
+                    // Write into array_new and weights. Skip output pixels
+                    // whose self-overlap (original) is non-positive -- which
+                    // would divide by zero -- or where the overlap came back
+                    // non-finite; degenerate geometry otherwise injects NaN/Inf.
+                    if (original > 0. && !(mNaN(overlap))) {
+                        double frac = overlap / original;
+                        *GETPTR2(array_new,col_new,jj,ii) += *GETPTR2(array,col_array,j,i) * frac;
+                        *GETPTR2(weights,col_new,jj,ii) += frac;
+                    }
                 }
             }
         }


### PR DESCRIPTION
I've noticed some non-deterministic failures related to NaN values, so this is just a preventive fix in case it is related