### PR TITLE
Significantly reduce memory usage due to WCS transformations

### DIFF
--- a/reproject/_wcs_utils.py
+++ b/reproject/_wcs_utils.py
@@ -9,12 +9,7 @@ from astropy.coordinates import SkyCoord, SpectralCoord
 from astropy.wcs import WCS
 from astropy.wcs.utils import pixel_to_pixel, proj_plane_pixel_scales
 
-__all__ = [
-    "has_celestial",
-    "pixel_to_pixel_chunked",
-    "pixel_to_pixel_with_roundtrip",
-    "pixel_scale",
-]
+__all__ = ["has_celestial", "pixel_to_pixel_chunked", "pixel_scale"]
 
 
 def has_celestial(wcs):
@@ -86,10 +81,6 @@ def pixel_to_pixel_chunked(wcs1, wcs2, *inputs, roundtrip=False, output=None, ch
             output[ipix].flat[chunk] = results[ipix]
 
     return output
-
-
-def pixel_to_pixel_with_roundtrip(wcs1, wcs2, *inputs):
-    return pixel_to_pixel_chunked(wcs1, wcs2, *inputs, roundtrip=True)
 
 
 def pixel_scale(wcs, shape):

--- a/reproject/_wcs_utils.py
+++ b/reproject/_wcs_utils.py
@@ -9,7 +9,7 @@ from astropy.coordinates import SkyCoord, SpectralCoord
 from astropy.wcs import WCS
 from astropy.wcs.utils import pixel_to_pixel, proj_plane_pixel_scales
 
-__all__ = ["has_celestial", "pixel_to_pixel_with_roundtrip", "pixel_scale"]
+__all__ = ["has_celestial", "pixel_to_pixel_chunked", "pixel_to_pixel_with_roundtrip", "pixel_scale"]
 
 
 def has_celestial(wcs):
@@ -38,20 +38,53 @@ def has_spectral(wcs):
         return False
 
 
+def pixel_to_pixel_chunked(wcs1, wcs2, *inputs, roundtrip=False, output=None, chunk_size=200_000):
+    """
+    Transform pixel coordinates from ``wcs1`` to ``wcs2`` in chunks of at most
+    ``chunk_size`` elements, which bounds the peak memory usage due to the
+    temporary arrays allocated inside the coordinate transformations (and is
+    typically also faster than a single full-size transform due to better CPU
+    cache usage).
+
+    If ``roundtrip`` is set, each chunk is also transformed back to ``wcs1``
+    and coordinates that do not round-trip to within a pixel are set to NaN.
+
+    ``output`` can be a list of arrays (one per pixel dimension of ``wcs2``,
+    each with the same number of elements as the inputs) into which the
+    results are written. Inputs and outputs are accessed with flat slices and
+    matched element-wise in C order, so they do not need to share a shape and
+    broadcast input views are never expanded into full-size arrays.
+    """
+    if np.isscalar(inputs[0]):
+        inputs = tuple(np.array(inp) for inp in inputs)
+
+    if output is None:
+        output = [np.empty(inputs[0].shape) for _ in range(wcs2.pixel_n_dim)]
+
+    for start in range(0, inputs[0].size, chunk_size):
+        chunk = slice(start, start + chunk_size)
+        chunk_inputs = [inp.flat[chunk] for inp in inputs]
+        results = pixel_to_pixel(wcs1, wcs2, *chunk_inputs)
+        if wcs2.pixel_n_dim == 1:
+            results = [results]
+        if roundtrip:
+            # Convert back to check that coordinates round-trip, if not then set to NaN
+            inputs_check = pixel_to_pixel(wcs2, wcs1, *results)
+            if wcs1.pixel_n_dim == 1:
+                inputs_check = [inputs_check]
+            reset = np.zeros(inputs_check[0].shape, dtype=bool)
+            for ipix in range(len(inputs_check)):
+                reset |= np.abs(inputs_check[ipix] - chunk_inputs[ipix]) > 1
+            if reset.any():
+                results = [np.where(reset, np.nan, result) for result in results]
+        for ipix in range(len(output)):
+            output[ipix].flat[chunk] = results[ipix]
+
+    return output
+
+
 def pixel_to_pixel_with_roundtrip(wcs1, wcs2, *inputs):
-    outputs = pixel_to_pixel(wcs1, wcs2, *inputs)
-
-    # Now convert back to check that coordinates round-trip, if not then set to NaN
-    inputs_check = pixel_to_pixel(wcs2, wcs1, *outputs)
-    reset = np.zeros(inputs_check[0].shape, dtype=bool)
-    for ipix in range(len(inputs_check)):
-        reset |= np.abs(inputs_check[ipix] - inputs[ipix]) > 1
-    if np.any(reset):
-        for ipix in range(len(inputs_check)):
-            outputs[ipix] = outputs[ipix].copy()
-            outputs[ipix][reset] = np.nan
-
-    return outputs
+    return pixel_to_pixel_chunked(wcs1, wcs2, *inputs, roundtrip=True)
 
 
 def pixel_scale(wcs, shape):

--- a/reproject/_wcs_utils.py
+++ b/reproject/_wcs_utils.py
@@ -9,7 +9,12 @@ from astropy.coordinates import SkyCoord, SpectralCoord
 from astropy.wcs import WCS
 from astropy.wcs.utils import pixel_to_pixel, proj_plane_pixel_scales
 
-__all__ = ["has_celestial", "pixel_to_pixel_chunked", "pixel_to_pixel_with_roundtrip", "pixel_scale"]
+__all__ = [
+    "has_celestial",
+    "pixel_to_pixel_chunked",
+    "pixel_to_pixel_with_roundtrip",
+    "pixel_scale",
+]
 
 
 def has_celestial(wcs):

--- a/reproject/adaptive/_core.py
+++ b/reproject/adaptive/_core.py
@@ -1,9 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import numpy as np
-from astropy.wcs.utils import pixel_to_pixel
 
-from .._wcs_utils import pixel_to_pixel_with_roundtrip
+from .._wcs_utils import pixel_to_pixel_chunked
 from .deforest import map_coordinates
 
 __all__ = ["_reproject_adaptive_2d"]
@@ -17,11 +16,16 @@ class CoordinateTransformer:
 
     def __call__(self, pixel_out):
         pixel_out = pixel_out[:, :, 0], pixel_out[:, :, 1]
-        if self.roundtrip_coords:
-            pixel_in = pixel_to_pixel_with_roundtrip(self.wcs_out, self.wcs_in, *pixel_out)
-        else:
-            pixel_in = pixel_to_pixel(self.wcs_out, self.wcs_in, *pixel_out)
-        pixel_in = np.array(pixel_in).transpose().swapaxes(0, 1)
+        # Transform in chunks, writing directly into the (ny, nx, 2) array
+        # that map_coordinates needs to avoid full-size stacking copies
+        pixel_in = np.empty((*pixel_out[0].shape, 2))
+        pixel_to_pixel_chunked(
+            self.wcs_out,
+            self.wcs_in,
+            *pixel_out,
+            roundtrip=self.roundtrip_coords,
+            output=[pixel_in[..., 0], pixel_in[..., 1]],
+        )
         return pixel_in
 
 

--- a/reproject/interpolation/_core.py
+++ b/reproject/interpolation/_core.py
@@ -3,10 +3,9 @@
 import dask.array as da
 import numpy as np
 from astropy.wcs import WCS
-from astropy.wcs.utils import pixel_to_pixel
 
 from .._array_utils import dask_map_coordinates, map_coordinates
-from .._wcs_utils import has_celestial, pixel_to_pixel_with_roundtrip
+from .._wcs_utils import has_celestial, pixel_to_pixel_chunked
 
 
 def _validate_wcs(wcs_in, wcs_out, shape_in, shape_out):
@@ -112,13 +111,19 @@ def _reproject_full(
         sparse=False,
         copy=False,
     )
-    pixel_out = [p.ravel() for p in pixel_out]
-    # For each pixel in the output array, get the pixel value in the input WCS
-    if roundtrip_coords:
-        pixel_in = pixel_to_pixel_with_roundtrip(wcs_out, wcs_in, *pixel_out[::-1])[::-1]
-    else:
-        pixel_in = pixel_to_pixel(wcs_out, wcs_in, *pixel_out[::-1])[::-1]
-    pixel_in = np.array(pixel_in)
+    # For each pixel in the output array, get the pixel value in the input
+    # WCS, transforming in chunks and writing directly into the
+    # (n_dim, n_pixels) coordinate array that map_coordinates needs, so the
+    # meshgrid views are never expanded into full-size arrays and no
+    # full-size stacking copy is made
+    pixel_in = np.empty((len(pixel_out), pixel_out[0].size))
+    pixel_to_pixel_chunked(
+        wcs_out,
+        wcs_in,
+        *pixel_out[::-1],
+        roundtrip=roundtrip_coords,
+        output=list(pixel_in[::-1]),
+    )
 
     # Loop over the broadcasted dimensions in our array, reusing the same
     # computed transformation each time

--- a/reproject/tests/test_utils.py
+++ b/reproject/tests/test_utils.py
@@ -186,13 +186,79 @@ def test_pixel_to_pixel_chunked():
     np.testing.assert_array_equal(output[0].ravel(), np.tile(xc, 2))
     np.testing.assert_array_equal(output[1].ravel(), np.tile(yc, 2))
 
-    # Coordinates that do not round-trip (here: behind the TAN projection
-    # plane) should be set to NaN when roundtrip is enabled
-    xf, yf = pixel_to_pixel_chunked(
-        wcs2, wcs1, np.array([0.0, 1500.0]), np.array([0.0, 0.0]), roundtrip=True, chunk_size=1
-    )
-    assert not np.isnan(xf[0]) and not np.isnan(yf[0])
-    assert np.isnan(xf[1]) and np.isnan(yf[1])
+    # Scalar inputs should be accepted and give the same answer as astropy
+    sx, sy = pixel_to_pixel_chunked(wcs1, wcs2, 5.0, 5.0)
+    ex, ey = pixel_to_pixel(wcs1, wcs2, 5.0, 5.0)
+    np.testing.assert_allclose([np.asarray(sx), np.asarray(sy)], [ex, ey])
+
+
+def test_pixel_to_pixel_chunked_1d():
+    # A one-dimensional WCS makes pixel_to_pixel return a bare array rather
+    # than a tuple, which needs special handling on both the forward and the
+    # roundtrip pass.
+    from astropy.wcs.utils import pixel_to_pixel
+
+    wcs1 = WCS(naxis=1)
+    wcs1.wcs.ctype = ("WAVE",)
+    wcs1.wcs.cunit = ("m",)
+    wcs1.wcs.crval = [1e-6]
+    wcs1.wcs.cdelt = [1e-9]
+    wcs1.wcs.crpix = [1]
+
+    wcs2 = WCS(naxis=1)
+    wcs2.wcs.ctype = ("WAVE",)
+    wcs2.wcs.cunit = ("m",)
+    wcs2.wcs.crval = [1e-6]
+    wcs2.wcs.cdelt = [2e-9]
+    wcs2.wcs.crpix = [1]
+
+    x = np.linspace(0, 50, 60)
+    ref = pixel_to_pixel(wcs1, wcs2, x)
+    (chunked,) = pixel_to_pixel_chunked(wcs1, wcs2, x, roundtrip=True, chunk_size=7)
+    np.testing.assert_array_equal(ref, chunked)
+
+
+def test_pixel_to_pixel_chunked_roundtrip():
+    # Reprojecting a full-sky output grid back to a small TAN input produces
+    # "ghost" pixels far from the footprint that transform to a finite input
+    # pixel but do not round-trip - these should be set to NaN when roundtrip
+    # is enabled, while pixels that do round-trip are left untouched.
+    from astropy.wcs.utils import pixel_to_pixel
+
+    wcs_in = WCS(naxis=2)
+    wcs_in.wcs.ctype = "RA---TAN", "DEC--TAN"
+    wcs_in.wcs.crval = 0.0, 0.0
+    wcs_in.wcs.crpix = 25.0, 25.0
+    wcs_in.wcs.cdelt = -0.1, 0.1
+    wcs_in.wcs.set()
+
+    wcs_out = WCS(naxis=2)
+    wcs_out.wcs.ctype = "RA---CAR", "DEC--CAR"
+    wcs_out.wcs.crval = 0.0, 0.0
+    wcs_out.wcs.crpix = 90.0, 45.0
+    wcs_out.wcs.cdelt = -2.0, 2.0
+    wcs_out.wcs.set()
+
+    y, x = np.mgrid[0:90, 0:180]
+    x = x.ravel().astype(float)
+    y = y.ravel().astype(float)
+
+    # Reference: forward transform with the round-trip reset applied by hand
+    fx, fy = pixel_to_pixel(wcs_out, wcs_in, x, y)
+    bx, by = pixel_to_pixel(wcs_in, wcs_out, fx, fy)
+    reset = (np.abs(bx - x) > 1) | (np.abs(by - y) > 1)
+    ref_x = np.where(reset, np.nan, fx)
+    ref_y = np.where(reset, np.nan, fy)
+
+    cx, cy = pixel_to_pixel_chunked(wcs_out, wcs_in, x, y, roundtrip=True, chunk_size=777)
+    np.testing.assert_array_equal(cx, ref_x)
+    np.testing.assert_array_equal(cy, ref_y)
+
+    # Sanity check that this geometry actually exercises the reset (some
+    # pixels transform to a finite input pixel but are still reset to NaN)
+    forward_finite = np.isfinite(fx) & np.isfinite(fy)
+    assert (reset & forward_finite).any()
+    assert np.isfinite(cx).any()
 
 
 class TestHDUToMemmap:

--- a/reproject/tests/test_utils.py
+++ b/reproject/tests/test_utils.py
@@ -5,7 +5,7 @@ from astropy.io import fits
 from astropy.utils.data import get_pkg_data_filename
 from astropy.wcs import WCS
 
-from reproject._wcs_utils import has_celestial
+from reproject._wcs_utils import has_celestial, pixel_to_pixel_chunked
 from reproject.conftest import set_wcs_array_shape
 from reproject.tests.helpers import assert_wcs_allclose
 from reproject.utils import (
@@ -142,6 +142,57 @@ def test_has_celestial():
 
     wwh2 = HighLevelWCSWrapper(SlicedLowLevelWCS(ww, [slice(0, 1), slice(0, 1)]))
     assert has_celestial(wwh2)
+
+
+def test_pixel_to_pixel_chunked():
+    from astropy.wcs.utils import pixel_to_pixel
+
+    wcs1 = WCS(naxis=2)
+    wcs1.wcs.ctype = "RA---TAN", "DEC--TAN"
+    wcs1.wcs.crval = 43.0, 23.0
+    wcs1.wcs.cdelt = -0.1, 0.1
+    wcs1.wcs.crpix = 5.0, 5.0
+
+    wcs2 = WCS(naxis=2)
+    wcs2.wcs.ctype = "GLON-CAR", "GLAT-CAR"
+    # Center on the galactic coordinates of the wcs1 reference point so the
+    # two WCSes overlap
+    wcs2.wcs.crval = 155.97, -32.03
+    wcs2.wcs.cdelt = -0.1, 0.1
+    wcs2.wcs.crpix = 5.0, 5.0
+
+    rng = np.random.default_rng(42)
+    x = rng.uniform(0, 10, 1000)
+    y = rng.uniform(0, 10, 1000)
+
+    # Chunking should not change the results
+    xp, yp = pixel_to_pixel(wcs1, wcs2, x, y)
+    xc, yc = pixel_to_pixel_chunked(wcs1, wcs2, x, y, chunk_size=17)
+    np.testing.assert_array_equal(xp, xc)
+    np.testing.assert_array_equal(yp, yc)
+
+    # Results can be written into arrays of a different shape (matched in
+    # flat C order), and broadcast inputs should be handled without being
+    # expanded
+    output = np.empty((2, 40, 50))
+    pixel_to_pixel_chunked(
+        wcs1,
+        wcs2,
+        np.broadcast_to(x, (2, 1000)),
+        np.broadcast_to(y, (2, 1000)),
+        chunk_size=17,
+        output=list(output),
+    )
+    np.testing.assert_array_equal(output[0].ravel(), np.tile(xc, 2))
+    np.testing.assert_array_equal(output[1].ravel(), np.tile(yc, 2))
+
+    # Coordinates that do not round-trip (here: behind the TAN projection
+    # plane) should be set to NaN when roundtrip is enabled
+    xf, yf = pixel_to_pixel_chunked(
+        wcs2, wcs1, np.array([0.0, 1500.0]), np.array([0.0, 0.0]), roundtrip=True, chunk_size=1
+    )
+    assert not np.isnan(xf[0]) and not np.isnan(yf[0])
+    assert np.isnan(xf[1]) and np.isnan(yf[1])
 
 
 class TestHDUToMemmap:

--- a/reproject/wcs_utils.py
+++ b/reproject/wcs_utils.py
@@ -8,6 +8,9 @@ import warnings
 
 from astropy.utils.exceptions import AstropyDeprecationWarning
 
+from ._wcs_utils import has_celestial, pixel_scale
+from ._wcs_utils import pixel_to_pixel_chunked as _pixel_to_pixel_chunked
+
 warnings.warn(
     "reproject.wcs_utils is a private module and will be removed in a future "
     "version.  Please use the public API from reproject instead.",
@@ -15,4 +18,11 @@ warnings.warn(
     stacklevel=2,
 )
 
-from ._wcs_utils import *  # noqa: E402, F401, F403
+# pixel_to_pixel_with_roundtrip has been replaced by pixel_to_pixel_chunked but
+# is kept here for backward-compatibility until this deprecated module is
+# removed. The new function is intentionally not re-exported through this shim.
+__all__ = ["has_celestial", "pixel_scale", "pixel_to_pixel_with_roundtrip"]
+
+
+def pixel_to_pixel_with_roundtrip(wcs1, wcs2, *inputs):
+    return _pixel_to_pixel_chunked(wcs1, wcs2, *inputs, roundtrip=True)


### PR DESCRIPTION
This does several things to reduce memory usage:

* It calls ``pixel_to_pixel`` in chunks so that we don't blow up the memory with large e.g. GWCS transforms (as mentioned in https://github.com/astropy/reproject/issues/534)
* It improves the call sites of ``pixel_to_pixel_chunked`` (the new name for the function) to avoid excessive temporary memory usage when constructing the inputs/outputs to these functions.

This can significantly reduce memory usage (factor of several to factors of 10x) with, I hope, no downsides.