### PR TITLE
Implement support for chunked median with ``return_type='numpy'`` in ``reproject_and_coadd``

### DIFF
--- a/reproject/mosaicking/_coadd.py
+++ b/reproject/mosaicking/_coadd.py
@@ -637,7 +637,9 @@ def _coadd_numpy(
     # Define 'on-the-fly' mode: in the case where we don't need to match the
     # backgrounds, we don't have to keep track of the intermediate arrays and
     # can just modify the output array on-the-fly
-    on_the_fly = not match_background
+    # A median cannot be computed on the fly, so like match_background it
+    # retains all the reprojected arrays and combines them at the end
+    on_the_fly = not match_background and combine_function != "median"
 
     on_the_fly_prefix = "Using" if on_the_fly else "Not using"
     logger.info(
@@ -802,11 +804,55 @@ def _coadd_numpy(
             for array, correction in zip(arrays, corrections, strict=True):
                 array.array -= correction
 
-        if match_background:
+        if not on_the_fly:
             logger.info(f"Combining reprojected arrays with function {combine_function}")
-            # if we're not matching the background, this part has already been done
-            for array in arrays:
-                _combine_array_into_output(combine_function, array, output_array, output_footprint)
+            # if we're combining on the fly, this part has already been done
+            if combine_function == "median":
+                # The median needs all the values covering each pixel at once,
+                # so combine chunk by chunk with the same per-chunk logic as
+                # the return_type='dask' path, gathering the overlapping piece
+                # of every retained reprojected array for each chunk.
+                for chunk in iterate_chunks(
+                    output_array.shape, max_chunk_size=DEFAULT_MAX_CHUNK_SIZE
+                ):
+                    pieces = []
+                    dests = []
+                    for subset in arrays:
+                        overlap = [
+                            (max(slc.start, imin), min(slc.stop, imax))
+                            for slc, (imin, imax) in zip(chunk, subset.bounds, strict=True)
+                        ]
+                        if any(hi <= lo for lo, hi in overlap):
+                            continue
+                        local = tuple(
+                            slice(lo - imin, hi - imin)
+                            for (lo, hi), (imin, _) in zip(overlap, subset.bounds, strict=True)
+                        )
+                        pieces.append(subset.array[local])
+                        pieces.append(subset.footprint[local])
+                        dests.append(
+                            tuple(
+                                slice(lo - slc.start, hi - slc.start)
+                                for (lo, hi), slc in zip(overlap, chunk, strict=True)
+                            )
+                        )
+                    if not pieces:
+                        # No coverage; the blank fill below takes care of it
+                        continue
+                    result = _combine_tile_pieces(
+                        *pieces,
+                        combine_function="median",
+                        blank_pixel_value=blank_pixel_value,
+                        dests=tuple(dests),
+                        trailing_shape=tuple(slc.stop - slc.start for slc in chunk),
+                    )
+                    output_array[chunk] = result[0]
+                    output_footprint[chunk] = result[1]
+            else:
+                for array in arrays:
+                    _combine_array_into_output(
+                        combine_function, array, output_array, output_footprint
+                    )
 
         if combine_function == "mean":
             logger.info("Handle normalization of output array")
@@ -907,7 +953,10 @@ def reproject_and_coadd(
         simply overlaid on top of each other. With respect to the order of the
         input images in ``input_data``, either the first or the last image to
         cover a region of overlap determines the output data for that region.
-        'median' is only available with ``return_type='dask'``.
+        The median is unweighted, and with ``return_type='numpy'`` it cannot
+        be computed on the fly, so all the reprojected arrays are kept until
+        the end (as for ``match_background``; ``intermediate_memmap`` can be
+        used to keep them on disk).
     match_background : bool
         Whether to match the backgrounds of the images. Only supported with
         ``return_type='numpy'``.
@@ -954,8 +1003,7 @@ def reproject_and_coadd(
         combination matches the ``return_type='numpy'`` path exactly
         (footprint-weighted for 'mean' and 'sum', footprint-aware selection for
         'first', 'last', 'min' and 'max'), and ``input_weights`` are supported. A
-        ``combine_function`` of 'median' is additionally available here (as an
-        unweighted median), which the ``return_type='numpy'`` path cannot compute.
+        ``combine_function`` of 'median' is available as an unweighted median.
         ``match_background``, ``output_array``, ``output_footprint`` and
         ``intermediate_memmap`` are not supported, since the result is an
         uncomputed graph rather than arrays filled in place. If ``'zarr'``,
@@ -1018,11 +1066,7 @@ def reproject_and_coadd(
     elif zarr_path is not None:
         raise ValueError("zarr_path can only be set when using return_type='zarr'")
 
-    # 'median' is only available for the deferred dask path (return_type='dask'); the
-    # return_type='numpy' path cannot compute a median on the fly.
-    allowed_combine = ("mean", "sum", "first", "last", "min", "max")
-    if return_type in ("dask", "zarr"):
-        allowed_combine = allowed_combine + ("median",)
+    allowed_combine = ("mean", "sum", "first", "last", "min", "max", "median")
     if combine_function not in allowed_combine:
         raise ValueError(f"combine_function should be one of {'/'.join(allowed_combine)}")
 

--- a/reproject/mosaicking/_coadd.py
+++ b/reproject/mosaicking/_coadd.py
@@ -80,6 +80,27 @@ def _combine_array_into_output(combine_function, array, output_array, output_foo
         )
 
 
+def _overlap_slices(bounds, region):
+    # Given the (min, max) bounds of a reprojected image along some dimensions
+    # and a target region as (start, stop) pairs along the same dimensions,
+    # return the slices of the image covering the intersection and the slices
+    # of the region where that intersection lands, or (None, None) if the two
+    # do not overlap.
+    overlap = [
+        (max(start, imin), min(stop, imax))
+        for (start, stop), (imin, imax) in zip(region, bounds, strict=True)
+    ]
+    if any(hi <= lo for lo, hi in overlap):
+        return None, None
+    local = tuple(
+        slice(lo - imin, hi - imin) for (lo, hi), (imin, _) in zip(overlap, bounds, strict=True)
+    )
+    dest = tuple(
+        slice(lo - start, hi - start) for (lo, hi), (start, _) in zip(overlap, region, strict=True)
+    )
+    return local, dest
+
+
 # Everything the per-image reprojection needs to know about one input dataset
 # and the cutout of the output grid that it covers.
 _InputCutout = namedtuple(
@@ -420,31 +441,19 @@ def _coadd_dask(
         pieces = []
         dests = []
         for array, footprint, bounds in tiles:
-            trailing_bounds = bounds[n_lead:]
-            overlap = [
-                (max(lo, imin), min(hi, imax))
-                for (lo, hi), (imin, imax) in zip(extents, trailing_bounds, strict=True)
-            ]
-            if any(hi <= lo for lo, hi in overlap):
+            local, dest = _overlap_slices(bounds[n_lead:], extents)
+            if local is None:
                 continue
             # Slice of the image (in cutout coordinates) that falls inside this
             # column, kept as one chunk along the reprojected dimensions and
             # matching the output chunking along the non-reprojected ones.
-            local = (slice(None),) * n_lead + tuple(
-                slice(lo - imin, hi - imin)
-                for (lo, hi), (imin, _) in zip(overlap, trailing_bounds, strict=True)
-            )
+            local = (slice(None),) * n_lead + local
             rechunk_spec = {idim: lead_chunks[idim] for idim in range(n_lead)}
             rechunk_spec.update({n_lead + idim: -1 for idim in range(n_dim_reproject)})
             pieces.append(array[local].rechunk(rechunk_spec))
             pieces.append(footprint[local].rechunk(rechunk_spec))
             # Where the piece lands within the column's chunks.
-            dests.append(
-                tuple(
-                    slice(lo - start, hi - start)
-                    for (lo, hi), (start, _) in zip(overlap, extents, strict=True)
-                )
-            )
+            dests.append(dest)
         chunk_shape = tuple(hi - lo for lo, hi in extents)
         if not pieces:
             # No image overlaps this column; a zeros template just provides the
@@ -818,24 +827,14 @@ def _coadd_numpy(
                     pieces = []
                     dests = []
                     for subset in arrays:
-                        overlap = [
-                            (max(slc.start, imin), min(slc.stop, imax))
-                            for slc, (imin, imax) in zip(chunk, subset.bounds, strict=True)
-                        ]
-                        if any(hi <= lo for lo, hi in overlap):
-                            continue
-                        local = tuple(
-                            slice(lo - imin, hi - imin)
-                            for (lo, hi), (imin, _) in zip(overlap, subset.bounds, strict=True)
+                        local, dest = _overlap_slices(
+                            subset.bounds, [(slc.start, slc.stop) for slc in chunk]
                         )
+                        if local is None:
+                            continue
                         pieces.append(subset.array[local])
                         pieces.append(subset.footprint[local])
-                        dests.append(
-                            tuple(
-                                slice(lo - slc.start, hi - slc.start)
-                                for (lo, hi), slc in zip(overlap, chunk, strict=True)
-                            )
-                        )
+                        dests.append(dest)
                     if not pieces:
                         # No coverage; the blank fill below takes care of it
                         continue

--- a/reproject/mosaicking/tests/test_coadd.py
+++ b/reproject/mosaicking/tests/test_coadd.py
@@ -139,9 +139,8 @@ class TestReprojectAndCoAdd:
         assert_allclose(array, self.array, atol=ATOL)
 
     def test_coadd_dask_median(self, reproject_function):
-        # 'median' is only available through the deferred dask path (the return_type='numpy' path
-        # cannot compute a median on the fly). Check it against a direct numpy
-        # nanmedian of the reprojected images, and that the result is uncomputed.
+        # Check the deferred median against a direct numpy nanmedian of the
+        # reprojected images, and that the result is uncomputed.
         input_data = self._get_tiles(self._overlapping_views)
 
         array, footprint = reproject_and_coadd(
@@ -164,15 +163,55 @@ class TestReprojectAndCoAdd:
         covered = np.asarray(footprint) > 0
         assert_allclose(np.asarray(array)[covered], reference[covered], atol=ATOL)
 
-        # The return_type='numpy' path must still reject 'median'.
-        with pytest.raises(ValueError, match="combine_function should be one of"):
-            reproject_and_coadd(
-                input_data,
-                self.wcs,
-                shape_out=self.array.shape,
-                combine_function="median",
-                reproject_function=reproject_function,
-            )
+        # The return_type='numpy' path combines the retained reprojected
+        # arrays chunk by chunk and must match the deferred median exactly
+        array_numpy, footprint_numpy = reproject_and_coadd(
+            input_data,
+            self.wcs,
+            shape_out=self.array.shape,
+            combine_function="median",
+            reproject_function=reproject_function,
+        )
+        assert_allclose(array_numpy, np.asarray(array))
+        assert_allclose(footprint_numpy, np.asarray(footprint))
+
+    @pytest.mark.parametrize("intermediate_memmap", [False, True])
+    def test_coadd_numpy_median_memmap(self, reproject_function, intermediate_memmap):
+        # The retained reprojected arrays can be kept on disk while computing
+        # the median chunk by chunk
+        input_data = self._get_tiles(self._overlapping_views)
+
+        array, footprint = reproject_and_coadd(
+            input_data,
+            self.wcs,
+            shape_out=self.array.shape,
+            combine_function="median",
+            reproject_function=reproject_function,
+            intermediate_memmap=intermediate_memmap,
+        )
+        covered = footprint > 0
+        assert_allclose(array[covered], self.array[covered], atol=ATOL)
+
+    def test_coadd_numpy_median_match_background(self, reproject_function):
+        # match_background composes with the median since the corrections are
+        # applied to the retained arrays before the combine (this is not
+        # possible with the deferred paths)
+        input_data = self._get_tiles(self._overlapping_views)
+        input_data = [(array + iview, wcs) for iview, (array, wcs) in enumerate(input_data)]
+
+        array, footprint = reproject_and_coadd(
+            input_data,
+            self.wcs,
+            shape_out=self.array.shape,
+            combine_function="median",
+            reproject_function=reproject_function,
+            match_background=True,
+        )
+        covered = footprint > 0
+        # The mean of the corrections is zero, so the matched result is offset
+        # from the reference by the mean of the applied offsets
+        offset = np.mean(np.arange(len(input_data)))
+        assert_allclose(array[covered], (self.array + offset)[covered], atol=ATOL)
 
     def test_coadd_dask_median_uncovered(self):
         # Pixels covered by no image must not make the deferred median warn about


### PR DESCRIPTION
This uses a similar chunked approach to https://github.com/astropy/reproject/pull/336 but had to be re-written from scratch due to extensive changes in ``reproject_and_coadd``