### PR TITLE
Allow Path in reproject_from_healpix

### DIFF
--- a/reproject/healpix/_utils.py
+++ b/reproject/healpix/_utils.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import numpy as np
 from astropy.coordinates import (
     ICRS,
@@ -40,14 +42,13 @@ def parse_input_healpix_data(input_data, field=0, hdu_in=None, nested=None):
         array_in = data[data.columns[field].name].ravel()
         if "ORDERING" in header:
             nested = header["ORDERING"].lower() == "nested"
-    elif isinstance(input_data, str):
-        # NOTE: hdu is not closed here.
-        hdu = fits.open(input_data)[hdu_in or 1]
-        return parse_input_healpix_data(hdu, field=field)
-    elif isinstance(input_data, tuple) and isinstance(input_data[0], np.ndarray):
+        return array_in, coordinate_system_in, nested
+    if isinstance(input_data, str | Path):
+        with fits.open(input_data) as hdulist:
+            return parse_input_healpix_data(hdulist[hdu_in or 1], field=field)
+    if isinstance(input_data, tuple) and isinstance(input_data[0], np.ndarray):
         array_in = input_data[0]
         coordinate_system_in = parse_coord_system(input_data[1])
-    else:
-        raise TypeError("input_data should either be an HDU object or a tuple of (array, frame)")
+        return array_in, coordinate_system_in, nested
+    raise TypeError("input_data should either be an HDU object or a tuple of (array, frame)")
 
-    return array_in, coordinate_system_in, nested

--- a/reproject/healpix/_utils.py
+++ b/reproject/healpix/_utils.py
@@ -51,4 +51,3 @@ def parse_input_healpix_data(input_data, field=0, hdu_in=None, nested=None):
         coordinate_system_in = parse_coord_system(input_data[1])
         return array_in, coordinate_system_in, nested
     raise TypeError("input_data should either be an HDU object or a tuple of (array, frame)")
-

--- a/reproject/healpix/tests/test_utils.py
+++ b/reproject/healpix/tests/test_utils.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import numpy as np
 import pytest
 from astropy.coordinates import FK5, Galactic
@@ -42,6 +44,10 @@ def test_parse_input_healpix_data(tmpdir):
     filename = tmpdir.join("test.fits").strpath
     hdu.writeto(filename)
     array, coordinate_system, nested = parse_input_healpix_data(filename)
+    np.testing.assert_allclose(array, data)
+
+    # As Path
+    array, coordinate_system, nested = parse_input_healpix_data(Path(filename))
     np.testing.assert_allclose(array, data)
 
     # As array


### PR DESCRIPTION
The docs of `reproject_from_healpix` state:

```python
def reproject_from_healpix(
    input_data, output_projection, shape_out=None, hdu_in=1, order="bilinear", nested=None, field=0
):
    """
    Reproject data from a HEALPIX projection to a standard projection.

    Parameters
    ----------
    input_data : object
        The input data to reproject. This can be:

            * The name of a HEALPIX FITS file
            * A `~astropy.io.fits.TableHDU` or `~astropy.io.fits.BinTableHDU`
              instance
            * A tuple where the first element is a `~numpy.ndarray` and the
              second element is a `~astropy.coordinates.BaseCoordinateFrame`
              instance or a string alias for a coordinate frame.
```
However, in the current first branch is only checked in 'The name of a HEALPIX FITS file' is a `str` type. This is a simple PR to fix the type checking for `input_data`.