### PR TITLE
Fix computation of footprint in co-addition when non-reprojected dimensions are present

### DIFF
--- a/reproject/mosaicking/_coadd.py
+++ b/reproject/mosaicking/_coadd.py
@@ -7,14 +7,14 @@ from logging import getLogger
 
 import numpy as np
 from astropy.wcs import WCS
-from astropy.wcs.utils import pixel_to_pixel
 from astropy.wcs.wcsapi import SlicedLowLevelWCS
 
-from .._array_utils import iterate_chunks, sample_array_edges
+from .._array_utils import iterate_chunks
 from ..interpolation._core import _validate_wcs
 from ..utils import parse_input_data, parse_input_weights, parse_output_projection
 from ._background import determine_offset_matrix, solve_corrections_sgd
 from ._subset_array import DEFAULT_MAX_CHUNK_SIZE, ReprojectedArraySubset
+from ._wcs_helpers import sample_input_edges_in_output
 
 __all__ = ["reproject_and_coadd"]
 
@@ -306,10 +306,7 @@ def reproject_and_coadd(
             # which provides a lot of redundant information.
 
             try:
-                edges = sample_array_edges(
-                    array_in.shape[-wcs_in.low_level_wcs.pixel_n_dim :], n_samples=11
-                )[::-1]
-                edges_out = pixel_to_pixel(wcs_in, wcs_out, *edges)[::-1]
+                edges_out = sample_input_edges_in_output(array_in.shape, wcs_in, wcs_out)
             except Exception:
                 # If the edge coordinates cannot be transformed (for example if
                 # they fall outside the validity region of the WCS), fall back to

--- a/reproject/mosaicking/_coadd.py
+++ b/reproject/mosaicking/_coadd.py
@@ -209,7 +209,14 @@ def reproject_and_coadd(
 
     # non_reprojected_dims is used below to size the cutouts correctly and is
     # also forwarded to reproject_function for each individual reprojection.
+    # Validate it here too since reproject_function performs the same check but
+    # is never called if no input is predicted to overlap the output, in which
+    # case an invalid value would otherwise silently produce a blank mosaic.
     if non_reprojected_dims is not None:
+        if non_reprojected_dims != tuple(range(len(non_reprojected_dims))):
+            raise ValueError(
+                "non_reprojected_dims should be a tuple with values increasing sequentially from zero"
+            )
         kwargs["non_reprojected_dims"] = non_reprojected_dims
 
     if progress_bar is None:
@@ -307,10 +314,14 @@ def reproject_and_coadd(
 
             try:
                 edges_out = sample_input_edges_in_output(array_in.shape, wcs_in, wcs_out)
-            except Exception:
+            except Exception as exc:
                 # If the edge coordinates cannot be transformed (for example if
                 # they fall outside the validity region of the WCS), fall back to
                 # assuming no predicted overlap so the full output is considered.
+                logger.info(
+                    f"Could not determine cutout bounds for input data {idata + 1} "
+                    f"({exc}), reprojecting to the full output instead"
+                )
                 edges_out = np.array([np.nan])
 
             # Determine the cutout parameters

--- a/reproject/mosaicking/_wcs_helpers.py
+++ b/reproject/mosaicking/_wcs_helpers.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+import itertools
 import warnings
 
 import numpy as np
@@ -9,12 +10,15 @@ from astropy.io.fits import Header
 from astropy.wcs import WCS
 from astropy.wcs.utils import (
     celestial_frame_to_wcs,
+    pixel_to_pixel,
     pixel_to_skycoord,
     skycoord_to_pixel,
     wcs_to_celestial_frame,
 )
-from astropy.wcs.wcsapi import BaseHighLevelWCS, BaseLowLevelWCS
+from astropy.wcs.wcsapi import BaseHighLevelWCS, BaseLowLevelWCS, SlicedLowLevelWCS
+from astropy.wcs.wcsapi.high_level_wcs_wrapper import HighLevelWCSWrapper
 
+from .._array_utils import sample_array_edges
 from .._wcs_utils import pixel_scale
 from ..utils import parse_input_shape
 
@@ -321,3 +325,67 @@ def find_optimal_celestial_wcs(
     naxis2 = int(round(ymax - ymin))
 
     return wcs_final, (naxis2, naxis1)
+
+
+def sample_input_edges_in_output(array_shape, wcs_in, wcs_out, n_samples=11):
+    """
+    Sample the edges of an input array and return their pixel coordinates in the
+    output WCS, for the reprojected (trailing) dimensions.
+
+    This is used to determine the minimal region of the output that an input
+    image covers. If the input WCS has more pixel dimensions than the output WCS
+    (for example when using ``non_reprojected_dims`` to reproject a cube into a
+    celestial-only output), the input WCS is sliced down to its reprojected
+    (trailing) dimensions before being related to the output, since
+    ``pixel_to_pixel`` requires the two WCS to describe the same number of world
+    coordinates. Because the reprojected WCS may vary along the non-reprojected
+    axes (for example a drifting pointing, possibly non-linear), the input WCS is
+    sliced at ``n_samples`` positions along each of those axes and the resulting
+    footprints are combined.
+
+    Parameters
+    ----------
+    array_shape : tuple
+        The shape of the input array.
+    wcs_in : `~astropy.wcs.wcsapi.BaseHighLevelWCS`
+        The WCS of the input array.
+    wcs_out : `~astropy.wcs.wcsapi.BaseHighLevelWCS`
+        The WCS of the output array.
+    n_samples : int, optional
+        The number of samples to take along each edge.
+
+    Returns
+    -------
+    list of `~numpy.ndarray`
+        The output pixel coordinates of the sampled edges, in array (numpy)
+        dimension order.
+    """
+    n_extra_in = wcs_in.low_level_wcs.pixel_n_dim - wcs_out.low_level_wcs.pixel_n_dim
+
+    if n_extra_in <= 0:
+        edges = sample_array_edges(
+            array_shape[-wcs_in.low_level_wcs.pixel_n_dim :], n_samples=n_samples
+        )[::-1]
+        return pixel_to_pixel(wcs_in, wcs_out, *edges)[::-1]
+
+    n_reproject = wcs_out.low_level_wcs.pixel_n_dim
+    edges = sample_array_edges(array_shape[-n_reproject:], n_samples=n_samples)[::-1]
+    leading_shape = array_shape[:n_extra_in]
+    # Sample positions along each non-reprojected axis (not just its end points)
+    # so that non-linear variation of the reprojected WCS along that axis is
+    # captured. Use integer pixel indices and de-duplicate for short axes.
+    leading_samples = [
+        sorted({int(round(idx)) for idx in np.linspace(0, size - 1, n_samples)})
+        for size in leading_shape
+    ]
+    edges_out_corners = []
+    for corner in itertools.product(*leading_samples):
+        slices = list(corner) + [slice(None)] * n_reproject
+        wcs_in_reproject = HighLevelWCSWrapper(
+            SlicedLowLevelWCS(wcs_in.low_level_wcs, slices=slices)
+        )
+        edges_out_corners.append(pixel_to_pixel(wcs_in_reproject, wcs_out, *edges)[::-1])
+    return [
+        np.concatenate([corner[idim] for corner in edges_out_corners])
+        for idim in range(n_reproject)
+    ]

--- a/reproject/mosaicking/_wcs_helpers.py
+++ b/reproject/mosaicking/_wcs_helpers.py
@@ -327,6 +327,17 @@ def find_optimal_celestial_wcs(
     return wcs_final, (naxis2, naxis1)
 
 
+def _pixel_to_pixel_list(wcs_in, wcs_out, *inputs):
+    # pixel_to_pixel returns a bare array rather than a list of per-dimension
+    # arrays when the output WCS has a single pixel dimension, which would make
+    # the [::-1] reversals in sample_input_edges_in_output reverse the samples
+    # instead of the dimensions.
+    outputs = pixel_to_pixel(wcs_in, wcs_out, *inputs)
+    if wcs_out.low_level_wcs.pixel_n_dim == 1:
+        outputs = [outputs]
+    return outputs
+
+
 def sample_input_edges_in_output(array_shape, wcs_in, wcs_out, n_samples=11):
     """
     Sample the edges of an input array and return their pixel coordinates in the
@@ -341,7 +352,9 @@ def sample_input_edges_in_output(array_shape, wcs_in, wcs_out, n_samples=11):
     coordinates. Because the reprojected WCS may vary along the non-reprojected
     axes (for example a drifting pointing, possibly non-linear), the input WCS is
     sliced at ``n_samples`` positions along each of those axes and the resulting
-    footprints are combined.
+    footprints are combined; variation between the sampled positions is not
+    captured. Axes that do not affect the reprojected world coordinates
+    (according to the axis correlation matrix) are sliced at a single position.
 
     Parameters
     ----------
@@ -366,25 +379,38 @@ def sample_input_edges_in_output(array_shape, wcs_in, wcs_out, n_samples=11):
         edges = sample_array_edges(
             array_shape[-wcs_in.low_level_wcs.pixel_n_dim :], n_samples=n_samples
         )[::-1]
-        return pixel_to_pixel(wcs_in, wcs_out, *edges)[::-1]
+        return _pixel_to_pixel_list(wcs_in, wcs_out, *edges)[::-1]
 
     n_reproject = wcs_out.low_level_wcs.pixel_n_dim
     edges = sample_array_edges(array_shape[-n_reproject:], n_samples=n_samples)[::-1]
-    leading_shape = array_shape[:n_extra_in]
+    # Trim the array shape to the dimensions the input WCS describes before
+    # taking the non-reprojected leading sizes, since the array may have extra
+    # leading broadcast dimensions beyond the WCS (as in the branch above).
+    leading_shape = array_shape[-wcs_in.low_level_wcs.pixel_n_dim : -n_reproject]
     # Sample positions along each non-reprojected axis (not just its end points)
     # so that non-linear variation of the reprojected WCS along that axis is
-    # captured. Use integer pixel indices and de-duplicate for short axes.
-    leading_samples = [
-        sorted({int(round(idx)) for idx in np.linspace(0, size - 1, n_samples)})
-        for size in leading_shape
-    ]
+    # captured, provided the variation is smooth on the scale of the sample
+    # spacing. Axes that the correlation matrix shows do not affect the
+    # reprojected world coordinates are sampled at a single position, since
+    # every slice along them gives the same footprint. Use integer pixel
+    # indices and de-duplicate for short axes.
+    matrix = wcs_in.low_level_wcs.axis_correlation_matrix
+    world_reprojected = matrix[:, :n_reproject].any(axis=1)
+    leading_samples = []
+    for iaxis, size in enumerate(leading_shape):
+        pixel_axis = wcs_in.low_level_wcs.pixel_n_dim - 1 - iaxis
+        if matrix[world_reprojected, pixel_axis].any():
+            samples = sorted({int(round(idx)) for idx in np.linspace(0, size - 1, n_samples)})
+        else:
+            samples = [0]
+        leading_samples.append(samples)
     edges_out_corners = []
     for corner in itertools.product(*leading_samples):
         slices = list(corner) + [slice(None)] * n_reproject
         wcs_in_reproject = HighLevelWCSWrapper(
             SlicedLowLevelWCS(wcs_in.low_level_wcs, slices=slices)
         )
-        edges_out_corners.append(pixel_to_pixel(wcs_in_reproject, wcs_out, *edges)[::-1])
+        edges_out_corners.append(_pixel_to_pixel_list(wcs_in_reproject, wcs_out, *edges)[::-1])
     return [
         np.concatenate([corner[idim] for corner in edges_out_corners])
         for idim in range(n_reproject)

--- a/reproject/mosaicking/tests/test_coadd.py
+++ b/reproject/mosaicking/tests/test_coadd.py
@@ -524,16 +524,24 @@ def test_coadd_solar_map():
 
 @pytest.mark.filterwarnings("ignore::erfa.ErfaWarning")
 @pytest.mark.parametrize("combine_function", ["mean", "sum"])
-def test_coadd_non_reprojected_dims(combine_function):
+@pytest.mark.parametrize("celestial_output", [False, True])
+def test_coadd_non_reprojected_dims(combine_function, celestial_output):
     # Co-add cubes whose celestial coordinates drift along the non-reprojected
-    # (time) axis, treating that axis as non-reprojected. The result should
-    # match co-adding each time slice independently with the WCS sliced at that
-    # time.
+    # (time) axis, treating that axis as non-reprojected. With a full cube
+    # output WCS the result should match co-adding without non_reprojected_dims
+    # (which is an optimization and shouldn't change the answer). With a
+    # celestial-only (2D) output WCS the input WCS has more pixel dimensions
+    # than the output, so computing each tile's footprint requires relating
+    # only the reprojected (celestial) sub-space of the input WCS to the
+    # output; the result should match co-adding each time slice independently
+    # with the input WCS sliced at that time.
 
     n_time = 5
     shape_out = (n_time, 30, 30)
     wcs_in = _drifting_cube_wcs(drift=0.6)
     wcs_out = _drifting_cube_wcs(drift=0.0)
+    if celestial_output:
+        wcs_out = wcs_out.celestial
 
     rng = np.random.default_rng(12345)
     data1 = rng.random((n_time, 30, 30))
@@ -553,66 +561,48 @@ def test_coadd_non_reprojected_dims(combine_function):
         intermediate_memmap=True,
     )
 
-    # Run without non-reprojected dims (non_reprojected_dims is an optimization
-    # but shouldn't give a different answer)
-    reference, reference_footprint = reproject_and_coadd(
-        [(data1, wcs_in), (data2, wcs_in)],
-        wcs_out,
-        shape_out=shape_out,
-        reproject_function=reproject_interp,
-        combine_function=combine_function,
-        parallel=True,
-        block_size=(1,) + shape_out[1:],
-        roundtrip_coords=False,
-        intermediate_memmap=True,
-    )
-
-    assert_allclose(array, reference, atol=ATOL)
-    assert_allclose(footprint, reference_footprint, atol=ATOL)
-
-
-@pytest.mark.parametrize("combine_function", ["mean", "sum"])
-def test_coadd_non_reprojected_dims_celestial_output(combine_function):
-    # Co-add a drifting cube into a celestial-only (2D) output WCS, treating the
-    # leading axis as non-reprojected. Here the input WCS has more pixel
-    # dimensions than the output WCS, so computing each tile's footprint requires
-    # relating only the reprojected (celestial) sub-space of the input WCS to the
-    # output. The result should match co-adding each time slice independently
-    # with the input WCS sliced at that time.
-    n_time = 5
-    shape_out = (n_time, 30, 30)
-    wcs_in = _drifting_cube_wcs(drift=0.6)
-    wcs_out = _drifting_cube_wcs(drift=0.0).celestial
-
-    rng = np.random.default_rng(12345)
-    data1 = rng.random((n_time, 30, 30))
-    data2 = rng.random((n_time, 30, 30))
-
-    array, footprint = reproject_and_coadd(
-        [(data1, wcs_in), (data2, wcs_in)],
-        wcs_out,
-        shape_out=shape_out,
-        reproject_function=reproject_interp,
-        combine_function=combine_function,
-        non_reprojected_dims=(0,),
-        parallel=True,
-        block_size=(1,) + shape_out[1:],
-        roundtrip_coords=False,
-    )
-
-    reference = np.zeros(shape_out)
-    reference_footprint = np.zeros(shape_out)
-    for itime in range(n_time):
-        ref, ref_fp = reproject_and_coadd(
-            [(data1[itime], wcs_in[itime]), (data2[itime], wcs_in[itime])],
+    if celestial_output:
+        reference = np.zeros(shape_out)
+        reference_footprint = np.zeros(shape_out)
+        for itime in range(n_time):
+            reference[itime], reference_footprint[itime] = reproject_and_coadd(
+                [(data1[itime], wcs_in[itime]), (data2[itime], wcs_in[itime])],
+                wcs_out,
+                shape_out=shape_out[1:],
+                reproject_function=reproject_interp,
+                combine_function=combine_function,
+                roundtrip_coords=False,
+            )
+    else:
+        # Run without non-reprojected dims (non_reprojected_dims is an
+        # optimization but shouldn't give a different answer)
+        reference, reference_footprint = reproject_and_coadd(
+            [(data1, wcs_in), (data2, wcs_in)],
             wcs_out,
-            shape_out=shape_out[1:],
+            shape_out=shape_out,
             reproject_function=reproject_interp,
             combine_function=combine_function,
+            parallel=True,
+            block_size=(1,) + shape_out[1:],
             roundtrip_coords=False,
+            intermediate_memmap=True,
         )
-        reference[itime] = ref
-        reference_footprint[itime] = ref_fp
 
     assert_allclose(array, reference, atol=ATOL)
     assert_allclose(footprint, reference_footprint, atol=ATOL)
+
+
+def test_coadd_non_reprojected_dims_invalid():
+    # An invalid non_reprojected_dims should raise even if no input overlaps
+    # the output (in which case the same check inside reproject_function is
+    # never reached).
+    wcs_in = _drifting_cube_wcs(drift=0.0)
+    with pytest.raises(ValueError, match="increasing sequentially from zero"):
+        reproject_and_coadd(
+            [(np.zeros((5, 30, 30)), wcs_in)],
+            wcs_in.celestial,
+            shape_out=(5, 30, 30),
+            reproject_function=reproject_interp,
+            combine_function="mean",
+            non_reprojected_dims=(1,),
+        )

--- a/reproject/mosaicking/tests/test_coadd.py
+++ b/reproject/mosaicking/tests/test_coadd.py
@@ -569,3 +569,50 @@ def test_coadd_non_reprojected_dims(combine_function):
 
     assert_allclose(array, reference, atol=ATOL)
     assert_allclose(footprint, reference_footprint, atol=ATOL)
+
+
+@pytest.mark.parametrize("combine_function", ["mean", "sum"])
+def test_coadd_non_reprojected_dims_celestial_output(combine_function):
+    # Co-add a drifting cube into a celestial-only (2D) output WCS, treating the
+    # leading axis as non-reprojected. Here the input WCS has more pixel
+    # dimensions than the output WCS, so computing each tile's footprint requires
+    # relating only the reprojected (celestial) sub-space of the input WCS to the
+    # output. The result should match co-adding each time slice independently
+    # with the input WCS sliced at that time.
+    n_time = 5
+    shape_out = (n_time, 30, 30)
+    wcs_in = _drifting_cube_wcs(drift=0.6)
+    wcs_out = _drifting_cube_wcs(drift=0.0).celestial
+
+    rng = np.random.default_rng(12345)
+    data1 = rng.random((n_time, 30, 30))
+    data2 = rng.random((n_time, 30, 30))
+
+    array, footprint = reproject_and_coadd(
+        [(data1, wcs_in), (data2, wcs_in)],
+        wcs_out,
+        shape_out=shape_out,
+        reproject_function=reproject_interp,
+        combine_function=combine_function,
+        non_reprojected_dims=(0,),
+        parallel=True,
+        block_size=(1,) + shape_out[1:],
+        roundtrip_coords=False,
+    )
+
+    reference = np.zeros(shape_out)
+    reference_footprint = np.zeros(shape_out)
+    for itime in range(n_time):
+        ref, ref_fp = reproject_and_coadd(
+            [(data1[itime], wcs_in[itime]), (data2[itime], wcs_in[itime])],
+            wcs_out,
+            shape_out=shape_out[1:],
+            reproject_function=reproject_interp,
+            combine_function=combine_function,
+            roundtrip_coords=False,
+        )
+        reference[itime] = ref
+        reference_footprint[itime] = ref_fp
+
+    assert_allclose(array, reference, atol=ATOL)
+    assert_allclose(footprint, reference_footprint, atol=ATOL)

--- a/reproject/mosaicking/tests/test_wcs_helpers.py
+++ b/reproject/mosaicking/tests/test_wcs_helpers.py
@@ -11,7 +11,8 @@ from numpy.testing import assert_allclose, assert_equal
 
 from reproject.tests.helpers import assert_wcs_allclose
 
-from .._wcs_helpers import find_optimal_celestial_wcs
+from ...tests.test_non_reprojected_dims import _drifting_cube_wcs
+from .._wcs_helpers import find_optimal_celestial_wcs, sample_input_edges_in_output
 
 try:
     import shapely  # noqa
@@ -382,3 +383,127 @@ def test_negative_lon_cdelt():
     wcs_out, _ = find_optimal_celestial_wcs(((10, 10), wcs_ref), negative_lon_cdelt="auto")
 
     assert np.all(wcs_out.wcs.cdelt > 0)
+
+
+# Tests for sample_input_edges_in_output, which projects the edges of an input
+# array into the output WCS pixel space (for the reprojected dimensions only)
+# and is used by reproject_and_coadd to size each tile's cutout.
+
+
+@pytest.mark.filterwarnings("ignore::astropy.wcs.wcs.FITSFixedWarning")
+def test_sample_edges_equal_dims_identity(simple_celestial_fits_wcs):
+    # With identical input and output WCS the transform is the identity, so the
+    # sampled edges trace the array boundary (-0.5 to shape - 0.5), returned in
+    # array (y, x) order.
+    wcs = simple_celestial_fits_wcs
+    edges_out = sample_input_edges_in_output((30, 40), wcs, wcs)
+    assert len(edges_out) == 2
+    assert_allclose(edges_out[0].min(), -0.5, atol=1e-6)
+    assert_allclose(edges_out[0].max(), 29.5, atol=1e-6)
+    assert_allclose(edges_out[1].min(), -0.5, atol=1e-6)
+    assert_allclose(edges_out[1].max(), 39.5, atol=1e-6)
+
+
+@pytest.mark.filterwarnings("ignore::astropy.wcs.wcs.FITSFixedWarning")
+def test_sample_edges_equal_dims_translation(simple_celestial_fits_wcs):
+    # Shifting the output reference pixel along the RA (x) axis by 5 pixels
+    # translates the output pixel coordinates by +5 along x only. This also pins
+    # the array-order convention: the shift shows up in index 1 (x), not 0 (y).
+    wcs_in = simple_celestial_fits_wcs
+    wcs_out = simple_celestial_fits_wcs.deepcopy()
+    wcs_out.wcs.crpix = wcs_in.wcs.crpix + [5, 0]
+    edges_out = sample_input_edges_in_output((30, 40), wcs_in, wcs_out)
+    assert_allclose(edges_out[0].min(), -0.5, atol=1e-6)
+    assert_allclose(edges_out[0].max(), 29.5, atol=1e-6)
+    assert_allclose(edges_out[1].min(), 4.5, atol=1e-6)
+    assert_allclose(edges_out[1].max(), 44.5, atol=1e-6)
+
+
+@pytest.mark.filterwarnings("ignore::astropy.wcs.wcs.FITSFixedWarning")
+def test_sample_edges_fewer_dims_no_drift():
+    # Input WCS has more pixel dimensions than the output (a cube into a
+    # celestial-only output). With no drift the celestial mapping is the identity
+    # for every time slice, so the edges again trace the celestial array boundary.
+    wcs_in = _drifting_cube_wcs(drift=0.0)
+    wcs_out = wcs_in.celestial
+    edges_out = sample_input_edges_in_output((5, 30, 40), wcs_in, wcs_out)
+    assert len(edges_out) == 2
+    assert_allclose(edges_out[0].min(), -0.5, atol=1e-6)
+    assert_allclose(edges_out[0].max(), 29.5, atol=1e-6)
+    assert_allclose(edges_out[1].min(), -0.5, atol=1e-6)
+    assert_allclose(edges_out[1].max(), 39.5, atol=1e-6)
+
+
+@pytest.mark.filterwarnings("ignore::astropy.wcs.wcs.FITSFixedWarning")
+@pytest.mark.filterwarnings("ignore::erfa.ErfaWarning")
+def test_sample_edges_fewer_dims_drift_covers_union():
+    # When the celestial footprint drifts along the non-reprojected axis, the
+    # sampled edges must cover the union of the footprint across that axis rather
+    # than just one slice. We check this against an independent computation that
+    # projects the four array corners at the first and last time slices through
+    # the full input WCS (low-level pix2world/world2pix), which does not share
+    # code with the function under test.
+    shape = (5, 30, 40)
+    wcs_in = _drifting_cube_wcs(drift=0.6)
+    wcs_out = _drifting_cube_wcs(drift=0.0).celestial
+    edges_out = sample_input_edges_in_output(shape, wcs_in, wcs_out)
+
+    cx = np.array([-0.5, -0.5, 39.5, 39.5])
+    cy = np.array([-0.5, 29.5, 29.5, -0.5])
+    px_all, py_all = [], []
+    for t in (0, shape[0] - 1):
+        world = wcs_in.wcs_pix2world(np.column_stack([cx, cy, np.full(4, t)]), 0)
+        out = wcs_out.wcs_world2pix(world[:, :2], 0)
+        px_all.append(out[:, 0])
+        py_all.append(out[:, 1])
+    px_all = np.concatenate(px_all)
+    py_all = np.concatenate(py_all)
+
+    # the drift must actually move the corners between the two time slices
+    assert not np.allclose(px_all[:4], px_all[4:])
+
+    # the sampled edges bound the corner projections at both time slices
+    assert edges_out[1].min() <= px_all.min() + 1e-6
+    assert edges_out[1].max() >= px_all.max() - 1e-6
+    assert edges_out[0].min() <= py_all.min() + 1e-6
+    assert edges_out[0].max() >= py_all.max() - 1e-6
+
+    # and the drift genuinely widens the footprint beyond a single (no-drift) slice
+    no_drift = sample_input_edges_in_output(shape, _drifting_cube_wcs(drift=0.0), wcs_out)
+    assert (edges_out[1].max() - edges_out[1].min()) > (no_drift[1].max() - no_drift[1].min()) + 1.0
+
+
+@pytest.mark.filterwarnings("ignore::astropy.wcs.wcs.FITSFixedWarning")
+def test_sample_edges_multiple_leading_axes():
+    # Two non-reprojected leading axes (e.g. stokes and time) into a 2D celestial
+    # output: the function iterates over the product of samples along both axes.
+    wcs_in = WCS(naxis=4)
+    wcs_in.wcs.ctype = "RA---TAN", "DEC--TAN", "TIME", "STOKES"
+    wcs_in.wcs.crpix = [20, 15, 1, 1]
+    wcs_in.wcs.crval = [40.0, 0.0, 0.0, 1.0]
+    wcs_in.wcs.cdelt = [-0.01, 0.01, 1.0, 1.0]
+    wcs_out = wcs_in.celestial
+    edges_out = sample_input_edges_in_output((2, 5, 30, 40), wcs_in, wcs_out)
+    assert len(edges_out) == 2
+    assert_allclose(edges_out[0].min(), -0.5, atol=1e-6)
+    assert_allclose(edges_out[0].max(), 29.5, atol=1e-6)
+    assert_allclose(edges_out[1].min(), -0.5, atol=1e-6)
+    assert_allclose(edges_out[1].max(), 39.5, atol=1e-6)
+
+
+@pytest.mark.filterwarnings("ignore::astropy.wcs.wcs.FITSFixedWarning")
+def test_sample_edges_n_samples_and_short_leading_axis():
+    # A leading axis shorter than n_samples must not error: the sampled integer
+    # indices are de-duplicated. A larger n_samples samples each edge more finely
+    # (longer output arrays) but for a linear drift the extent is unchanged since
+    # the endpoints already bound it.
+    shape = (2, 30, 40)
+    wcs_in = _drifting_cube_wcs(drift=0.3)
+    wcs_out = _drifting_cube_wcs(drift=0.0).celestial
+    e11 = sample_input_edges_in_output(shape, wcs_in, wcs_out, n_samples=11)
+    e2 = sample_input_edges_in_output(shape, wcs_in, wcs_out, n_samples=2)
+    assert len(e11[0]) > len(e2[0])
+    assert_allclose(e11[0].min(), e2[0].min(), atol=1e-2)
+    assert_allclose(e11[0].max(), e2[0].max(), atol=1e-2)
+    assert_allclose(e11[1].min(), e2[1].min(), atol=1e-2)
+    assert_allclose(e11[1].max(), e2[1].max(), atol=1e-2)

--- a/reproject/mosaicking/tests/test_wcs_helpers.py
+++ b/reproject/mosaicking/tests/test_wcs_helpers.py
@@ -492,6 +492,62 @@ def test_sample_edges_multiple_leading_axes():
 
 
 @pytest.mark.filterwarnings("ignore::astropy.wcs.wcs.FITSFixedWarning")
+@pytest.mark.filterwarnings("ignore::erfa.ErfaWarning")
+def test_sample_edges_extra_broadcast_dims():
+    # The array may have extra leading broadcast dimensions beyond the input
+    # WCS; the non-reprojected sizes must be taken from the dimensions the WCS
+    # describes, not blindly from the leading array dimensions.
+    wcs_in = _drifting_cube_wcs(drift=0.6)
+    wcs_out = _drifting_cube_wcs(drift=0.0).celestial
+    edges_out = sample_input_edges_in_output((5, 30, 40), wcs_in, wcs_out)
+    edges_out_broadcast = sample_input_edges_in_output((3, 5, 30, 40), wcs_in, wcs_out)
+    assert len(edges_out) == len(edges_out_broadcast)
+    for edges, edges_broadcast in zip(edges_out, edges_out_broadcast, strict=True):
+        assert_allclose(edges, edges_broadcast)
+
+
+@pytest.mark.filterwarnings("ignore::astropy.wcs.wcs.FITSFixedWarning")
+def test_sample_edges_single_output_dim():
+    # With a single output pixel dimension, pixel_to_pixel returns a bare array
+    # rather than a list of per-dimension arrays; make sure both branches
+    # normalize this so the result is a list with one entry per output dimension.
+    wcs_1d = WCS(naxis=1)
+    wcs_1d.wcs.ctype = ["FREQ"]
+    wcs_1d.wcs.crpix = [1]
+    wcs_1d.wcs.crval = [1.0e9]
+    wcs_1d.wcs.cdelt = [1.0e6]
+
+    edges_out = sample_input_edges_in_output((20,), wcs_1d, wcs_1d)
+    assert len(edges_out) == 1
+    assert_allclose(edges_out[0].min(), -0.5, atol=1e-6)
+    assert_allclose(edges_out[0].max(), 19.5, atol=1e-6)
+
+    wcs_in = WCS(naxis=3)
+    wcs_in.wcs.ctype = ["FREQ", "RA---TAN", "DEC--TAN"]
+    wcs_in.wcs.crpix = [1, 15, 15]
+    wcs_in.wcs.crval = [1.0e9, 40.0, 0.0]
+    wcs_in.wcs.cdelt = [1.0e6, -0.01, 0.01]
+
+    edges_out = sample_input_edges_in_output((10, 12, 20), wcs_in, wcs_1d)
+    assert len(edges_out) == 1
+    assert_allclose(edges_out[0].min(), -0.5, atol=1e-6)
+    assert_allclose(edges_out[0].max(), 19.5, atol=1e-6)
+
+
+@pytest.mark.filterwarnings("ignore::astropy.wcs.wcs.FITSFixedWarning")
+@pytest.mark.filterwarnings("ignore::erfa.ErfaWarning")
+def test_sample_edges_uncorrelated_leading_axis_single_sample():
+    # A leading axis that does not affect the reprojected world coordinates is
+    # sliced at a single position, whereas a correlated (drifting) axis longer
+    # than n_samples is sliced at n_samples positions.
+    shape = (50, 30, 40)
+    wcs_out = _drifting_cube_wcs(drift=0.0).celestial
+    edges_no_drift = sample_input_edges_in_output(shape, _drifting_cube_wcs(drift=0.0), wcs_out)
+    edges_drift = sample_input_edges_in_output(shape, _drifting_cube_wcs(drift=0.6), wcs_out)
+    assert len(edges_drift[0]) == 11 * len(edges_no_drift[0])
+
+
+@pytest.mark.filterwarnings("ignore::astropy.wcs.wcs.FITSFixedWarning")
 def test_sample_edges_n_samples_and_short_leading_axis():
     # A leading axis shorter than n_samples must not error: the sampled integer
     # indices are de-duplicated. A larger n_samples samples each edge more finely


### PR DESCRIPTION
This is a fix to make sure that things still work if e.g. the input WCS has say 3 dimensions and the output has 2 (previously this would error, leading to the default NaN edges and full footprint)