### PR TITLE
Assemble each output chunk of the dask coaddition from only the images that overlap it and reduce memory usage for big-endian data

### DIFF
--- a/reproject/_array_utils.py
+++ b/reproject/_array_utils.py
@@ -1,4 +1,3 @@
-import dask.array as da
 import numpy as np
 from dask_image.ndinterp import map_coordinates as dask_image_map_coordinates
 from dask_image.ndinterp import spline_filter
@@ -288,55 +287,6 @@ def sample_array_edges(shape, *, n_samples):
             all_positions.append(positions)
     positions = np.unique(np.vstack(all_positions), axis=0).T
     return positions
-
-
-def pad_dask_array_to_grid(array, bounds, target_shape, target_chunks):
-    """
-    Pad a dask array with zeros so that it occupies the region given by
-    ``bounds`` (one ``(imin, imax)`` pair per dimension) within an array of
-    shape ``target_shape``, with chunk boundaries aligned to ``target_chunks``.
-
-    da.pad would chunk the pad region at the array's own chunk sizes, so a
-    later rechunk to the target chunking would have to split and recombine
-    chunks, making the number of tasks grow much faster than the number of
-    padded arrays being combined. With the chunks aligned here, that rechunk
-    only has to merge chunks at the edges of the original array.
-    """
-    for idim, (imin, imax) in enumerate(bounds):
-        edges = np.cumsum(target_chunks[idim])[:-1]
-
-        def aligned_chunks(lo, hi, edges=edges):
-            cuts = [lo] + [int(edge) for edge in edges if lo < edge < hi] + [hi]
-            return tuple(np.diff(cuts).tolist())
-
-        array = array.rechunk(
-            array.chunks[:idim] + (aligned_chunks(imin, imax),) + array.chunks[idim + 1 :]
-        )
-        pieces = [array]
-        if imin > 0:
-            pieces.insert(
-                0,
-                da.zeros(
-                    array.shape[:idim] + (imin,) + array.shape[idim + 1 :],
-                    chunks=array.chunks[:idim]
-                    + (aligned_chunks(0, imin),)
-                    + array.chunks[idim + 1 :],
-                    dtype=array.dtype,
-                ),
-            )
-        if imax < target_shape[idim]:
-            pieces.append(
-                da.zeros(
-                    array.shape[:idim] + (target_shape[idim] - imax,) + array.shape[idim + 1 :],
-                    chunks=array.chunks[:idim]
-                    + (aligned_chunks(imax, target_shape[idim]),)
-                    + array.chunks[idim + 1 :],
-                    dtype=array.dtype,
-                ),
-            )
-        if len(pieces) > 1:
-            array = da.concatenate(pieces, axis=idim)
-    return array
 
 
 class ArrayWrapper:

--- a/reproject/_array_utils.py
+++ b/reproject/_array_utils.py
@@ -238,17 +238,29 @@ def map_coordinates(
 
             chunk = list(chunk)
 
-            # Adjust chunks to add padding
+            coords_subset = coords[:, include].copy()
+
+            # Clip each chunk to the bounding box of the coordinates that fall
+            # inside it (plus the interpolation padding), since the coordinates
+            # can cover a region much smaller than the chunk, in which case only
+            # that region needs to be accessed and, for non-native data (which
+            # scipy's map_coordinates copies internally), copied. Coordinates
+            # can be NaN (e.g. for pixels that fail round-tripping), which the
+            # interpolation turns into NaN values, so the bounding box is
+            # computed from the finite coordinates, keeping the whole (padded)
+            # chunk if there are none.
             for idim, slc in enumerate(chunk):
-                start = max(0, slc.start - padding)
-                stop = min(original_shape[idim], slc.stop + padding)
+                finite = coords_subset[idim][np.isfinite(coords_subset[idim])]
+                if len(finite) > 0:
+                    start = max(0, int(np.floor(finite.min())) - padding)
+                    stop = min(original_shape[idim], int(np.ceil(finite.max())) + 1 + padding)
+                else:
+                    start = max(0, slc.start - padding)
+                    stop = min(original_shape[idim], slc.stop + padding)
                 chunk[idim] = slice(start, stop)
+                coords_subset[idim, :] -= start
 
             chunk = tuple(chunk)
-
-            coords_subset = coords[:, include].copy()
-            for idim, slc in enumerate(chunk):
-                coords_subset[idim, :] -= slc.start
 
             if optimize_memory:
                 image_subset = memory_efficient_access(image, chunk)

--- a/reproject/interpolation/_core.py
+++ b/reproject/interpolation/_core.py
@@ -146,7 +146,12 @@ def _reproject_full(
                 cval=np.nan,
                 mode="constant",
                 output=array_out_loopable[i].ravel(),
-                max_chunk_size=256 * 1024**2,
+                # max_chunk_size is a number of elements, not bytes, so this
+                # bounds the copies made for non-native (e.g. FITS) data to
+                # 64MB for 32-bit and 128MB for 64-bit values, which costs
+                # only a few percent in speed compared to larger chunks even
+                # when the coordinates span the whole input array
+                max_chunk_size=16 * 1024**2,
             )
 
     # n.b. We write the reprojected data into array_out_loopable, but array_out

--- a/reproject/interpolation/tests/test_core.py
+++ b/reproject/interpolation/tests/test_core.py
@@ -575,7 +575,10 @@ def test_reproject_roundtrip_kwarg(aia_test_data):
         block_size=(32, 32),
     )
 
-    assert_allclose(output_roundtrip_1, output_roundtrip_2)
+    # The blocked path interpolates with coordinates offset to each block's
+    # clipped input region, which changes the float32 rounding slightly, so
+    # the results are not bitwise identical to the unblocked ones.
+    assert_allclose(output_roundtrip_1, output_roundtrip_2, rtol=1e-5)
 
     output_noroundtrip_1 = reproject_interp(
         (data, wcs),
@@ -593,7 +596,7 @@ def test_reproject_roundtrip_kwarg(aia_test_data):
         block_size=(32, 32),
     )
 
-    assert_allclose(output_noroundtrip_1, output_noroundtrip_2)
+    assert_allclose(output_noroundtrip_1, output_noroundtrip_2, rtol=1e-5)
 
     # The array with round-tripping should have more NaN values:
     assert np.sum(np.isnan(output_roundtrip_1)) > 9500
@@ -1103,4 +1106,7 @@ def test_reproject_order_method(order):
             dask_method="none",
         )
 
-        assert_allclose(array_out_memmap, array_out_none)
+        # The two dask methods route through different map_coordinates
+        # implementations (numpy with per-block input clipping vs dask-image),
+        # which agree to within rounding but not bitwise.
+        assert_allclose(array_out_memmap, array_out_none, rtol=1e-5)

--- a/reproject/mosaicking/_coadd.py
+++ b/reproject/mosaicking/_coadd.py
@@ -12,7 +12,7 @@ import numpy as np
 from astropy.wcs import WCS
 from astropy.wcs.wcsapi import SlicedLowLevelWCS
 
-from .._array_utils import iterate_chunks, pad_dask_array_to_grid
+from .._array_utils import iterate_chunks
 from ..interpolation._core import _validate_wcs
 from ..utils import parse_input_data, parse_input_weights, parse_output_projection
 from ._background import determine_offset_matrix, solve_corrections_sgd
@@ -230,6 +230,81 @@ def _input_cutout_iterator(
         )
 
 
+def _combine_tile_pieces(
+    *pieces, combine_function, blank_pixel_value, dests, trailing_shape, block_info=None
+):
+    # Combine the pieces of the reprojected images that overlap one chunk of the
+    # output, using the same per-pixel logic as _combine_array_into_output (the
+    # images are applied in input order, so the sequential semantics of 'first'
+    # and 'last' are preserved). pieces holds an array block and a footprint
+    # block for each overlapping image, each covering dests[i] within the
+    # chunk; when no image overlaps (dests is empty), a single zeros template
+    # just provides the leading shape and the chunk comes out blank.
+    if dests:
+        arrays = pieces[0::2]
+        footprints = pieces[1::2]
+    else:
+        arrays = footprints = ()
+    lead_shape = pieces[0].shape[: pieces[0].ndim - len(trailing_shape)]
+    shape = lead_shape + tuple(trailing_shape)
+
+    output_array = np.zeros(shape)
+    output_footprint = np.zeros(shape)
+    if combine_function == "min":
+        output_array[...] = np.inf
+    elif combine_function == "max":
+        output_array[...] = -np.inf
+
+    if combine_function in ("mean", "sum"):
+        # Footprint-weighted sum, and for the mean divide by the summed
+        # footprint (as the return_type='numpy' path does, including
+        # contributions where the footprint is negative, which can happen when
+        # reprojecting weight maps with interpolation orders that overshoot);
+        # zeros in the divisor are replaced by one to avoid a 0/0 warning,
+        # since those pixels are set to the blank value below anyway.
+        for array, footprint, dest in zip(arrays, footprints, dests, strict=True):
+            region = (Ellipsis,) + dest
+            output_array[region] += array * footprint
+            output_footprint[region] += footprint
+        if combine_function == "mean":
+            output_array /= np.where(output_footprint == 0, 1, output_footprint)
+    elif combine_function == "median":
+        # Unweighted median of the values covering each pixel. Pixels covered
+        # by no image would be all-NaN slices, which make nanmedian warn; give
+        # them a dummy value of zero since they are blanked below anyway.
+        values = np.full((max(len(dests), 1),) + shape, np.nan)
+        for index, (array, footprint, dest) in enumerate(
+            zip(arrays, footprints, dests, strict=True)
+        ):
+            region = (Ellipsis,) + dest
+            values[index][region] = np.where(footprint > 0, array, np.nan)
+            output_footprint[region] += footprint
+        values[0][np.isnan(values).all(axis=0)] = 0.0
+        output_array = np.nanmedian(values, axis=0)
+    else:
+        # first/last/min/max select one image per pixel.
+        for array, footprint, dest in zip(arrays, footprints, dests, strict=True):
+            region = (Ellipsis,) + dest
+            if combine_function == "first":
+                mask = (footprint > 0) & (output_footprint[region] == 0)
+            elif combine_function == "last":
+                mask = footprint > 0
+            elif combine_function == "min":
+                mask = (footprint > 0) & (array < output_array[region])
+            elif combine_function == "max":
+                mask = (footprint > 0) & (array > output_array[region])
+            else:
+                raise ValueError(f"Unexpected combine_function: {combine_function}")
+            np.copyto(output_footprint[region], footprint, where=mask)
+            np.copyto(output_array[region], array, where=mask)
+
+    # Match the return_type='numpy' path's final step: set pixels with no
+    # coverage to the blank value (only where the summed footprint is exactly
+    # zero, keeping pixels with a negative summed footprint).
+    output_array = np.where(output_footprint == 0, blank_pixel_value, output_array)
+    return np.stack([output_array, output_footprint])
+
+
 def _coadd_dask(
     cutouts,
     *,
@@ -237,12 +312,13 @@ def _coadd_dask(
     combine_function,
     shape_out,
     target_chunks,
+    n_dim_reproject,
     blank_pixel_value,
     hdu_in,
     reproject_kwargs,
 ):
-    # The return_type='dask' co-addition: reproject each cutout lazily, pad it
-    # onto the output grid, and combine all the images along a stacking axis,
+    # The return_type='dask' co-addition: reproject each cutout lazily, then
+    # assemble each chunk of the output from only the images that overlap it,
     # matching the return_type='numpy' path's _combine_array_into_output
     # semantics exactly. The result is returned uncomputed so the whole graph
     # (reprojections and co-addition) is evaluated in one computation by the
@@ -250,8 +326,7 @@ def _coadd_dask(
 
     logger = getLogger(__name__)
 
-    dask_arrays = []
-    dask_footprints = []
+    tiles = []
 
     # Dask identifies arrays by their name, so two different input arrays that
     # share a name (a bug seen in the wild for arrays built with a hard-coded
@@ -275,11 +350,9 @@ def _coadd_dask(
                 )
         # Reproject this image (and its weights) lazily, mirroring the return_type='numpy'
         # per-image handling: NaNs are masked out of the array and footprint,
-        # any weights are folded into the footprint, and both the array and
-        # footprint are padded back onto the full output grid (the uncovered
-        # region gets a zero footprint so it drops out of the combine). The
-        # footprint is kept so that the combine below can weight by it exactly
-        # as the return_type='numpy' path does. Nothing is computed here.
+        # and any weights are folded into the footprint, which is kept so that
+        # the combine below can weight by it exactly as the return_type='numpy'
+        # path does. Nothing is computed here.
         logger.info(
             f"Calling {reproject_function.__name__} lazily with "
             f"shape_out={cutout.shape_out_indiv} (return_type='dask')"
@@ -320,88 +393,84 @@ def _coadd_dask(
         if weights is not None:
             footprint = footprint * da.where(reset, 0.0, weights)
 
-        dask_arrays.append(pad_dask_array_to_grid(array, cutout.bounds, shape_out, target_chunks))
-        dask_footprints.append(
-            pad_dask_array_to_grid(footprint, cutout.bounds, shape_out, target_chunks)
-        )
+        tiles.append((array, footprint, cutout.bounds))
 
-    if not dask_arrays:
+    if not tiles:
         # No image is predicted to overlap the output; return the same blank
         # mosaic and zero footprint as the return_type='numpy' path, lazily.
         output_array = da.full(tuple(shape_out), float(blank_pixel_value), chunks=target_chunks)
         output_footprint = da.zeros(tuple(shape_out), chunks=target_chunks)
         return output_array, output_footprint
 
-    # Each padded image has chunks aligned to the output chunking, with at most
-    # two extra chunk boundaries per dimension at the cutout edges. Rechunking to
-    # the common output chunking here therefore only merges those, and stacking
-    # identically-chunked arrays keeps the stack and reduction below small
-    # (stacking mismatched chunk grids would make dask unify them into an
-    # ever-finer grid, with the task count growing super-linearly with the
-    # number of images).
-    dask_arrays = [array.rechunk(target_chunks) for array in dask_arrays]
-    dask_footprints = [footprint.rechunk(target_chunks) for footprint in dask_footprints]
-    stacked_array = da.stack(dask_arrays)
-    stacked_footprint = da.stack(dask_footprints)
+    # Assemble each chunk of the output from only the images that overlap it:
+    # for every column of output chunks along the reprojected dimensions,
+    # slice the overlapping region out of each reprojected image and combine
+    # the pieces chunk by chunk in _combine_tile_pieces. Compared to padding
+    # every image onto the full output grid and reducing along a stacking
+    # axis, no zero chunks are ever materialized and each output chunk depends
+    # only on the images that actually cover it, so both the graph size and
+    # the amount of data resident during the computation are proportional to
+    # the true overlap rather than to n_images x n_chunks.
+    n_lead = len(shape_out) - n_dim_reproject
+    lead_chunks = target_chunks[:n_lead]
+    trailing_chunks = target_chunks[n_lead:]
+    edges = [np.concatenate([[0], np.cumsum(chunks)]) for chunks in trailing_chunks]
 
-    if combine_function in ("mean", "sum"):
-        # Footprint-weighted sum: output = sum(array * footprint), footprint =
-        # sum(footprint), and for the mean divide the two (as the
-        # return_type='numpy' path does, including contributions where the
-        # footprint is negative, which can happen when reprojecting weight maps
-        # with interpolation orders that overshoot). The numerator is zero
-        # wherever the footprint is zero, so for the mean divide by a footprint
-        # that has its zeros replaced by one to avoid a lazily-evaluated 0/0
-        # (which would warn at compute time).
-        output_array = (stacked_array * stacked_footprint).sum(axis=0)
-        output_footprint = stacked_footprint.sum(axis=0)
-        if combine_function == "mean":
-            output_array = output_array / da.where(output_footprint == 0, 1.0, output_footprint)
-    elif combine_function == "median":
-        covered = stacked_footprint > 0
-        # Unweighted median of the covered images. This is only available for the
-        # dask path (the return_type='numpy' path cannot compute a median on the fly).
-        masked = da.where(covered, stacked_array, np.nan)
-        # Pixels covered by no image at all would be all-NaN slices, which would
-        # make nanmedian warn at compute time; give them a value of zero since
-        # they are set to blank_pixel_value below anyway.
-        masked = da.where(covered.any(axis=0)[np.newaxis], masked, 0.0)
-        # The median needs the whole stacking axis at once, so collapse it to a
-        # single chunk and let dask re-split the other axes so that the total
-        # chunk size stays bounded instead of growing with the number of images.
-        masked = masked.rechunk({0: -1, **{iaxis: "auto" for iaxis in range(1, masked.ndim)}})
-        output_array = da.nanmedian(masked, axis=0).rechunk(target_chunks)
-        output_footprint = stacked_footprint.sum(axis=0)
-    else:
-        # first/last/min/max select one image per pixel; we find its index along
-        # the stacking axis and take both the value and the footprint from there.
-        covered = stacked_footprint > 0
-        n_images = stacked_array.shape[0]
-        axis_index = da.arange(n_images).reshape((n_images,) + (1,) * (stacked_array.ndim - 1))
-        if combine_function == "first":
-            selected = da.where(covered, axis_index, n_images).min(axis=0)
-        elif combine_function == "last":
-            selected = da.where(covered, axis_index, -1).max(axis=0)
-        elif combine_function == "min":
-            selected = da.where(covered, stacked_array, np.inf).argmin(axis=0)
-        elif combine_function == "max":
-            selected = da.where(covered, stacked_array, -np.inf).argmax(axis=0)
-        else:
-            raise ValueError(f"Unexpected combine_function: {combine_function}")
-        # Pick the value and footprint from the selected image with a one-hot
-        # mask along the stacking axis (dask has no take_along_axis). For pixels
-        # covered by no image, the selected index either matches no image
-        # (first/last) or picks an image whose footprint there is zero (min/max),
-        # so the sums give a zero footprint and the pixel is blanked below.
-        onehot = axis_index == selected[np.newaxis]
-        output_array = da.where(onehot, stacked_array, 0.0).sum(axis=0)
-        output_footprint = da.where(onehot, stacked_footprint, 0.0).sum(axis=0)
+    columns = np.empty(tuple(len(chunks) for chunks in trailing_chunks), dtype=object)
+    for index in np.ndindex(columns.shape):
+        extents = [(int(edges[idim][i]), int(edges[idim][i + 1])) for idim, i in enumerate(index)]
+        pieces = []
+        dests = []
+        for array, footprint, bounds in tiles:
+            trailing_bounds = bounds[n_lead:]
+            overlap = [
+                (max(lo, imin), min(hi, imax))
+                for (lo, hi), (imin, imax) in zip(extents, trailing_bounds, strict=True)
+            ]
+            if any(hi <= lo for lo, hi in overlap):
+                continue
+            # Slice of the image (in cutout coordinates) that falls inside this
+            # column, kept as one chunk along the reprojected dimensions and
+            # matching the output chunking along the non-reprojected ones.
+            local = (slice(None),) * n_lead + tuple(
+                slice(lo - imin, hi - imin)
+                for (lo, hi), (imin, _) in zip(overlap, trailing_bounds, strict=True)
+            )
+            rechunk_spec = {idim: lead_chunks[idim] for idim in range(n_lead)}
+            rechunk_spec.update({n_lead + idim: -1 for idim in range(n_dim_reproject)})
+            pieces.append(array[local].rechunk(rechunk_spec))
+            pieces.append(footprint[local].rechunk(rechunk_spec))
+            # Where the piece lands within the column's chunks.
+            dests.append(
+                tuple(
+                    slice(lo - start, hi - start)
+                    for (lo, hi), (start, _) in zip(overlap, extents, strict=True)
+                )
+            )
+        chunk_shape = tuple(hi - lo for lo, hi in extents)
+        if not pieces:
+            # No image overlaps this column; a zeros template just provides the
+            # block structure so the chunks come out blank.
+            pieces = [
+                da.zeros(
+                    tuple(shape_out[:n_lead]) + chunk_shape,
+                    chunks=lead_chunks + tuple((size,) for size in chunk_shape),
+                )
+            ]
+        columns[index] = da.map_blocks(
+            _combine_tile_pieces,
+            *pieces,
+            combine_function=combine_function,
+            blank_pixel_value=blank_pixel_value,
+            dests=tuple(dests),
+            trailing_shape=chunk_shape,
+            dtype=float,
+            new_axis=0,
+            chunks=((2,),) + lead_chunks + tuple((size,) for size in chunk_shape),
+        )
 
-    # Match the return_type='numpy' path's final step: set pixels with no coverage
-    # to the blank value (the return_type='numpy' loop does this at the end where
-    # output_footprint == 0, keeping pixels with a negative summed footprint).
-    output_array = da.where(output_footprint == 0, blank_pixel_value, output_array)
-    return output_array, output_footprint
+    result = da.block(columns.tolist())
+    return result[0], result[1]
 
 
 def _coadd_numpy(
@@ -736,9 +805,9 @@ def reproject_and_coadd(
         reprojected data. Only supported with ``return_type='numpy'``.
     return_type : {None, 'numpy', 'dask'}, optional
         If ``'dask'``, reproject each image lazily (using ``return_type='dask'``
-        on the reprojection function), pad each onto the output grid, and combine
-        them along a stacking axis, returning the resulting **uncomputed** dask
-        arrays so the whole co-addition is computed lazily in one go. The
+        on the reprojection function) and assemble each chunk of the output
+        from the images that overlap it, returning the resulting **uncomputed**
+        dask arrays so the whole co-addition is computed lazily in one go. The
         combination matches the ``return_type='numpy'`` path exactly
         (footprint-weighted for 'mean' and 'sum', footprint-aware selection for
         'first', 'last', 'min' and 'max'), and ``input_weights`` are supported. A
@@ -936,6 +1005,7 @@ def reproject_and_coadd(
             combine_function=combine_function,
             shape_out=shape_out,
             target_chunks=target_chunks,
+            n_dim_reproject=n_dim_reproject,
             blank_pixel_value=blank_pixel_value,
             hdu_in=hdu_in,
             reproject_kwargs=kwargs,

--- a/reproject/mosaicking/_coadd.py
+++ b/reproject/mosaicking/_coadd.py
@@ -36,34 +36,47 @@ def _safe_remove(path):
         pass
 
 
+def _combine_piece(combine_function, array, footprint, output_array, output_footprint):
+    # Combine one piece of a reprojected image into the output array and
+    # footprint, where output_array and output_footprint are views covering
+    # the same region as the piece. This is the per-pixel logic shared between
+    # the return_type='numpy' and return_type='dask' co-addition paths; in
+    # both, the images are applied in input order, which is what gives 'first'
+    # and 'last' their sequential meaning.
+    if combine_function in ("mean", "sum"):
+        output_footprint += footprint
+        output_array += array * footprint
+    elif combine_function in ("first", "last", "min", "max"):
+        if combine_function == "first":
+            mask = (footprint > 0) & (output_footprint == 0)
+        elif combine_function == "last":
+            mask = footprint > 0
+        elif combine_function == "min":
+            mask = (footprint > 0) & (array < output_array)
+        elif combine_function == "max":
+            mask = (footprint > 0) & (array > output_array)
+
+        # Update only the selected pixels in place, which avoids allocating
+        # and rewriting the whole chunk as np.where would.
+        np.copyto(output_footprint, footprint, where=mask)
+        np.copyto(output_array, array, where=mask)
+    else:
+        raise ValueError(f"Unexpected combine_function: {combine_function}")
+
+
 def _combine_array_into_output(combine_function, array, output_array, output_footprint):
     for chunk in array.as_chunks():
         # Values outside of the footprint are set to NaN by default
         # but we set these to 0 here to avoid NaNs in the means/sums.
         if combine_function in ("mean", "sum"):
             chunk.array[chunk.footprint == 0] = 0.0
-            output_footprint[chunk.view_in_original_array] += chunk.footprint
-            output_array[chunk.view_in_original_array] += chunk.array * chunk.footprint
-        elif combine_function in ("first", "last", "min", "max"):
-            if combine_function == "first":
-                mask = (chunk.footprint > 0) & (output_footprint[chunk.view_in_original_array] == 0)
-            elif combine_function == "last":
-                mask = chunk.footprint > 0
-            elif combine_function == "min":
-                mask = (chunk.footprint > 0) & (
-                    chunk.array < output_array[chunk.view_in_original_array]
-                )
-            elif combine_function == "max":
-                mask = (chunk.footprint > 0) & (
-                    chunk.array > output_array[chunk.view_in_original_array]
-                )
-
-            # Update only the selected pixels in place, which avoids allocating
-            # and rewriting the whole chunk as np.where would.
-            np.copyto(output_footprint[chunk.view_in_original_array], chunk.footprint, where=mask)
-            np.copyto(output_array[chunk.view_in_original_array], chunk.array, where=mask)
-        else:
-            raise ValueError(f"Unexpected combine_function: {combine_function}")
+        _combine_piece(
+            combine_function,
+            chunk.array,
+            chunk.footprint,
+            output_array[chunk.view_in_original_array],
+            output_footprint[chunk.view_in_original_array],
+        )
 
 
 # Everything the per-image reprojection needs to know about one input dataset
@@ -234,9 +247,8 @@ def _combine_tile_pieces(
     *pieces, combine_function, blank_pixel_value, dests, trailing_shape, block_info=None
 ):
     # Combine the pieces of the reprojected images that overlap one chunk of the
-    # output, using the same per-pixel logic as _combine_array_into_output (the
-    # images are applied in input order, so the sequential semantics of 'first'
-    # and 'last' are preserved). pieces holds an array block and a footprint
+    # output, using the same per-pixel logic as the return_type='numpy' path
+    # (shared through _combine_piece). pieces holds an array block and a footprint
     # block for each overlapping image, each covering dests[i] within the
     # chunk; when no image overlaps (dests is empty), a single zeros template
     # just provides the leading shape and the chunk comes out blank.
@@ -255,20 +267,7 @@ def _combine_tile_pieces(
     elif combine_function == "max":
         output_array[...] = -np.inf
 
-    if combine_function in ("mean", "sum"):
-        # Footprint-weighted sum, and for the mean divide by the summed
-        # footprint (as the return_type='numpy' path does, including
-        # contributions where the footprint is negative, which can happen when
-        # reprojecting weight maps with interpolation orders that overshoot);
-        # zeros in the divisor are replaced by one to avoid a 0/0 warning,
-        # since those pixels are set to the blank value below anyway.
-        for array, footprint, dest in zip(arrays, footprints, dests, strict=True):
-            region = (Ellipsis,) + dest
-            output_array[region] += array * footprint
-            output_footprint[region] += footprint
-        if combine_function == "mean":
-            output_array /= np.where(output_footprint == 0, 1, output_footprint)
-    elif combine_function == "median":
+    if combine_function == "median":
         # Unweighted median of the values covering each pixel. Pixels covered
         # by no image would be all-NaN slices, which make nanmedian warn; give
         # them a dummy value of zero since they are blanked below anyway.
@@ -282,21 +281,19 @@ def _combine_tile_pieces(
         values[0][np.isnan(values).all(axis=0)] = 0.0
         output_array = np.nanmedian(values, axis=0)
     else:
-        # first/last/min/max select one image per pixel.
+        # For the mean, divide the footprint-weighted sum by the summed
+        # footprint (as the return_type='numpy' path does, including
+        # contributions where the footprint is negative, which can happen when
+        # reprojecting weight maps with interpolation orders that overshoot);
+        # zeros in the divisor are replaced by one to avoid a 0/0 warning,
+        # since those pixels are set to the blank value below anyway.
         for array, footprint, dest in zip(arrays, footprints, dests, strict=True):
             region = (Ellipsis,) + dest
-            if combine_function == "first":
-                mask = (footprint > 0) & (output_footprint[region] == 0)
-            elif combine_function == "last":
-                mask = footprint > 0
-            elif combine_function == "min":
-                mask = (footprint > 0) & (array < output_array[region])
-            elif combine_function == "max":
-                mask = (footprint > 0) & (array > output_array[region])
-            else:
-                raise ValueError(f"Unexpected combine_function: {combine_function}")
-            np.copyto(output_footprint[region], footprint, where=mask)
-            np.copyto(output_array[region], array, where=mask)
+            _combine_piece(
+                combine_function, array, footprint, output_array[region], output_footprint[region]
+            )
+        if combine_function == "mean":
+            output_array /= np.where(output_footprint == 0, 1, output_footprint)
 
     # Match the return_type='numpy' path's final step: set pixels with no
     # coverage to the blank value (only where the summed footprint is exactly

--- a/reproject/mosaicking/tests/test_coadd.py
+++ b/reproject/mosaicking/tests/test_coadd.py
@@ -283,6 +283,75 @@ class TestReprojectAndCoAdd:
             )
         assert not any("share the name" in str(w.message) for w in recorded)
 
+    @pytest.mark.parametrize(
+        "combine_function", ["mean", "sum", "first", "last", "min", "max", "median"]
+    )
+    def test_coadd_dask_chunked_combine(self, combine_function):
+        # The dask co-addition assembles each output chunk from the images that
+        # overlap it; with chunks much smaller than the mosaic this exercises
+        # the per-chunk placement and combination for every combine function,
+        # which must match the return_type='numpy' path (or, for 'median',
+        # which that path cannot compute, a direct nanmedian of the
+        # individually reprojected images). The tiles are scaled to different
+        # values so that the selecting combine functions are non-trivial.
+        input_data = [
+            (array * (index + 1), wcs)
+            for index, (array, wcs) in enumerate(self._get_tiles(self._overlapping_views))
+        ]
+
+        array, footprint = reproject_and_coadd(
+            input_data,
+            self.wcs,
+            shape_out=self.array.shape,
+            combine_function=combine_function,
+            reproject_function=reproject_interp,
+            return_type="dask",
+            block_size=(100, 100),
+        )
+        array = np.asarray(array)
+        footprint = np.asarray(footprint)
+
+        if combine_function == "median":
+            refs = []
+            for arr, wcs in input_data:
+                reprojected, fp = reproject_interp((arr, wcs), self.wcs, shape_out=self.array.shape)
+                reprojected[fp == 0] = np.nan
+                refs.append(reprojected)
+            reference = np.nanmedian(np.array(refs), axis=0)
+            covered = footprint > 0
+            assert covered.any()
+            assert_allclose(array[covered], reference[covered], atol=ATOL)
+        else:
+            reference, reference_footprint = reproject_and_coadd(
+                input_data,
+                self.wcs,
+                shape_out=self.array.shape,
+                combine_function=combine_function,
+                reproject_function=reproject_interp,
+            )
+            assert_allclose(array, reference, atol=ATOL)
+            assert_allclose(footprint, reference_footprint, atol=ATOL)
+
+    def test_coadd_dask_graph_scales_with_overlap(self):
+        # Each output chunk depends only on the images that actually overlap
+        # it, so no zero-padding chunks are materialized and the graph size
+        # scales with the total overlap area rather than with the number of
+        # images times the number of chunks (padding every image to the full
+        # mosaic and reducing along a stacking axis produced several times
+        # more tasks for this configuration).
+        input_data = self._get_tiles(self._nonoverlapping_views)
+
+        array, footprint = reproject_and_coadd(
+            input_data,
+            self.wcs,
+            shape_out=self.array.shape,
+            combine_function="mean",
+            reproject_function=reproject_interp,
+            return_type="dask",
+            block_size=(100, 100),
+        )
+        assert len(dict(array.__dask_graph__())) < 1500
+
     def test_coadd_dask_rejects_unsupported(self):
         # Options that fill arrays in place cannot apply to a deferred dask result
         # and must raise rather than being silently ignored.

--- a/reproject/tests/test_array_utils.py
+++ b/reproject/tests/test_array_utils.py
@@ -1,14 +1,9 @@
-import dask.array as da
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose
 from scipy.ndimage import map_coordinates as scipy_map_coordinates
 
-from reproject._array_utils import (
-    dask_map_coordinates,
-    map_coordinates,
-    pad_dask_array_to_grid,
-)
+from reproject._array_utils import dask_map_coordinates, map_coordinates
 
 
 @pytest.mark.parametrize("cval", [3, np.nan])
@@ -60,42 +55,3 @@ def test_custom_map_coordinates(cval, shape, order, dtype):
     )
 
     assert_allclose(result1, result2)
-
-
-@pytest.mark.parametrize(
-    "bounds",
-    [
-        [(7, 19), (18, 27)],  # interior: padding on every side
-        [(0, 12), (31, 40)],  # flush with the grid edges: no padding there
-        [(0, 30), (0, 9)],  # one dimension spanning the full grid
-    ],
-)
-def test_pad_dask_array_to_grid(bounds):
-    target_shape = (30, 40)
-    # Non-uniform chunking along the second dimension (remainder chunk)
-    target_chunks = da.core.normalize_chunks((10, 16), shape=target_shape, dtype=float)
-
-    shape = tuple(imax - imin for (imin, imax) in bounds)
-    data = np.random.default_rng(42).random(shape).astype("<f4")
-    array = da.from_array(data, chunks=(5, 4))
-
-    padded = pad_dask_array_to_grid(array, bounds, target_shape, target_chunks)
-
-    assert padded.shape == target_shape
-    assert padded.dtype == array.dtype
-
-    expected = np.zeros(target_shape, dtype="<f4")
-    expected[tuple(slice(imin, imax) for (imin, imax) in bounds)] = data
-    assert_allclose(np.asarray(padded), expected)
-
-    # The chunk boundaries are the target grid boundaries plus at most cuts at
-    # the bounds of the original array, so that the rechunk to the target
-    # chunking below only has to merge chunks rather than split and recombine
-    # them across the whole grid.
-    for idim in range(padded.ndim):
-        target_edges = set(np.cumsum(target_chunks[idim]))
-        result_edges = set(np.cumsum(padded.chunks[idim]))
-        assert target_edges <= result_edges
-        assert result_edges <= target_edges | set(bounds[idim])
-
-    assert padded.rechunk(target_chunks).chunks == target_chunks

--- a/reproject/tests/test_array_utils.py
+++ b/reproject/tests/test_array_utils.py
@@ -55,3 +55,31 @@ def test_custom_map_coordinates(cval, shape, order, dtype):
     )
 
     assert_allclose(result1, result2)
+
+
+def test_map_coordinates_clips_to_coordinate_bounding_box():
+    # For non-native data (as read from FITS files), map_coordinates copies the
+    # data since scipy's map_coordinates copies non-native input internally.
+    # The copies should be clipped to the region that the coordinates actually
+    # cover, so interpolating a small region of a large array should only
+    # allocate memory proportional to that region, not to the whole array.
+    import tracemalloc
+
+    np.random.seed(1249)
+
+    data = np.random.random((64, 128, 128)).astype(">f4")  # 4 MB
+
+    coords = np.random.uniform(20, 30, (3, 10_000))
+
+    tracemalloc.start()
+    result = map_coordinates(data, coords, order=1, cval=np.nan, mode="constant")
+    _, peak = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+
+    # The coordinates cover a ~10x10x10 region, so with padding the copies
+    # should be well under a megabyte; without clipping the whole 4 MB array
+    # would be copied.
+    assert peak < 1_000_000
+
+    expected = map_coordinates(data.astype("<f4"), coords, order=1, cval=np.nan, mode="constant")
+    assert_allclose(result, expected, rtol=1e-6)


### PR DESCRIPTION
This combines the pieces per chunk with the same per-pixel logic as the numpy path, so no zero padding chunks are materialized and the graph size and resident data scale with the true overlap instead of the number of images times the number of chunks.