### PR TITLE
Added intermediate_memmap='zarr' option which dumps to temporary zarr arrays

### DIFF
--- a/reproject/_common.py
+++ b/reproject/_common.py
@@ -129,7 +129,9 @@ def _reproject_dispatcher(
         Whether to return numpy or dask arrays or whether to dump the result to
         a zarr array on disk. If 'zarr', then the ``zarr_path`` keyword has to
         also be specified, and the function will return dask arrays constructed
-        from the zarr array.
+        from the zarr array. In this case the reprojection is always carried out
+        in blocks (using dask, on the synchronous scheduler when ``parallel`` is
+        `False`), and ``block_size`` defaults to ``'auto'`` when not specified.
     dask_method : {'memmap', 'none'}, optional
         Method to use when input array is a dask array. The methods are:
             * ``'memmap'``: write out the entire input dask array to a temporary

--- a/reproject/_common.py
+++ b/reproject/_common.py
@@ -165,11 +165,11 @@ def _reproject_dispatcher(
     if reproject_func_kwargs is None:
         reproject_func_kwargs = {}
 
-    if return_type == 'zarr':
+    if return_type == "zarr":
         if zarr_path is None:
             raise ValueError("zarr_path needs to be set if return_type is 'zarr'")
         elif os.path.exists(zarr_path):
-            raise Exception("Path {zarr_path} already exists")
+            raise ValueError(f"Path {zarr_path} already exists")
 
     # For now, we are quite restrictive in what non_reprojected_dims can
     # be, but it is designed so that if we wanted we could support more use
@@ -572,7 +572,7 @@ def _reproject_dispatcher(
 
         # We now convert the dask arrays back to Numpy arrays
 
-        if parallel or return_type == 'zarr':
+        if parallel or return_type == "zarr":
             # As discussed in https://github.com/dask/dask/issues/9556, da.store
             # will not work well in parallel mode when the destination is a
             # Numpy array. Instead, in this case we save the dask array to a zarr
@@ -581,7 +581,7 @@ def _reproject_dispatcher(
             # 'synchronous' scheduler since that is I/O limited so does not need
             # to be done in parallel.
 
-            if return_type != 'zarr':
+            if return_type != "zarr":
                 zarr_path = os.path.join(local_tmp_dir, f"{uuid.uuid4()}.zarr")
 
             logger.info(f"Computing output array directly to zarr array at {zarr_path}")
@@ -609,7 +609,7 @@ def _reproject_dispatcher(
 
             result = da.from_zarr(zarr_path)
 
-            if return_type == 'zarr':
+            if return_type == "zarr":
                 if return_footprint:
                     return result[0], result[1]
                 else:

--- a/reproject/_common.py
+++ b/reproject/_common.py
@@ -376,7 +376,7 @@ def _reproject_dispatcher(
                 "to compute the blocks concurrently)"
             )
 
-        if output_footprint is None and return_footprint and return_type != "dask":
+        if output_footprint is None and return_footprint and return_type == "numpy":
             output_footprint = np.zeros(shape_out, dtype=float)
 
         def reproject_single_block(a, array_or_path, block_info=None):

--- a/reproject/_common.py
+++ b/reproject/_common.py
@@ -70,6 +70,7 @@ def _reproject_dispatcher(
     reproject_func_kwargs=None,
     return_type=None,
     dask_method=None,
+    zarr_path=None,
 ):
     """
     Main function that handles either calling the core algorithms directly or
@@ -124,8 +125,11 @@ def _reproject_dispatcher(
         dask.distributed), set this to ``'current-scheduler'``.
     reproject_func_kwargs : dict, optional
         Keyword arguments to pass through to ``reproject_func``
-    return_type : {'numpy', 'dask' }, optional
-        Whether to return numpy or dask arrays.
+    return_type : {'numpy', 'dask', 'zarr'}, optional
+        Whether to return numpy or dask arrays or whether to dump the result to
+        a zarr array on disk. If 'zarr', then the ``zarr_path`` keyword has to
+        also be specified, and the function will return dask arrays constructed
+        from the zarr array.
     dask_method : {'memmap', 'none'}, optional
         Method to use when input array is a dask array. The methods are:
             * ``'memmap'``: write out the entire input dask array to a temporary
@@ -138,14 +142,20 @@ def _reproject_dispatcher(
               fits into memory (as this will then be faster than ``'memmap'``),
               and when the data contains more dimensions than the input WCS and
               the block_size is chosen to iterate over the extra dimensions.
+    zarr_path : str, optional
+        If return_type is 'zarr', this specifies the path to use for the zarr
+        array. This should be a non-existent path.
     """
 
     logger = logging.getLogger(__name__)
 
     if return_type is None:
         return_type = "numpy"
-    elif return_type not in ("numpy", "dask"):
-        raise ValueError("return_type should be set to 'numpy' or 'dask'")
+    elif return_type not in ("numpy", "dask", "zarr"):
+        raise ValueError("return_type should be set to 'numpy', 'dask', or 'zarr'")
+
+    if return_type == "zarr" and block_size is None:
+        block_size = "auto"
 
     if dask_method is None:
         dask_method = "memmap"
@@ -154,6 +164,12 @@ def _reproject_dispatcher(
 
     if reproject_func_kwargs is None:
         reproject_func_kwargs = {}
+
+    if return_type == 'zarr':
+        if zarr_path is None:
+            raise ValueError("zarr_path needs to be set if return_type is 'zarr'")
+        elif os.path.exists(zarr_path):
+            raise Exception("Path {zarr_path} already exists")
 
     # For now, we are quite restrictive in what non_reprojected_dims can
     # be, but it is designed so that if we wanted we could support more use
@@ -204,7 +220,7 @@ def _reproject_dispatcher(
 
     with tempfile.TemporaryDirectory() as local_tmp_dir:
         if array_out is None:
-            if return_type != "dask":
+            if return_type == "numpy":
                 array_out = np.zeros(shape_out, dtype=float)
         elif array_out.shape != tuple(shape_out):
             raise ValueError(
@@ -227,9 +243,9 @@ def _reproject_dispatcher(
             # If a dask array was passed as input, we first convert this to a
             # Numpy memory mapped array
 
-            if return_type == "dask":
+            if return_type in ("dask", "zarr"):
                 raise ValueError(
-                    "Output cannot be returned as dask arrays "
+                    "Output cannot be returned as dask or zarr arrays "
                     "when parallel=False and no block size has "
                     "been specified"
                 )
@@ -556,7 +572,7 @@ def _reproject_dispatcher(
 
         # We now convert the dask arrays back to Numpy arrays
 
-        if parallel:
+        if parallel or return_type == 'zarr':
             # As discussed in https://github.com/dask/dask/issues/9556, da.store
             # will not work well in parallel mode when the destination is a
             # Numpy array. Instead, in this case we save the dask array to a zarr
@@ -565,11 +581,15 @@ def _reproject_dispatcher(
             # 'synchronous' scheduler since that is I/O limited so does not need
             # to be done in parallel.
 
-            zarr_path = os.path.join(local_tmp_dir, f"{uuid.uuid4()}.zarr")
+            if return_type != 'zarr':
+                zarr_path = os.path.join(local_tmp_dir, f"{uuid.uuid4()}.zarr")
 
             logger.info(f"Computing output array directly to zarr array at {zarr_path}")
 
-            if parallel == "current-scheduler":
+            if not parallel:
+                with dask.config.set(scheduler="synchronous"):
+                    result.to_zarr(zarr_path)
+            elif parallel == "current-scheduler":
                 # Just use whatever is the current active scheduler, which can
                 # be used for e.g. dask.distributed
                 result.to_zarr(zarr_path)
@@ -588,6 +608,12 @@ def _reproject_dispatcher(
                     result.to_zarr(zarr_path)
 
             result = da.from_zarr(zarr_path)
+
+            if return_type == 'zarr':
+                if return_footprint:
+                    return result[0], result[1]
+                else:
+                    return result[0]
 
         logger.info("Copying output zarr array into output Numpy arrays")
 

--- a/reproject/adaptive/_high_level.py
+++ b/reproject/adaptive/_high_level.py
@@ -224,8 +224,13 @@ def reproject_adaptive(
         by ``block_size`` (if the block size is not set, it will be determined
         automatically). To use the currently active dask scheduler (e.g.
         dask.distributed), set this to ``'current-scheduler'``.
-    return_type : {'numpy', 'dask'}, optional
-        Whether to return numpy or dask arrays.
+    return_type : {'numpy', 'dask', 'zarr'}, optional
+        Whether to return numpy or dask arrays, or to write the output to a zarr
+        array on disk. If ``'zarr'``, ``zarr_path`` must also be given; the
+        output is then computed in blocks (using dask, on the synchronous
+        scheduler when ``parallel`` is `False`), ``block_size`` defaults to
+        ``'auto'`` when not specified, and dask arrays backed by the zarr array
+        are returned.
     dask_method : {'memmap', 'none'}, optional
         Method to use when input array is a dask array. The methods are:
             * ``'memmap'``: write out the entire input dask array to a temporary
@@ -238,6 +243,9 @@ def reproject_adaptive(
               fits into memory (as this will then be faster than ``'memmap'``),
               and when the data contains more dimensions than the input WCS and
               the block_size is chosen to iterate over the extra dimensions.
+    zarr_path : str, optional
+        Path to use for the output zarr array when ``return_type='zarr'``. This
+        must be a path that does not already exist.
 
     Returns
     -------

--- a/reproject/adaptive/_high_level.py
+++ b/reproject/adaptive/_high_level.py
@@ -34,6 +34,7 @@ def reproject_adaptive(
     parallel=False,
     return_type=None,
     dask_method=None,
+    zarr_path=None,
 ):
     """
     Reproject a 2D array from one WCS to another using the DeForest (2004)
@@ -285,4 +286,5 @@ def reproject_adaptive(
         ),
         return_type=return_type,
         dask_method=dask_method,
+        zarr_path=zarr_path,
     )

--- a/reproject/interpolation/_high_level.py
+++ b/reproject/interpolation/_high_level.py
@@ -120,8 +120,13 @@ def reproject_interp(
         by ``block_size`` (if the block size is not set, it will be determined
         automatically). To use the currently active dask scheduler (e.g.
         dask.distributed), set this to ``'current-scheduler'``.
-    return_type : {'numpy', 'dask'}, optional
-        Whether to return numpy or dask arrays.
+    return_type : {'numpy', 'dask', 'zarr'}, optional
+        Whether to return numpy or dask arrays, or to write the output to a zarr
+        array on disk. If ``'zarr'``, ``zarr_path`` must also be given; the
+        output is then computed in blocks (using dask, on the synchronous
+        scheduler when ``parallel`` is `False`), ``block_size`` defaults to
+        ``'auto'`` when not specified, and dask arrays backed by the zarr array
+        are returned.
     dask_method : {'memmap', 'none'}, optional
         Method to use when input array is a dask array. The methods are:
             * ``'memmap'``: write out the entire input dask array to a temporary
@@ -129,6 +134,9 @@ def reproject_interp(
               the entire input array.
             * ``'none'`` (default): use native dask interpolation, which avoids
               having to write the array to disk.
+    zarr_path : str, optional
+        Path to use for the output zarr array when ``return_type='zarr'``. This
+        must be a path that does not already exist.
 
     Returns
     -------

--- a/reproject/interpolation/_high_level.py
+++ b/reproject/interpolation/_high_level.py
@@ -29,6 +29,7 @@ def reproject_interp(
     parallel=False,
     return_type=None,
     dask_method=None,
+    zarr_path=None,
 ):
     """
     Reproject data to a new projection using interpolation (this is typically
@@ -170,4 +171,5 @@ def reproject_interp(
         ),
         return_type=return_type,
         dask_method=dask_method,
+        zarr_path=zarr_path,
     )

--- a/reproject/interpolation/tests/test_core.py
+++ b/reproject/interpolation/tests/test_core.py
@@ -977,7 +977,7 @@ def test_auto_block_size(dask_method):
     wcs_out = WCS(naxis=2)
 
     # When block size and parallel aren't specified, can't return as dask arrays
-    with pytest.raises(ValueError, match="Output cannot be returned as dask arrays"):
+    with pytest.raises(ValueError, match="Output cannot be returned as dask or zarr arrays"):
         reproject_interp(
             (array_in, wcs_in),
             wcs_out,

--- a/reproject/mosaicking/_coadd.py
+++ b/reproject/mosaicking/_coadd.py
@@ -317,6 +317,8 @@ def _combine_tile_pieces(
         if combine_function == "mean":
             output_array /= np.where(output_footprint == 0, 1, output_footprint)
 
+    # Parse the output projection to avoid having to do it for each
+
     # Match the return_type='numpy' path's final step: set pixels with no
     # coverage to the blank value (only where the summed footprint is exactly
     # zero, keeping pixels with a negative summed footprint).
@@ -671,7 +673,15 @@ def _coadd_numpy(
             # able to handle weights, and make the footprint become the combined
             # footprint + weight map
 
-            if intermediate_memmap:
+            extra_kwargs = {}
+            array = footprint = None
+
+            if intermediate_memmap == 'zarr':
+
+                extra_kwargs['return_type'] = 'zarr'
+                extra_kwargs['zarr_path'] = os.path.join(local_tmp_dir, f"array_{uuid.uuid4()}.zarr")
+
+            elif intermediate_memmap:
 
                 array_path = os.path.join(local_tmp_dir, f"array_{uuid.uuid4()}.np")
 
@@ -716,11 +726,20 @@ def _coadd_numpy(
                 output_footprint=footprint,
                 block_size=cutout.block_size,
                 **reproject_kwargs,
+                **extra_kwargs,
             )
 
             if cutout.weights_in is not None:
 
-                if intermediate_memmap:
+                extra_kwargs = {}
+                weights = None
+
+                if intermediate_memmap == 'zarr':
+
+                    extra_kwargs['return_type'] = 'zarr'
+                    extra_kwargs['zarr_path'] = os.path.join(local_tmp_dir, f"weights_{uuid.uuid4()}.zarr")
+
+                elif intermediate_memmap:
 
                     weights_path = os.path.join(local_tmp_dir, f"weights_{uuid.uuid4()}.np")
 
@@ -735,10 +754,6 @@ def _coadd_numpy(
                         dtype=float,
                     )
 
-                else:
-
-                    weights = None
-
                 logger.info(
                     f"Calling {reproject_function.__name__} with shape_out={cutout.shape_out_indiv} for weights"
                 )
@@ -752,6 +767,7 @@ def _coadd_numpy(
                     block_size=cutout.block_size,
                     return_footprint=False,
                     **reproject_kwargs,
+                    **extra_kwargs,
                 )
 
             # For the purposes of mosaicking, we mask out NaN values from the array
@@ -773,7 +789,7 @@ def _coadd_numpy(
                     weights[chunk][reset] = 0.0
                     footprint[chunk] *= weights[chunk]
 
-            if cutout.weights_in is not None and intermediate_memmap:
+            if cutout.weights_in is not None and intermediate_memmap is True:
                 # Remove the reference to the memmap before trying to remove the file itself
                 logger.info("Removing memory-mapped weight array")
                 weights = None
@@ -791,7 +807,7 @@ def _coadd_numpy(
                 logger.info("Adding reprojected array to final array in chunks")
                 _combine_array_into_output(combine_function, array, output_array, output_footprint)
 
-                if intermediate_memmap:
+                if intermediate_memmap is True:
                     logger.info("Removing memory-mapped array and footprint arrays")
                     array = None
                     footprint = None
@@ -991,9 +1007,12 @@ def reproject_and_coadd(
     blank_pixel_value : float, optional
         Value to use for areas of the resulting mosaic that do not have input
         data.
-    intermediate_memmap : bool, optional
+    intermediate_memmap : {'False', 'True', 'zarr'}, optional
         If `True`, use `numpy.memmap` to store intermediate output arrays for
-        reprojected data. Only supported with ``return_type='numpy'``.
+        reprojected data. If `'zarr'`, intermediate output arrays will be
+        written to zarr arrays on disk. The latter should be more efficient,
+        but can only be used if ``match_background`` is `False`. Only supported
+        with ``return_type='numpy'``.
     return_type : {None, 'numpy', 'dask', 'zarr'}, optional
         If ``'dask'``, reproject each image lazily (using ``return_type='dask'``
         on the reprojection function) and assemble each chunk of the output
@@ -1161,6 +1180,9 @@ def reproject_and_coadd(
                 "If you specify an output footprint array, it must have a shape matching "
                 f"the output shape {shape_out}"
             )
+
+    if match_background and intermediate_memmap == 'zarr':
+        raise ValueError("Cannot use intermediate_memmap='zarr' when match_background=True")
 
     logger.info(f"Output mosaic will have shape {shape_out}")
 

--- a/reproject/mosaicking/_coadd.py
+++ b/reproject/mosaicking/_coadd.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import os
+import shutil
 import sys
 import tempfile
 import uuid
@@ -32,8 +33,12 @@ def _noop(iterable):
 
 def _safe_remove(path):
     try:
-        os.remove(path)
-    except PermissionError:
+        if os.path.isdir(path):
+            # zarr stores are directories rather than single files
+            shutil.rmtree(path, ignore_errors=True)
+        else:
+            os.remove(path)
+    except (PermissionError, FileNotFoundError):
         pass
 
 
@@ -678,8 +683,9 @@ def _coadd_numpy(
 
             if intermediate_memmap == 'zarr':
 
-                extra_kwargs['return_type'] = 'zarr'
-                extra_kwargs['zarr_path'] = os.path.join(local_tmp_dir, f"array_{uuid.uuid4()}.zarr")
+                array_zarr_path = os.path.join(local_tmp_dir, f"array_{uuid.uuid4()}.zarr")
+                extra_kwargs["return_type"] = "zarr"
+                extra_kwargs["zarr_path"] = array_zarr_path
 
             elif intermediate_memmap:
 
@@ -736,8 +742,9 @@ def _coadd_numpy(
 
                 if intermediate_memmap == 'zarr':
 
-                    extra_kwargs['return_type'] = 'zarr'
-                    extra_kwargs['zarr_path'] = os.path.join(local_tmp_dir, f"weights_{uuid.uuid4()}.zarr")
+                    weights_zarr_path = os.path.join(local_tmp_dir, f"weights_{uuid.uuid4()}.zarr")
+                    extra_kwargs["return_type"] = "zarr"
+                    extra_kwargs["zarr_path"] = weights_zarr_path
 
                 elif intermediate_memmap:
 
@@ -813,6 +820,16 @@ def _coadd_numpy(
                     footprint = None
                     for path in (array_path, footprint_path):
                         _safe_remove(path)
+                elif intermediate_memmap == "zarr":
+                    # The array and footprint share a single zarr store, and the
+                    # footprint may lazily reference the weights zarr, so these
+                    # can only be removed now that the arrays have been combined.
+                    logger.info("Removing intermediate zarr arrays")
+                    array = None
+                    footprint = None
+                    _safe_remove(array_zarr_path)
+                    if weights_in is not None:
+                        _safe_remove(weights_zarr_path)
 
             else:
 

--- a/reproject/mosaicking/_coadd.py
+++ b/reproject/mosaicking/_coadd.py
@@ -322,8 +322,6 @@ def _combine_tile_pieces(
         if combine_function == "mean":
             output_array /= np.where(output_footprint == 0, 1, output_footprint)
 
-    # Parse the output projection to avoid having to do it for each
-
     # Match the return_type='numpy' path's final step: set pixels with no
     # coverage to the blank value (only where the summed footprint is exactly
     # zero, keeping pixels with a negative summed footprint).
@@ -778,23 +776,42 @@ def _coadd_numpy(
                 )
 
             # For the purposes of mosaicking, we mask out NaN values from the array
-            # and set the footprint to 0 at these locations. We do this in chunks
-            # to avoid excessive memory usage.
-            for chunk in iterate_chunks(array.shape, max_chunk_size=DEFAULT_MAX_CHUNK_SIZE):
+            # and set the footprint to 0 at these locations.
+            if isinstance(array, da.core.Array):
 
-                # Determine location of NaNs
-                reset = np.isnan(array[chunk])
+                # Assigning into a slice of a dask array only mutates the
+                # temporary object returned by the slicing, so the in-place
+                # chunked approach below would be silently lost. Instead we
+                # build lazy masked arrays, which are evaluated chunk by chunk
+                # when the subset is combined into the output.
+                reset = da.isnan(array)
                 if cutout.weights_in is not None:
-                    reset |= np.isnan(weights[chunk])
+                    reset |= da.isnan(weights)
 
-                # Mask them in-place in the arrays
-                array[chunk][reset] = 0.0
-                footprint[chunk][reset] = 0.0
-
-                # Combine weights and footprint
+                array = da.where(reset, 0.0, array)
                 if cutout.weights_in is not None:
-                    weights[chunk][reset] = 0.0
-                    footprint[chunk] *= weights[chunk]
+                    footprint = da.where(reset, 0.0, footprint * weights)
+                else:
+                    footprint = da.where(reset, 0.0, footprint)
+
+            else:
+
+                # We do this in chunks to avoid excessive memory usage.
+                for chunk in iterate_chunks(array.shape, max_chunk_size=DEFAULT_MAX_CHUNK_SIZE):
+
+                    # Determine location of NaNs
+                    reset = np.isnan(array[chunk])
+                    if cutout.weights_in is not None:
+                        reset |= np.isnan(weights[chunk])
+
+                    # Mask them in-place in the arrays
+                    array[chunk][reset] = 0.0
+                    footprint[chunk][reset] = 0.0
+
+                    # Combine weights and footprint
+                    if cutout.weights_in is not None:
+                        weights[chunk][reset] = 0.0
+                        footprint[chunk] *= weights[chunk]
 
             if cutout.weights_in is not None and intermediate_memmap is True:
                 # Remove the reference to the memmap before trying to remove the file itself

--- a/reproject/mosaicking/_coadd.py
+++ b/reproject/mosaicking/_coadd.py
@@ -681,7 +681,7 @@ def _coadd_numpy(
             extra_kwargs = {}
             array = footprint = None
 
-            if intermediate_memmap == 'zarr':
+            if intermediate_memmap == "zarr":
 
                 array_zarr_path = os.path.join(local_tmp_dir, f"array_{uuid.uuid4()}.zarr")
                 extra_kwargs["return_type"] = "zarr"
@@ -740,7 +740,7 @@ def _coadd_numpy(
                 extra_kwargs = {}
                 weights = None
 
-                if intermediate_memmap == 'zarr':
+                if intermediate_memmap == "zarr":
 
                     weights_zarr_path = os.path.join(local_tmp_dir, f"weights_{uuid.uuid4()}.zarr")
                     extra_kwargs["return_type"] = "zarr"
@@ -828,7 +828,7 @@ def _coadd_numpy(
                     array = None
                     footprint = None
                     _safe_remove(array_zarr_path)
-                    if weights_in is not None:
+                    if cutout.weights_in is not None:
                         _safe_remove(weights_zarr_path)
 
             else:
@@ -1199,7 +1199,7 @@ def reproject_and_coadd(
                 f"the output shape {shape_out}"
             )
 
-    if match_background and intermediate_memmap == 'zarr':
+    if match_background and intermediate_memmap == "zarr":
         raise ValueError("Cannot use intermediate_memmap='zarr' when match_background=True")
 
     logger.info(f"Output mosaic will have shape {shape_out}")

--- a/reproject/mosaicking/_coadd.py
+++ b/reproject/mosaicking/_coadd.py
@@ -1025,10 +1025,11 @@ def reproject_and_coadd(
         Value to use for areas of the resulting mosaic that do not have input
         data.
     intermediate_memmap : {'False', 'True', 'zarr'}, optional
-        If `True`, use `numpy.memmap` to store intermediate output arrays for
-        reprojected data. If `'zarr'`, intermediate output arrays will be
-        written to zarr arrays on disk. The latter should be more efficient,
-        but can only be used if ``match_background`` is `False`. Only supported
+        If `True`, use `numpy.memmap` to store intermediate reprojected arrays on
+        disk. If ``'zarr'``, store the intermediate arrays as zarr arrays on disk
+        instead, which is typically more efficient (each image is then reprojected
+        in blocks and the zarr store is removed once the image has been combined),
+        but cannot be used together with ``match_background=True``. Only supported
         with ``return_type='numpy'``.
     return_type : {None, 'numpy', 'dask', 'zarr'}, optional
         If ``'dask'``, reproject each image lazily (using ``return_type='dask'``

--- a/reproject/mosaicking/_subset_array.py
+++ b/reproject/mosaicking/_subset_array.py
@@ -127,7 +127,7 @@ class ReprojectedArraySubset:
 
     def as_chunks(self, max_chunk_size=None):
 
-        # TOOD: do we want to use the native dask chunking when possible
+        # TODO: do we want to use the native dask chunking when possible
 
         for chunk in iterate_chunks(
             self.shape, max_chunk_size=max_chunk_size or DEFAULT_MAX_CHUNK_SIZE

--- a/reproject/mosaicking/_subset_array.py
+++ b/reproject/mosaicking/_subset_array.py
@@ -3,6 +3,8 @@
 import operator
 from math import prod
 
+import numpy as np
+
 from .._array_utils import iterate_chunks
 
 __all__ = ["ReprojectedArraySubset"]
@@ -125,6 +127,8 @@ class ReprojectedArraySubset:
 
     def as_chunks(self, max_chunk_size=None):
 
+        # TOOD: do we want to use the native dask chunking when possible
+
         for chunk in iterate_chunks(
             self.shape, max_chunk_size=max_chunk_size or DEFAULT_MAX_CHUNK_SIZE
         ):
@@ -135,7 +139,7 @@ class ReprojectedArraySubset:
             )
 
             yield ReprojectedArraySubset(
-                array=self.array[chunk],
-                footprint=self.footprint[chunk],
+                array=np.asarray(self.array[chunk]),
+                footprint=np.asarray(self.footprint[chunk]),
                 bounds=bounds_chunk,
             )

--- a/reproject/mosaicking/tests/test_coadd.py
+++ b/reproject/mosaicking/tests/test_coadd.py
@@ -27,7 +27,7 @@ def reproject_function(request):
     return request.param
 
 
-@pytest.fixture(params=[False, True, 'zarr'])
+@pytest.fixture(params=[False, True, "zarr"])
 def intermediate_memmap(request):
     return request.param
 
@@ -107,6 +107,9 @@ class TestReprojectAndCoAdd:
         # Make sure that if all tiles are exactly non-overlapping, and
         # we use 'sum' or 'mean', we get the exact input array back.
 
+        if return_type == "dask" and intermediate_memmap:
+            pytest.skip("return_type='dask' does not support intermediate_memmap")
+
         input_data = self._get_tiles(self._nonoverlapping_views)
 
         array, footprint = reproject_and_coadd(
@@ -115,11 +118,8 @@ class TestReprojectAndCoAdd:
             shape_out=self.array.shape,
             combine_function=combine_function,
             reproject_function=reproject_function,
-<<<<<<< HEAD
             return_type=return_type,
-=======
             intermediate_memmap=intermediate_memmap,
->>>>>>> 67ffe1424 (Added intermediate_memmap='zarr' option which dumps to temporary zarr arrays instead of numpy memmap arrays)
         )
         # np.asarray is a no-op for the numpy path and computes the deferred dask
         # result for return_type='dask', which must match numerically.
@@ -133,6 +133,9 @@ class TestReprojectAndCoAdd:
         # Here we make the input tiles overlapping. We can only check the
         # mean, not the sum.
 
+        if return_type == "dask" and intermediate_memmap:
+            pytest.skip("return_type='dask' does not support intermediate_memmap")
+
         input_data = self._get_tiles(self._overlapping_views)
 
         array, footprint = reproject_and_coadd(
@@ -141,11 +144,8 @@ class TestReprojectAndCoAdd:
             shape_out=self.array.shape,
             combine_function="mean",
             reproject_function=reproject_function,
-<<<<<<< HEAD
             return_type=return_type,
-=======
             intermediate_memmap=intermediate_memmap,
->>>>>>> 67ffe1424 (Added intermediate_memmap='zarr' option which dumps to temporary zarr arrays instead of numpy memmap arrays)
         )
         array = _compute(array, return_type)
 
@@ -629,7 +629,7 @@ class TestReprojectAndCoAdd:
             shape_out=self.array.shape,
             combine_function="mean",
             reproject_function=reproject_function,
-            intermediate_memmap=intermediate_memmap_nozarr
+            intermediate_memmap=intermediate_memmap_nozarr,
         )
 
         assert not np.allclose(array, self.array, atol=ATOL)
@@ -643,7 +643,7 @@ class TestReprojectAndCoAdd:
             combine_function="mean",
             reproject_function=reproject_function,
             match_background=True,
-            intermediate_memmap=intermediate_memmap_nozarr
+            intermediate_memmap=intermediate_memmap_nozarr,
         )
 
         # The absolute values of the two arrays will be offset since any
@@ -651,7 +651,9 @@ class TestReprojectAndCoAdd:
 
         assert_allclose(array - np.mean(array), self.array - np.mean(self.array), atol=ATOL)
 
-    def test_coadd_background_matching_one_array(self, reproject_function, intermediate_memmap_nozarr):
+    def test_coadd_background_matching_one_array(
+        self, reproject_function, intermediate_memmap_nozarr
+    ):
         # Test that background matching doesn't affect the output when there's
         # only one input image.
 
@@ -751,7 +753,9 @@ class TestReprojectAndCoAdd:
         np.testing.assert_allclose(footprint_match, footprint_nomatch, atol=ATOL)
         np.testing.assert_allclose(array_match, array_nomatch, atol=ATOL)
 
-    def test_coadd_background_matching_with_nan(self, reproject_function, intermediate_memmap_nozarr):
+    def test_coadd_background_matching_with_nan(
+        self, reproject_function, intermediate_memmap_nozarr
+    ):
         # Test out the background matching when NaN values are present. We do
         # this by using three arrays with the same footprint but with different
         # parts masked.
@@ -788,6 +792,9 @@ class TestReprojectAndCoAdd:
         self, tmpdir, reproject_function, mode, intermediate_memmap, return_type
     ):
         # Make sure that things work properly when specifying weights
+
+        if return_type == "dask" and intermediate_memmap:
+            pytest.skip("return_type='dask' does not support intermediate_memmap")
 
         array1 = self.array + 1
         array2 = self.array - 1

--- a/reproject/mosaicking/tests/test_coadd.py
+++ b/reproject/mosaicking/tests/test_coadd.py
@@ -151,6 +151,48 @@ class TestReprojectAndCoAdd:
 
         assert_allclose(array, self.array, atol=ATOL)
 
+    def test_coadd_nan_masking_zarr(self, reproject_function, monkeypatch):
+        # NaN values in the input data and weights have to be masked out of
+        # the reprojected arrays and footprints before combination. With
+        # intermediate_memmap='zarr' the reprojected arrays are dask arrays,
+        # for which assigning into a slice only mutates the temporary object
+        # returned by the slicing, so the chunked in-place masking used for
+        # Numpy arrays would be silently lost whenever a chunk was a strict
+        # subset of the array (a slice covering the full array returns the
+        # array itself, which is why small test arrays did not catch this).
+        # Use a small chunk size to force multiple chunks per tile and check
+        # the zarr path against the plain Numpy path. The NaN values are
+        # placed in a single tile so that the overlapping tiles provide valid
+        # values at the same location; note that NaN data pixels only exercise
+        # the masking for reproject_exact, since reproject_interp derives its
+        # footprint from the non-NaN output pixels, so we also include NaN
+        # values in the weights of another tile.
+
+        monkeypatch.setattr("reproject.mosaicking._coadd.DEFAULT_MAX_CHUNK_SIZE", 1000)
+        monkeypatch.setattr("reproject.mosaicking._subset_array.DEFAULT_MAX_CHUNK_SIZE", 1000)
+
+        input_data = self._get_tiles(self._overlapping_views)
+        input_data[2][0][:10, :10] = np.nan
+
+        input_weights = [np.ones_like(array) for array, _ in input_data]
+        input_weights[10][:10, :10] = np.nan
+
+        results = {}
+        for intermediate in (False, "zarr"):
+            results[intermediate] = reproject_and_coadd(
+                input_data,
+                self.wcs,
+                shape_out=self.array.shape,
+                input_weights=input_weights,
+                combine_function="mean",
+                reproject_function=reproject_function,
+                intermediate_memmap=intermediate,
+            )
+
+        assert not np.any(np.isnan(results["zarr"][0]))
+        assert_allclose(results["zarr"][0], results[False][0], atol=ATOL)
+        assert_allclose(results["zarr"][1], results[False][1], atol=ATOL)
+
     def test_coadd_dask_median(self, reproject_function):
         # Check the deferred median against a direct numpy nanmedian of the
         # reprojected images, and that the result is uncomputed.

--- a/reproject/mosaicking/tests/test_coadd.py
+++ b/reproject/mosaicking/tests/test_coadd.py
@@ -27,7 +27,7 @@ def reproject_function(request):
     return request.param
 
 
-@pytest.fixture(params=[False, True])
+@pytest.fixture(params=[False, True, 'zarr'])
 def intermediate_memmap(request):
     return request.param
 
@@ -44,6 +44,11 @@ def _compute(result, return_type):
     if return_type == "dask":
         assert isinstance(result, da.core.Array)
     return np.asarray(result)
+
+
+@pytest.fixture(params=[False, True])
+def intermediate_memmap_nozarr(request):
+    return request.param
 
 
 class TestReprojectAndCoAdd:
@@ -110,7 +115,11 @@ class TestReprojectAndCoAdd:
             shape_out=self.array.shape,
             combine_function=combine_function,
             reproject_function=reproject_function,
+<<<<<<< HEAD
             return_type=return_type,
+=======
+            intermediate_memmap=intermediate_memmap,
+>>>>>>> 67ffe1424 (Added intermediate_memmap='zarr' option which dumps to temporary zarr arrays instead of numpy memmap arrays)
         )
         # np.asarray is a no-op for the numpy path and computes the deferred dask
         # result for return_type='dask', which must match numerically.
@@ -132,7 +141,11 @@ class TestReprojectAndCoAdd:
             shape_out=self.array.shape,
             combine_function="mean",
             reproject_function=reproject_function,
+<<<<<<< HEAD
             return_type=return_type,
+=======
+            intermediate_memmap=intermediate_memmap,
+>>>>>>> 67ffe1424 (Added intermediate_memmap='zarr' option which dumps to temporary zarr arrays instead of numpy memmap arrays)
         )
         array = _compute(array, return_type)
 
@@ -551,6 +564,7 @@ class TestReprojectAndCoAdd:
             reproject_function=reproject_function,
             output_array=output_array,
             output_footprint=output_footprint,
+            intermediate_memmap=intermediate_memmap,
         )
 
         assert_allclose(output_array, self.array, atol=ATOL)
@@ -599,7 +613,7 @@ class TestReprojectAndCoAdd:
             assert_allclose(output_values, (i + 7) % 20)
             array[view] = np.nan
 
-    def test_coadd_background_matching(self, reproject_function, intermediate_memmap):
+    def test_coadd_background_matching(self, reproject_function, intermediate_memmap_nozarr):
         # Test out the background matching
 
         input_data = self._get_tiles(self._overlapping_views)
@@ -615,6 +629,7 @@ class TestReprojectAndCoAdd:
             shape_out=self.array.shape,
             combine_function="mean",
             reproject_function=reproject_function,
+            intermediate_memmap=intermediate_memmap_nozarr
         )
 
         assert not np.allclose(array, self.array, atol=ATOL)
@@ -628,6 +643,7 @@ class TestReprojectAndCoAdd:
             combine_function="mean",
             reproject_function=reproject_function,
             match_background=True,
+            intermediate_memmap=intermediate_memmap_nozarr
         )
 
         # The absolute values of the two arrays will be offset since any
@@ -635,7 +651,7 @@ class TestReprojectAndCoAdd:
 
         assert_allclose(array - np.mean(array), self.array - np.mean(self.array), atol=ATOL)
 
-    def test_coadd_background_matching_one_array(self, reproject_function, intermediate_memmap):
+    def test_coadd_background_matching_one_array(self, reproject_function, intermediate_memmap_nozarr):
         # Test that background matching doesn't affect the output when there's
         # only one input image.
 
@@ -648,6 +664,7 @@ class TestReprojectAndCoAdd:
             combine_function="mean",
             reproject_function=reproject_function,
             match_background=True,
+            intermediate_memmap=intermediate_memmap_nozarr,
         )
 
         array, footprint = reproject_and_coadd(
@@ -657,6 +674,7 @@ class TestReprojectAndCoAdd:
             combine_function="mean",
             reproject_function=reproject_function,
             match_background=False,
+            intermediate_memmap=intermediate_memmap_nozarr,
         )
         np.testing.assert_allclose(array, array_matched)
         np.testing.assert_allclose(footprint, footprint_matched)
@@ -733,7 +751,7 @@ class TestReprojectAndCoAdd:
         np.testing.assert_allclose(footprint_match, footprint_nomatch, atol=ATOL)
         np.testing.assert_allclose(array_match, array_nomatch, atol=ATOL)
 
-    def test_coadd_background_matching_with_nan(self, reproject_function, intermediate_memmap):
+    def test_coadd_background_matching_with_nan(self, reproject_function, intermediate_memmap_nozarr):
         # Test out the background matching when NaN values are present. We do
         # this by using three arrays with the same footprint but with different
         # parts masked.
@@ -756,6 +774,7 @@ class TestReprojectAndCoAdd:
             combine_function="mean",
             reproject_function=reproject_function,
             match_background=True,
+            intermediate_memmap=intermediate_memmap_nozarr,
         )
 
         # The absolute values of the two arrays will be offset since any
@@ -804,6 +823,7 @@ class TestReprojectAndCoAdd:
             reproject_function=reproject_function,
             match_background=False,
             return_type=return_type,
+            intermediate_memmap=intermediate_memmap,
         )
         array = _compute(array, return_type)
 
@@ -839,6 +859,7 @@ class TestReprojectAndCoAdd:
             input_weights=input_weights,
             reproject_function=reproject_function,
             match_background=False,
+            intermediate_memmap=intermediate_memmap,
         )
 
         weights1_reprojected = reproject_function(
@@ -887,6 +908,7 @@ class TestReprojectAndCoAdd:
             shape_out=(3,) + self.array.shape,
             combine_function="mean",
             reproject_function=reproject_function,
+            intermediate_memmap=intermediate_memmap,
             **kwargs,
         )
 

--- a/reproject/spherical_intersect/_high_level.py
+++ b/reproject/spherical_intersect/_high_level.py
@@ -20,6 +20,7 @@ def reproject_exact(
     parallel=False,
     return_type=None,
     dask_method=None,
+    zarr_path=None,
 ):
     """
     Reproject data to a new projection using flux-conserving spherical
@@ -130,6 +131,7 @@ def reproject_exact(
             output_footprint=output_footprint,
             return_type=return_type,
             dask_method=dask_method,
+            zarr_path=zarr_path,
         )
     else:
         raise NotImplementedError(

--- a/reproject/spherical_intersect/_high_level.py
+++ b/reproject/spherical_intersect/_high_level.py
@@ -87,8 +87,13 @@ def reproject_exact(
         by ``block_size`` (if the block size is not set, it will be determined
         automatically). To use the currently active dask scheduler (e.g.
         dask.distributed), set this to ``'current-scheduler'``.
-    return_type : {'numpy', 'dask'}, optional
-        Whether to return numpy or dask arrays
+    return_type : {'numpy', 'dask', 'zarr'}, optional
+        Whether to return numpy or dask arrays, or to write the output to a zarr
+        array on disk. If ``'zarr'``, ``zarr_path`` must also be given; the
+        output is then computed in blocks (using dask, on the synchronous
+        scheduler when ``parallel`` is `False`), ``block_size`` defaults to
+        ``'auto'`` when not specified, and dask arrays backed by the zarr array
+        are returned.
     dask_method : {'memmap', 'none'}, optional
         Method to use when input array is a dask array. The methods are:
             * ``'memmap'``: write out the entire input dask array to a temporary
@@ -101,6 +106,9 @@ def reproject_exact(
               fits into memory (as this will then be faster than ``'memmap'``),
               and when the data contains more dimensions than the input WCS and
               the block_size is chosen to iterate over the extra dimensions.
+    zarr_path : str, optional
+        Path to use for the output zarr array when ``return_type='zarr'``. This
+        must be a path that does not already exist.
 
     Returns
     -------


### PR DESCRIPTION
Fixes https://github.com/astropy/reproject/issues/533