### PR TITLE
Add support for ``return_type='zarr'`` in reproject_and_coadd

### DIFF
--- a/reproject/mosaicking/_coadd.py
+++ b/reproject/mosaicking/_coadd.py
@@ -7,6 +7,7 @@ import warnings
 from collections import namedtuple
 from logging import getLogger
 
+import dask
 import dask.array as da
 import numpy as np
 from astropy.wcs import WCS
@@ -503,6 +504,21 @@ def _coadd_zarr(
 
     logger = getLogger(__name__)
 
+    # Compute with the scheduler implied by the parallel keyword, following
+    # the same semantics as the individual reprojection functions:
+    # 'current-scheduler' uses the active scheduler (e.g. dask.distributed),
+    # an integer uses that many threads, True uses the default number of
+    # threads, and False computes synchronously.
+    parallel = reproject_kwargs.get("parallel", False)
+    if parallel == "current-scheduler":
+        scheduler_config = {}
+    elif isinstance(parallel, bool):
+        scheduler_config = {"scheduler": "threads"} if parallel else {"scheduler": "synchronous"}
+    elif parallel > 0:
+        scheduler_config = {"scheduler": "threads", "num_workers": parallel}
+    else:
+        raise ValueError("The number of processors to use must be strictly positive")
+
     cutouts = list(cutouts)
 
     chunk_shape = tuple(chunks[0] for chunks in target_chunks)
@@ -581,13 +597,14 @@ def _coadd_zarr(
         )
         sources = [array[region] for region in regions] + [footprint[region] for region in regions]
         targets = [zarr_array] * len(regions) + [zarr_footprint] * len(regions)
-        da.store(
-            sources,
-            targets,
-            regions=regions + regions,
-            lock=False,
-            compute=True,
-        )
+        with dask.config.set(**scheduler_config):
+            da.store(
+                sources,
+                targets,
+                regions=regions + regions,
+                lock=False,
+                compute=True,
+            )
 
     return (
         da.from_zarr(zarr_path, component="array"),
@@ -955,7 +972,11 @@ def reproject_and_coadd(
         The number of output chunks to compute per batch when
         ``return_type='zarr'``, iterating over the output chunks in C order.
         The default picks a batch size such that one batch of the output is
-        around 2 GB.
+        around 2 GB. The batches are computed with the scheduler implied by
+        the ``parallel`` keyword, with the same semantics as for the
+        individual reprojection functions (``'current-scheduler'`` to use the
+        active scheduler, an integer for that many threads, `True` for the
+        default number of threads and `False` to compute synchronously).
 
     **kwargs
         Keyword arguments to be passed to the reprojection function.

--- a/reproject/mosaicking/_coadd.py
+++ b/reproject/mosaicking/_coadd.py
@@ -475,6 +475,126 @@ def _coadd_dask(
     return result[0], result[1]
 
 
+def _coadd_zarr(
+    cutouts,
+    *,
+    reproject_function,
+    combine_function,
+    shape_out,
+    target_chunks,
+    n_dim_reproject,
+    blank_pixel_value,
+    hdu_in,
+    reproject_kwargs,
+    zarr_path,
+    zarr_batch_size,
+):
+    # The return_type='zarr' co-addition: build the same deferred graphs as
+    # return_type='dask', but compute them here, batch by batch along the
+    # first dimension, into a zarr store on disk. Each batch is built as its
+    # own graph from only the images that overlap it, so the memory used by
+    # the computation is bounded by one batch regardless of the size of the
+    # mosaic (the scheduler never sees tasks from more than one batch), and
+    # each batch is written to a disjoint region of the store. Reprojected
+    # chunks of images that span a batch boundary are computed in each batch
+    # that needs them, trading some recomputation for the bounded memory.
+
+    import zarr  # noqa: PLC0415
+
+    logger = getLogger(__name__)
+
+    cutouts = list(cutouts)
+
+    chunk_shape = tuple(chunks[0] for chunks in target_chunks)
+
+    group = zarr.open_group(zarr_path, mode="w-")
+    # Batches with no overlapping images are never written, so the fill
+    # values provide the same blank mosaic values as the other paths
+    zarr_array = group.create_array(
+        "array",
+        shape=tuple(shape_out),
+        chunks=chunk_shape,
+        dtype=float,
+        fill_value=float(blank_pixel_value),
+    )
+    zarr_footprint = group.create_array(
+        "footprint",
+        shape=tuple(shape_out),
+        chunks=chunk_shape,
+        dtype=float,
+        fill_value=0.0,
+    )
+
+    # Batches are groups of output chunks, iterating over the chunk grid in
+    # C order, sized so that one batch of the output is around 2 GB by
+    # default, since the working memory of the computation scales with the
+    # batch size.
+    numblocks = tuple(len(chunks) for chunks in target_chunks)
+    all_edges = [np.concatenate([[0], np.cumsum(chunks)]).astype(int) for chunks in target_chunks]
+
+    if zarr_batch_size is None:
+        chunk_nbytes = float(np.prod(chunk_shape, dtype=float)) * 8
+        zarr_batch_size = max(1, int(2 * 1024**3 // max(chunk_nbytes, 1)))
+
+    chunk_indices = list(np.ndindex(numblocks))
+    n_batches = int(np.ceil(len(chunk_indices) / zarr_batch_size))
+    for ibatch in range(n_batches):
+        batch = chunk_indices[ibatch * zarr_batch_size : (ibatch + 1) * zarr_batch_size]
+
+        regions = [
+            tuple(
+                slice(int(all_edges[axis][index[axis]]), int(all_edges[axis][index[axis] + 1]))
+                for axis in range(len(numblocks))
+            )
+            for index in batch
+        ]
+
+        # Keep only the images that overlap at least one chunk in the batch
+        batch_cutouts = [
+            cutout
+            for cutout in cutouts
+            if any(
+                all(
+                    cutout.bounds[axis][1] > region[axis].start
+                    and cutout.bounds[axis][0] < region[axis].stop
+                    for axis in range(len(numblocks))
+                )
+                for region in regions
+            )
+        ]
+        logger.info(
+            f"Computing batch {ibatch + 1} of {n_batches} ({len(batch)} chunks, "
+            f"{len(batch_cutouts)} overlapping images)"
+        )
+        if not batch_cutouts:
+            continue
+        array, footprint = _coadd_dask(
+            batch_cutouts,
+            reproject_function=reproject_function,
+            combine_function=combine_function,
+            shape_out=shape_out,
+            target_chunks=target_chunks,
+            n_dim_reproject=n_dim_reproject,
+            blank_pixel_value=blank_pixel_value,
+            hdu_in=hdu_in,
+            reproject_kwargs=reproject_kwargs,
+        )
+        sources = [array[region] for region in regions] + [footprint[region] for region in regions]
+        targets = [zarr_array] * len(regions) + [zarr_footprint] * len(regions)
+        da.store(
+            sources,
+            targets,
+            regions=regions + regions,
+            lock=False,
+            compute=True,
+        )
+
+    return (
+        da.from_zarr(zarr_path, component="array"),
+        da.from_zarr(zarr_path, component="footprint"),
+    )
+
+
 def _coadd_numpy(
     cutouts,
     *,
@@ -709,6 +829,8 @@ def reproject_and_coadd(
     blank_pixel_value=0,
     intermediate_memmap=False,
     return_type=None,
+    zarr_path=None,
+    zarr_batch_size=None,
     **kwargs,
 ):
     """
@@ -805,7 +927,7 @@ def reproject_and_coadd(
     intermediate_memmap : bool, optional
         If `True`, use `numpy.memmap` to store intermediate output arrays for
         reprojected data. Only supported with ``return_type='numpy'``.
-    return_type : {None, 'numpy', 'dask'}, optional
+    return_type : {None, 'numpy', 'dask', 'zarr'}, optional
         If ``'dask'``, reproject each image lazily (using ``return_type='dask'``
         on the reprojection function) and assemble each chunk of the output
         from the images that overlap it, returning the resulting **uncomputed**
@@ -817,8 +939,23 @@ def reproject_and_coadd(
         unweighted median), which the ``return_type='numpy'`` path cannot compute.
         ``match_background``, ``output_array``, ``output_footprint`` and
         ``intermediate_memmap`` are not supported, since the result is an
-        uncomputed graph rather than arrays filled in place. The default (`None`)
-        is equivalent to ``'numpy'``.
+        uncomputed graph rather than arrays filled in place. If ``'zarr'``,
+        build the same graphs as ``'dask'`` but compute them here, batch by
+        batch along the first dimension, into a zarr store at ``zarr_path``,
+        returning dask arrays that read from the store. This bounds the memory
+        used by the computation to one batch regardless of the size of the
+        mosaic, at the cost of recomputing reprojected chunks of images that
+        span a batch boundary, and the restrictions of ``'dask'`` apply. The
+        default (`None`) is equivalent to ``'numpy'``.
+    zarr_path : str, optional
+        The path at which to create the zarr store when
+        ``return_type='zarr'``. The path must not already exist. The store is
+        created as a group with ``'array'`` and ``'footprint'`` arrays.
+    zarr_batch_size : int, optional
+        The number of output chunks to compute per batch when
+        ``return_type='zarr'``, iterating over the output chunks in C order.
+        The default picks a batch size such that one batch of the output is
+        around 2 GB.
 
     **kwargs
         Keyword arguments to be passed to the reprojection function.
@@ -827,7 +964,8 @@ def reproject_and_coadd(
     -------
     array : `~numpy.ndarray` or `~dask.array.Array`
         The co-added array. This is an uncomputed dask array when
-        ``return_type='dask'``.
+        ``return_type='dask'``, and a dask array reading from the computed
+        zarr store when ``return_type='zarr'``.
     footprint : `~numpy.ndarray` or `~dask.array.Array`
         Footprint of the co-added array. Values of 0 indicate no coverage or
         valid values in the input image, while values of 1 indicate valid
@@ -846,13 +984,21 @@ def reproject_and_coadd(
     # silently select the return_type='numpy' co-addition.
     if return_type is None:
         return_type = "numpy"
-    if return_type not in ("numpy", "dask"):
-        raise ValueError("return_type should be set to 'numpy' or 'dask'")
+    if return_type not in ("numpy", "dask", "zarr"):
+        raise ValueError("return_type should be set to 'numpy', 'dask' or 'zarr'")
+
+    if return_type == "zarr":
+        if zarr_path is None:
+            raise ValueError("zarr_path should be set when using return_type='zarr'")
+        if os.path.exists(zarr_path):
+            raise ValueError(f"Path {zarr_path} already exists")
+    elif zarr_path is not None:
+        raise ValueError("zarr_path can only be set when using return_type='zarr'")
 
     # 'median' is only available for the deferred dask path (return_type='dask'); the
     # return_type='numpy' path cannot compute a median on the fly.
     allowed_combine = ("mean", "sum", "first", "last", "min", "max")
-    if return_type == "dask":
+    if return_type in ("dask", "zarr"):
         allowed_combine = allowed_combine + ("median",)
     if combine_function not in allowed_combine:
         raise ValueError(f"combine_function should be one of {'/'.join(allowed_combine)}")
@@ -918,17 +1064,21 @@ def reproject_and_coadd(
     # the images are combined with a nan-aware reduction. The uncomputed dask arrays
     # are returned so the whole thing is computed once at the end, so we must not
     # allocate the (potentially huge) output arrays here.
-    coadd_with_dask = return_type == "dask"
+    coadd_with_dask = return_type in ("dask", "zarr")
 
     if coadd_with_dask:
         if match_background:
-            raise ValueError("Cannot use return_type='dask' together with match_background")
+            raise ValueError(
+                f"Cannot use return_type={return_type!r} together with match_background"
+            )
         if output_array is not None or output_footprint is not None:
             raise ValueError(
-                "Cannot use return_type='dask' together with output_array or output_footprint"
+                f"Cannot use return_type={return_type!r} together with output_array or output_footprint"
             )
         if intermediate_memmap:
-            raise ValueError("Cannot use return_type='dask' together with intermediate_memmap")
+            raise ValueError(
+                f"Cannot use return_type={return_type!r} together with intermediate_memmap"
+            )
     else:
         if output_array is None:
             output_array = np.zeros(shape_out)
@@ -1000,7 +1150,21 @@ def reproject_and_coadd(
         progress_bar,
     )
 
-    if coadd_with_dask:
+    if return_type == "zarr":
+        return _coadd_zarr(
+            cutouts,
+            reproject_function=reproject_function,
+            combine_function=combine_function,
+            shape_out=shape_out,
+            target_chunks=target_chunks,
+            n_dim_reproject=n_dim_reproject,
+            blank_pixel_value=blank_pixel_value,
+            hdu_in=hdu_in,
+            reproject_kwargs=kwargs,
+            zarr_path=zarr_path,
+            zarr_batch_size=zarr_batch_size,
+        )
+    elif coadd_with_dask:
         return _coadd_dask(
             cutouts,
             reproject_function=reproject_function,

--- a/reproject/mosaicking/_coadd.py
+++ b/reproject/mosaicking/_coadd.py
@@ -524,16 +524,18 @@ def _coadd_zarr(
     chunk_shape = tuple(chunks[0] for chunks in target_chunks)
 
     group = zarr.open_group(zarr_path, mode="w-")
+    # zarr 2 calls the array creation method create_dataset
+    create = group.create_array if hasattr(group, "create_array") else group.create_dataset
     # Batches with no overlapping images are never written, so the fill
     # values provide the same blank mosaic values as the other paths
-    zarr_array = group.create_array(
+    zarr_array = create(
         "array",
         shape=tuple(shape_out),
         chunks=chunk_shape,
         dtype=float,
         fill_value=float(blank_pixel_value),
     )
-    zarr_footprint = group.create_array(
+    zarr_footprint = create(
         "footprint",
         shape=tuple(shape_out),
         chunks=chunk_shape,

--- a/reproject/mosaicking/tests/test_coadd.py
+++ b/reproject/mosaicking/tests/test_coadd.py
@@ -1173,6 +1173,47 @@ def test_coadd_return_type_zarr_non_reprojected_dims(tmp_path):
     assert_allclose(np.asarray(footprint_zarr), np.asarray(footprint_dask))
 
 
+def test_coadd_return_type_zarr_parallel(tmp_path):
+    # The batch computation follows the same parallel semantics as the
+    # individual reprojection functions
+
+    data = np.random.default_rng(0).random((30, 30))
+    wcs = WCS(naxis=2)
+    wcs.wcs.ctype = ["RA---TAN", "DEC--TAN"]
+    wcs.wcs.cdelt = [-0.001, 0.001]
+
+    kwargs = dict(
+        reproject_function=reproject_interp,
+        shape_out=(30, 30),
+        roundtrip_coords=False,
+        block_size=(10, 10),
+        return_type="zarr",
+    )
+
+    results = {}
+    for parallel in [False, True, 2, "current-scheduler"]:
+        array, footprint = reproject_and_coadd(
+            [(data, wcs)],
+            wcs,
+            zarr_path=str(tmp_path / f"coadd_{parallel}.zarr"),
+            parallel=parallel,
+            **kwargs,
+        )
+        results[parallel] = np.asarray(array)
+
+    for parallel in [True, 2, "current-scheduler"]:
+        assert_allclose(results[parallel], results[False])
+
+    with pytest.raises(ValueError, match="strictly positive"):
+        reproject_and_coadd(
+            [(data, wcs)],
+            wcs,
+            zarr_path=str(tmp_path / "coadd_invalid.zarr"),
+            parallel=-1,
+            **kwargs,
+        )
+
+
 def test_coadd_return_type_zarr_validation(tmp_path):
     data = np.ones((10, 10))
     wcs = WCS(naxis=2)

--- a/reproject/mosaicking/tests/test_coadd.py
+++ b/reproject/mosaicking/tests/test_coadd.py
@@ -1087,3 +1087,114 @@ def test_coadd_non_reprojected_dims_invalid():
             combine_function="mean",
             non_reprojected_dims=(1,),
         )
+
+
+@pytest.mark.parametrize("combine_function", ["mean", "first", "median"])
+@pytest.mark.parametrize("block_size", [(20, 20), (80, 20)])
+def test_coadd_return_type_zarr(tmp_path, combine_function, block_size):
+    # The zarr return type computes the same graphs as the dask return type
+    # batch by batch into a store; results must match exactly, including the
+    # blank fill in regions covered by no image (which for skipped batches
+    # comes from the zarr fill value rather than a computed chunk). The
+    # (80, 20) block size spans the full first dimension, so the batches
+    # iterate over chunks of the second dimension.
+
+    wcs1 = WCS(naxis=2)
+    wcs1.wcs.ctype = ["RA---TAN", "DEC--TAN"]
+    wcs1.wcs.crval = [40.0, 0.0]
+    wcs1.wcs.cdelt = [-0.001, 0.001]
+    wcs1.wcs.crpix = [20.0, 20.0]
+    wcs2 = wcs1.deepcopy()
+    wcs2.wcs.crpix[0] -= 15
+    wcs2.wcs.crpix[1] -= 15
+
+    rng = np.random.default_rng(42)
+    input_data = [(rng.random((40, 40)), wcs1), (rng.random((40, 40)), wcs2)]
+
+    # Output taller than the coverage so that at least one batch contains no
+    # images at all and is never computed
+    shape_out = (80, 60)
+
+    kwargs = dict(
+        reproject_function=reproject_interp,
+        shape_out=shape_out,
+        combine_function=combine_function,
+        roundtrip_coords=False,
+        block_size=block_size,
+        blank_pixel_value=-1,
+    )
+
+    array_dask, footprint_dask = reproject_and_coadd(input_data, wcs1, return_type="dask", **kwargs)
+    array_zarr, footprint_zarr = reproject_and_coadd(
+        input_data,
+        wcs1,
+        return_type="zarr",
+        zarr_path=str(tmp_path / "coadd.zarr"),
+        zarr_batch_size=1,
+        **kwargs,
+    )
+
+    assert_allclose(np.asarray(array_zarr), np.asarray(array_dask))
+    assert_allclose(np.asarray(footprint_zarr), np.asarray(footprint_dask))
+
+
+def test_coadd_return_type_zarr_non_reprojected_dims(tmp_path):
+    # Batching along a non-reprojected leading dimension (the slab case)
+
+    n_time = 6
+    shape_out = (n_time, 30, 30)
+    wcs_in = _drifting_cube_wcs(drift=0.6)
+    wcs_out = _drifting_cube_wcs(drift=0.0)
+
+    rng = np.random.default_rng(12345)
+    input_data = [(rng.random(shape_out), wcs_in), (rng.random(shape_out), wcs_in)]
+
+    kwargs = dict(
+        reproject_function=reproject_interp,
+        shape_out=shape_out,
+        non_reprojected_dims=(0,),
+        roundtrip_coords=False,
+        block_size=(30, 30),
+    )
+
+    array_dask, footprint_dask = reproject_and_coadd(
+        input_data, wcs_out, return_type="dask", **kwargs
+    )
+    array_zarr, footprint_zarr = reproject_and_coadd(
+        input_data,
+        wcs_out,
+        return_type="zarr",
+        zarr_path=str(tmp_path / "coadd.zarr"),
+        zarr_batch_size=2,
+        **kwargs,
+    )
+
+    assert_allclose(np.asarray(array_zarr), np.asarray(array_dask))
+    assert_allclose(np.asarray(footprint_zarr), np.asarray(footprint_dask))
+
+
+def test_coadd_return_type_zarr_validation(tmp_path):
+    data = np.ones((10, 10))
+    wcs = WCS(naxis=2)
+    wcs.wcs.ctype = ["RA---TAN", "DEC--TAN"]
+
+    kwargs = dict(reproject_function=reproject_interp, shape_out=(10, 10))
+
+    with pytest.raises(ValueError, match="zarr_path should be set"):
+        reproject_and_coadd([(data, wcs)], wcs, return_type="zarr", **kwargs)
+
+    existing = tmp_path / "existing.zarr"
+    existing.mkdir()
+    with pytest.raises(ValueError, match="already exists"):
+        reproject_and_coadd(
+            [(data, wcs)], wcs, return_type="zarr", zarr_path=str(existing), **kwargs
+        )
+
+    with pytest.raises(ValueError, match="can only be set"):
+        reproject_and_coadd(
+            [(data, wcs)],
+            wcs,
+            return_type="dask",
+            zarr_path=str(tmp_path / "new.zarr"),
+            **kwargs,
+        )


### PR DESCRIPTION
Using ``return_type='dask'`` in ``reproject_and_coadd`` does not always work well because when computing the whole mosaic in one go, dask is not always great at keeping the memory within bounds. This PR adds support for ``reproject_type='zarr'``, which progressively writes out the mosaic to zarr in chunks (we iterate manually over sub-regions of the whole mosaic, so this is different from just doing ``final_array.to_zarr(...)``.